### PR TITLE
Editors and Overlays: get rid of toSelector outdated utility in tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -417,22 +417,22 @@
 /packages/devextreme/js/ui/multi_view.d.ts                     @DevExpress/devextreme-navigation @DevExpress/devextreme-apireviewers
 
 ## radio_group
-/packages/devextreme/js/ui/radio_group.js                      @DevExpress/devextreme-navigation
-/packages/devextreme/js/ui/radio_group/**                      @DevExpress/devextreme-navigation
-/packages/devextreme/js/__internal/ui/radio_group/**           @DevExpress/devextreme-navigation
+/packages/devextreme/js/ui/radio_group.js                      @DevExpress/devextreme-editors
+/packages/devextreme/js/ui/radio_group/**                      @DevExpress/devextreme-editors
+/packages/devextreme/js/__internal/ui/radio_group/**           @DevExpress/devextreme-editors
 
-/packages/devextreme-scss/scss/**/radioGroup/**                @DevExpress/devextreme-navigation
+/packages/devextreme-scss/scss/**/radioGroup/**                @DevExpress/devextreme-editors
 
-/apps/demos/Demos/RadioGroup/**                                @DevExpress/devextreme-navigation
+/apps/demos/Demos/RadioGroup/**                                @DevExpress/devextreme-editors
 
-/packages/testcafe-models/radioGroup/**                        @DevExpress/devextreme-navigation
-/e2e/testcafe-devextreme/tests/accessibility/common/radioGroup.ts   @DevExpress/devextreme-navigation
-/packages/devextreme/testing/tests/**/radioGroup.*             @DevExpress/devextreme-navigation
-/packages/devextreme/testing/tests/**/radioButton.*            @DevExpress/devextreme-navigation
+/packages/testcafe-models/radioGroup/**                        @DevExpress/devextreme-editors
+/e2e/testcafe-devextreme/tests/accessibility/common/radioGroup.ts   @DevExpress/devextreme-editors
+/packages/devextreme/testing/tests/**/radioGroup.*             @DevExpress/devextreme-editors
+/packages/devextreme/testing/tests/**/radioButton.*            @DevExpress/devextreme-editors
 
-/packages/devextreme/js/ui/radio_group_types.d.ts              @DevExpress/devextreme-navigation @DevExpress/devextreme-apireviewers
-/packages/devextreme/js/ui/radio_group.d.ts                    @DevExpress/devextreme-navigation @DevExpress/devextreme-apireviewers
-/packages/devextreme/js/ui/radio_group/**/*.d.ts               @DevExpress/devextreme-navigation @DevExpress/devextreme-apireviewers
+/packages/devextreme/js/ui/radio_group_types.d.ts              @DevExpress/devextreme-editors @DevExpress/devextreme-apireviewers
+/packages/devextreme/js/ui/radio_group.d.ts                    @DevExpress/devextreme-editors @DevExpress/devextreme-apireviewers
+/packages/devextreme/js/ui/radio_group/**/*.d.ts               @DevExpress/devextreme-editors @DevExpress/devextreme-apireviewers
 
 ## resizable
 /packages/devextreme/js/ui/resizable.js                        @DevExpress/devextreme-navigation

--- a/packages/devextreme/testing/tests/DevExpress.knockout/lookup.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.knockout/lookup.tests.js
@@ -23,10 +23,6 @@ QUnit.testStart(function() {
 
 const LIST_CLASS = 'dx-list';
 
-const toSelector = function(val) {
-    return '.' + val;
-};
-
 const openPopupWithList = function(lookup) {
     $(lookup._$field).trigger('dxclick');
 };
@@ -52,7 +48,7 @@ QUnit.test('lookup should delegate templates to child widgets (T131530)', functi
 
     openPopupWithList(lookup);
 
-    const $list = $(toSelector(LIST_CLASS));
+    const $list = $(`.${LIST_CLASS}`);
 
     assert.equal($list.find('.dx-list-item').text().trim(), 'TemplateTemplate');
 });
@@ -65,7 +61,7 @@ QUnit.test('lookup with item template', function(assert) {
 
     openPopupWithList(lookup);
 
-    const $list = $(toSelector(LIST_CLASS));
+    const $list = $(`.${LIST_CLASS}`);
 
     assert.equal($list.find('.dx-list-item').text().trim(), 'Template');
 });

--- a/packages/devextreme/testing/tests/DevExpress.serverSide/trackBar.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.serverSide/trackBar.tests.js
@@ -11,10 +11,6 @@ QUnit.testStart(function() {
     $('#qunit-fixture').html(markup);
 });
 
-function toSelector(text) {
-    return '.' + text;
-}
-
 const TRACKBAR_RANGE_CLASS = 'dx-trackbar-range';
 
 QUnit.module('Range width', {
@@ -28,7 +24,7 @@ QUnit.module('Range width', {
             min: 0,
             max: 100
         }).css('width', 100);
-        const $range = $trackBar.find(toSelector(TRACKBAR_RANGE_CLASS));
+        const $range = $trackBar.find(`.${TRACKBAR_RANGE_CLASS}`);
 
         assert.equal($range[0].style.width, '0px', 'range width is right');
     });

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/calendar.markup.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/calendar.markup.tests.js
@@ -22,10 +22,6 @@ const CALENDAR_RANGE_CLASS = 'dx-calendar-range';
 
 const ARIA_LABEL_DATE_FORMAT = 'date';
 
-const toSelector = function(className) {
-    return '.' + className;
-};
-
 const getFormattedDate = (date) => {
     return dateLocalization.format(new Date(date), ARIA_LABEL_DATE_FORMAT);
 };
@@ -50,7 +46,7 @@ QUnit.module('Calendar markup', {
     });
 
     QUnit.test('navigator is rendered', function(assert) {
-        assert.equal(this.$element.find(toSelector(CALENDAR_NAVIGATOR_CLASS)).length, 1, 'navigator is rendered');
+        assert.equal(this.$element.find(`.${CALENDAR_NAVIGATOR_CLASS}`).length, 1, 'navigator is rendered');
     });
 
     [1, 2].forEach((viewsCount) => {
@@ -58,9 +54,9 @@ QUnit.module('Calendar markup', {
             this.calendar.option('viewsCount', viewsCount);
             if(windowUtils.hasWindow()) {
                 const hiddenViews = 2;
-                assert.equal(this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS) + ' .dx-widget').length, viewsCount + hiddenViews, 'all views are rendered');
+                assert.equal(this.$element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS} .dx-widget`).length, viewsCount + hiddenViews, 'all views are rendered');
             } else {
-                assert.equal(this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS) + ' .dx-widget').length, viewsCount, 'only one view is rendered');
+                assert.equal(this.$element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS} .dx-widget`).length, viewsCount, 'only one view is rendered');
             }
         });
     });
@@ -164,18 +160,18 @@ QUnit.module('Navigator', {
     });
 
     QUnit.test('Calendar must display previous and next month links, and previous and next year links', function(assert) {
-        assert.strictEqual(this.$element.find(toSelector(CALENDAR_NAVIGATOR_PREVIOUS_VIEW_CLASS)).length, 1);
-        assert.strictEqual(this.$element.find(toSelector(CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS)).length, 1);
+        assert.strictEqual(this.$element.find(`.${CALENDAR_NAVIGATOR_PREVIOUS_VIEW_CLASS}`).length, 1);
+        assert.strictEqual(this.$element.find(`.${CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS}`).length, 1);
     });
 
     QUnit.test('Calendar must display the current month and year', function(assert) {
-        const navigatorCaption = this.$element.find(toSelector(CALENDAR_CAPTION_BUTTON_CLASS));
+        const navigatorCaption = this.$element.find(`.${CALENDAR_CAPTION_BUTTON_CLASS}`);
         assert.equal(navigatorCaption.text(), 'June 2015');
     });
 
     QUnit.test('Calendar with two views should display 2 months', function(assert) {
         this.calendar.option('viewsCount', 2);
-        const navigatorCaption = this.$element.find(toSelector(CALENDAR_CAPTION_BUTTON_CLASS));
+        const navigatorCaption = this.$element.find(`.${CALENDAR_CAPTION_BUTTON_CLASS}`);
         assert.equal(navigatorCaption.text(), 'June 2015July 2015');
     });
 });
@@ -194,7 +190,7 @@ QUnit.module('Calendar footer', {
             value: new Date(2015, 5, 13),
             showTodayButton: true
         }).dxCalendar('instance');
-        assert.equal($element.find(toSelector(CALENDAR_FOOTER_CLASS)).length, 1, 'footer exist');
+        assert.equal($element.find(`.${CALENDAR_FOOTER_CLASS}`).length, 1, 'footer exist');
     });
 
     QUnit.test('calendar mustn\'t have _footer if showTodayButton  = false', function(assert) {
@@ -203,7 +199,7 @@ QUnit.module('Calendar footer', {
             value: new Date(2015, 5, 13),
             showTodayButton: false
         }).dxCalendar('instance');
-        assert.equal($element.find(toSelector(CALENDAR_FOOTER_CLASS)).length, 0, 'footer doesn\'t exist');
+        assert.equal($element.find(`.${CALENDAR_FOOTER_CLASS}`).length, 0, 'footer doesn\'t exist');
     });
 });
 

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/calendar.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/calendar.tests.js
@@ -75,10 +75,6 @@ const getAfterViewInstance = (calendar) => {
     return calendar._afterView;
 };
 
-const toSelector = (className) => {
-    return '.' + className;
-};
-
 const iterateViews = (callback) => {
     const views = ['month', 'year', 'decade', 'century'];
     $.each(views, callback);
@@ -159,7 +155,7 @@ QUnit.module('Navigator', {
             $window.scrollTop(50000);
             actualScrollTop = $window.scrollTop();
             if(actualScrollTop > 0) {
-                immediateClick(this.$element.find(toSelector(CALENDAR_NAVIGATOR_PREVIOUS_VIEW_CLASS))[0]);
+                immediateClick(this.$element.find(`.${CALENDAR_NAVIGATOR_PREVIOUS_VIEW_CLASS}`)[0]);
                 assert.ok($window.scrollTop() >= actualScrollTop);
             } else {
                 assert.ok(true, 'scrollTop does not work on older Android browsers, and so this test will not work');
@@ -170,7 +166,7 @@ QUnit.module('Navigator', {
     });
 
     QUnit.test('Calendar must display the current month and year', function(assert) {
-        const navigatorCaption = this.$element.find(toSelector(CALENDAR_CAPTION_BUTTON_CLASS));
+        const navigatorCaption = this.$element.find(`.${CALENDAR_CAPTION_BUTTON_CLASS}`);
         assert.equal(navigatorCaption.text(), 'June 2015');
     });
 });
@@ -184,18 +180,18 @@ QUnit.module('Navigator integration', {
             value: new Date(2015, 5, 13)
         }).dxCalendar('instance');
 
-        this.$navigatorCaption = this.$element.find(toSelector(CALENDAR_CAPTION_BUTTON_CLASS));
-        this.$navigatorNext = this.$element.find(toSelector(CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS));
-        this.$navigatorPrev = this.$element.find(toSelector(CALENDAR_NAVIGATOR_PREVIOUS_VIEW_CLASS));
+        this.$navigatorCaption = this.$element.find(`.${CALENDAR_CAPTION_BUTTON_CLASS}`);
+        this.$navigatorNext = this.$element.find(`.${CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS}`);
+        this.$navigatorPrev = this.$element.find(`.${CALENDAR_NAVIGATOR_PREVIOUS_VIEW_CLASS}`);
 
         this.reinit = (options) => {
             this.$element.remove();
             this.$element = $('<div>').appendTo('#qunit-fixture');
             this.calendar = this.$element.dxCalendar(options).dxCalendar('instance');
 
-            this.$navigatorCaption = this.$element.find(toSelector(CALENDAR_CAPTION_BUTTON_CLASS));
-            this.$navigatorNext = this.$element.find(toSelector(CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS));
-            this.$navigatorPrev = this.$element.find(toSelector(CALENDAR_NAVIGATOR_PREVIOUS_VIEW_CLASS));
+            this.$navigatorCaption = this.$element.find(`.${CALENDAR_CAPTION_BUTTON_CLASS}`);
+            this.$navigatorNext = this.$element.find(`.${CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS}`);
+            this.$navigatorPrev = this.$element.find(`.${CALENDAR_NAVIGATOR_PREVIOUS_VIEW_CLASS}`);
         };
     },
     afterEach: function() {
@@ -251,7 +247,7 @@ QUnit.module('Navigator integration', {
             value: new Date(2021, 9, 17)
         });
 
-        const $navigatorCaptionButton = this.$element.find(toSelector(CALENDAR_CAPTION_BUTTON_CLASS));
+        const $navigatorCaptionButton = this.$element.find(`.${CALENDAR_CAPTION_BUTTON_CLASS}`);
 
         $navigatorCaptionButton.trigger('dxclick');
 
@@ -556,7 +552,7 @@ QUnit.module('Views initial positions', {
             width: 400
         });
 
-        const $navigatorNext = this.$element.find(toSelector(CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS));
+        const $navigatorNext = this.$element.find(`.${CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS}`);
         $($navigatorNext).trigger('dxclick');
 
         const animateSpy = sinon.spy(fx, 'animate');
@@ -695,10 +691,10 @@ QUnit.module('Views integration', {
         const $element = this.$element;
 
         this.calendar.option('value', new Date(2013, 9, 15));
-        $($element.find(toSelector(CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS))).trigger('dxclick');
+        $($element.find(`.${CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS}`)).trigger('dxclick');
         $($element.find('td[data-value=\'2013/11/13\']')).trigger('dxclick');
 
-        assert.equal($element.find(toSelector(CALENDAR_SELECTED_DATE_CLASS)).length, 1, 'there is only one selected cell');
+        assert.equal($element.find(`.${CALENDAR_SELECTED_DATE_CLASS}`).length, 1, 'there is only one selected cell');
     });
 
     QUnit.test('views should not be rerendered after other month cell click', function(assert) {
@@ -724,7 +720,7 @@ QUnit.module('Views integration', {
         $.each(['month', 'year', 'decade', 'century'], (_, type) => {
             calendar.option('maxZoomLevel', type);
 
-            const $selectedCell = $element.find(toSelector(CALENDAR_SELECTED_DATE_CLASS));
+            const $selectedCell = $element.find(`.${CALENDAR_SELECTED_DATE_CLASS}`);
 
             assert.equal($selectedCell.length, 1, 'there is a selected cell');
             assert.equal($selectedCell.get(0), getCurrentViewInstance(calendar)._getCellByDate(calendar.option('value')).get(0), 'correct cell is selected');
@@ -737,7 +733,7 @@ QUnit.module('Views integration', {
             value: new Date(2013, 8, 9)
         });
 
-        const $dayElement = this.$element.find(toSelector(CALENDAR_CELL_CLASS)).first();
+        const $dayElement = this.$element.find(`.${CALENDAR_CELL_CLASS}`).first();
         const pointer = pointerMock($dayElement).start();
 
         pointer.active(this.$element);
@@ -759,7 +755,7 @@ QUnit.module('Views integration', {
         $.each(['month', 'year', 'decade', 'century'], (_, type) => {
             calendar.option('maxZoomLevel', type);
 
-            const $cell = $element.find(toSelector(CALENDAR_CELL_CLASS)).eq(5);
+            const $cell = $element.find(`.${CALENDAR_CELL_CLASS}`).eq(5);
             const cellDate = dataUtils.data($cell.get(0), CALENDAR_DATE_VALUE_KEY);
 
             $($cell).trigger('dxclick');
@@ -782,7 +778,7 @@ QUnit.module('Views integration', {
 
         $.each(['month', 'year', 'decade', 'century'], (_, type) => {
             calendar.option('maxZoomLevel', type);
-            const $cell = $element.find(toSelector(CALENDAR_CELL_CLASS)).eq(5);
+            const $cell = $element.find(`.${CALENDAR_CELL_CLASS}`).eq(5);
             const cellDate = dataUtils.data($cell.get(0), CALENDAR_DATE_VALUE_KEY);
 
             $cell.trigger('dxclick');
@@ -825,16 +821,16 @@ QUnit.module('Views integration', {
             const $mainView = $(getCurrentViewInstance(this.calendar).$element());
             const $additionalView = $(getAdditionalViewInstance(this.calendar).$element());
 
-            let $contouredCellOnMainView = $mainView.find(toSelector(CALENDAR_CONTOURED_DATE_CLASS));
-            let $contouredCellOnAdditionalView = $additionalView.find(toSelector(CALENDAR_CONTOURED_DATE_CLASS));
+            let $contouredCellOnMainView = $mainView.find(`.${CALENDAR_CONTOURED_DATE_CLASS}`);
+            let $contouredCellOnAdditionalView = $additionalView.find(`.${CALENDAR_CONTOURED_DATE_CLASS}`);
 
             assert.strictEqual($contouredCellOnMainView.length, 1, 'contoured date is on main view');
             assert.strictEqual($contouredCellOnAdditionalView.length, 0, 'contoured date is not on additional view');
 
             keyboard.press('right');
 
-            $contouredCellOnMainView = $mainView.find(toSelector(CALENDAR_CONTOURED_DATE_CLASS));
-            $contouredCellOnAdditionalView = $additionalView.find(toSelector(CALENDAR_CONTOURED_DATE_CLASS));
+            $contouredCellOnMainView = $mainView.find(`.${CALENDAR_CONTOURED_DATE_CLASS}`);
+            $contouredCellOnAdditionalView = $additionalView.find(`.${CALENDAR_CONTOURED_DATE_CLASS}`);
 
             assert.strictEqual($contouredCellOnMainView.length, 0, 'contoured date is not on main view');
             assert.strictEqual($contouredCellOnAdditionalView.length, 1, 'contoured date is on additional view');
@@ -869,7 +865,7 @@ QUnit.module('Views integration', {
 
         view.option('contouredDate', null);
 
-        const $contouredCell = getCurrentViewInstance(this.calendar).$element().find(toSelector(CALENDAR_CONTOURED_DATE_CLASS));
+        const $contouredCell = getCurrentViewInstance(this.calendar).$element().find(`.${CALENDAR_CONTOURED_DATE_CLASS}`);
 
         assert.strictEqual($contouredCell.length, 0, 'there is no contoured date cell');
     });
@@ -881,7 +877,7 @@ QUnit.module('Views integration', {
         });
 
         const calendar = this.calendar;
-        const $nextMonthButton = this.$element.find(toSelector(CALENDAR_NAVIGATOR_NEXT_MONTH_CLASS));
+        const $nextMonthButton = this.$element.find(`.${CALENDAR_NAVIGATOR_NEXT_MONTH_CLASS}`);
 
         assert.ok(
             dateUtils.sameMonth(calendar.option('currentDate'), new Date(2025, 1, 10)),
@@ -1244,14 +1240,14 @@ QUnit.module('Keyboard navigation', {
             const view = getCurrentViewInstance(calendar);
             const $view = $(view.$element());
 
-            calendar.option('value', new Date(dataUtils.data($view.find(toSelector(CALENDAR_CELL_CLASS)).not(toSelector(CALENDAR_OTHER_VIEW_CLASS)).eq(5).get(0), CALENDAR_DATE_VALUE_KEY)));
+            calendar.option('value', new Date(dataUtils.data($view.find(`.${CALENDAR_CELL_CLASS}`).not(`.${CALENDAR_OTHER_VIEW_CLASS}`).eq(5).get(0), CALENDAR_DATE_VALUE_KEY)));
 
-            let expectedContoured = dataUtils.data($view.find(toSelector(CALENDAR_CELL_CLASS)).not(toSelector(CALENDAR_OTHER_VIEW_CLASS)).first().get(0), CALENDAR_DATE_VALUE_KEY);
+            let expectedContoured = dataUtils.data($view.find(`.${CALENDAR_CELL_CLASS}`).not(`.${CALENDAR_OTHER_VIEW_CLASS}`).first().get(0), CALENDAR_DATE_VALUE_KEY);
 
             triggerKeydown($viewsWrapper, HOME_KEY_CODE);
             assert.deepEqual(view.option('contouredDate'), expectedContoured, 'home button contoured first cell');
 
-            expectedContoured = dataUtils.data($view.find(toSelector(CALENDAR_CELL_CLASS)).not(toSelector(CALENDAR_OTHER_VIEW_CLASS)).last().get(0), CALENDAR_DATE_VALUE_KEY);
+            expectedContoured = dataUtils.data($view.find(`.${CALENDAR_CELL_CLASS}`).not(`.${CALENDAR_OTHER_VIEW_CLASS}`).last().get(0), CALENDAR_DATE_VALUE_KEY);
             triggerKeydown($viewsWrapper, END_KEY_CODE);
             assert.deepEqual(view.option('contouredDate'), expectedContoured, 'end button contoured last cell');
         });
@@ -1332,7 +1328,7 @@ QUnit.module('Keyboard navigation', {
 
             assert.deepEqual(this.calendar.option('currentDate'), new Date(2013, 8, 17), 'current date is correct');
             assert.deepEqual(getCurrentViewInstance(this.calendar).option('date'), new Date(2013, 8, 1), 'correct view is shown');
-            assert.equal(getCurrentViewInstance(this.calendar).$element().find(toSelector(CALENDAR_CONTOURED_DATE_CLASS)).length, 1, 'contoured date is rendered');
+            assert.equal(getCurrentViewInstance(this.calendar).$element().find(`.${CALENDAR_CONTOURED_DATE_CLASS}`).length, 1, 'contoured date is rendered');
         } finally {
             fx.off = fxOrigState;
         }
@@ -1449,7 +1445,7 @@ QUnit.module('Calendar footer', {
     }
 }, () => {
     QUnit.test('today button click reselect value when selectionMode is single', function(assert) {
-        const $todayButton = this.$element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS));
+        const $todayButton = this.$element.find(`.${CALENDAR_TODAY_BUTTON_CLASS}`);
 
         $todayButton.trigger('dxclick');
 
@@ -1469,7 +1465,7 @@ QUnit.module('Calendar footer', {
 
             assert.strictEqual(this.calendar.option('value').length, 1);
 
-            const $todayButton = this.$element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS));
+            const $todayButton = this.$element.find(`.${CALENDAR_TODAY_BUTTON_CLASS}`);
             $todayButton.trigger('dxclick');
 
             assert.strictEqual(this.calendar.option('value').length, 2);
@@ -1485,7 +1481,7 @@ QUnit.module('Calendar footer', {
 
         assert.strictEqual(this.calendar.option('value').length, 1);
 
-        const $todayButton = this.$element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS));
+        const $todayButton = this.$element.find(`.${CALENDAR_TODAY_BUTTON_CLASS}`);
         $todayButton.trigger('dxclick');
 
         assert.strictEqual(this.calendar.option('value').length, 0);
@@ -1494,7 +1490,7 @@ QUnit.module('Calendar footer', {
     QUnit.test('today view are current after today button click', function(assert) {
         const calendar = this.calendar;
 
-        const $todayButton = this.$element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS));
+        const $todayButton = this.$element.find(`.${CALENDAR_TODAY_BUTTON_CLASS}`);
 
         calendar.option('value', new Date(2020, 10, 10));
         assert.deepEqual(calendar.option('currentDate'), new Date(2020, 10, 10), 'change option correct');
@@ -1512,7 +1508,7 @@ QUnit.module('Calendar footer', {
 
     QUnit.test('today view already has a current', function(assert) {
         const calendar = this.calendar;
-        const $todayButton = this.$element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS));
+        const $todayButton = this.$element.find(`.${CALENDAR_TODAY_BUTTON_CLASS}`);
 
         const dateInTodayView = new Date();
         dateInTodayView.setDate(15);
@@ -1532,7 +1528,7 @@ QUnit.module('Calendar footer', {
         });
 
         const calendar = this.calendar;
-        const $todayButton = this.$element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS));
+        const $todayButton = this.$element.find(`.${CALENDAR_TODAY_BUTTON_CLASS}`);
 
         $($todayButton).trigger('dxclick');
         assert.equal(calendar.option('zoomLevel'), 'month', 'calendar view is changed correctly');
@@ -1542,7 +1538,7 @@ QUnit.module('Calendar footer', {
 
     QUnit.test('today view is visible after \'today\' button click', function(assert) {
         const $element = this.$element;
-        const $todayButton = $element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS));
+        const $todayButton = $element.find(`.${CALENDAR_TODAY_BUTTON_CLASS}`);
 
         $($todayButton).trigger('dxclick');
 
@@ -1550,15 +1546,15 @@ QUnit.module('Calendar footer', {
 
         assert.ok(dateUtils.sameMonthAndYear(view.option('date'), new Date()), 'calendar current view is correct');
         assert.equal(view.$element().position().left, 0, 'calendar current view position is correct');
-        assert.equal($element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS)).position().left, 0, 'views wrapper is centered');
-        assert.equal(view.$element().find(toSelector(CALENDAR_SELECTED_DATE_CLASS)).length, 1, 'there is selected cell on the current view');
+        assert.equal($element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS}`).position().left, 0, 'views wrapper is centered');
+        assert.equal(view.$element().find(`.${CALENDAR_SELECTED_DATE_CLASS}`).length, 1, 'there is selected cell on the current view');
     });
 
     QUnit.test('navigator caption should be changed after \'today\' button click', function(assert) {
         const $element = this.$element;
-        const $todayButton = $element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS));
+        const $todayButton = $element.find(`.${CALENDAR_TODAY_BUTTON_CLASS}`);
 
-        const $navigator = $element.find(toSelector(CALENDAR_CAPTION_BUTTON_CLASS));
+        const $navigator = $element.find(`.${CALENDAR_CAPTION_BUTTON_CLASS}`);
         const prevText = $navigator.text();
 
         $($todayButton).trigger('dxclick');
@@ -1575,7 +1571,7 @@ QUnit.module('Calendar footer', {
 
         const $element = this.$element;
         const calendar = this.calendar;
-        const viewWidth = $element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS) + ' .dx-widget').eq(0).width();
+        const viewWidth = $element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS} .dx-widget`).eq(0).width();
 
         try {
             fx.off = false;
@@ -1589,7 +1585,7 @@ QUnit.module('Calendar footer', {
                 return $.Deferred().resolve().promise();
             };
 
-            const $todayButton = $element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS));
+            const $todayButton = $element.find(`.${CALENDAR_TODAY_BUTTON_CLASS}`);
             $($todayButton).trigger('dxclick');
         } finally {
             fx.animate = origAnimate;
@@ -1604,7 +1600,7 @@ QUnit.module('Calendar footer', {
         const origAnimate = fx.animate;
 
         const calendar = this.calendar;
-        const viewWidth = this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS) + ' .dx-widget').eq(0).width();
+        const viewWidth = this.$element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS} .dx-widget`).eq(0).width();
         const today = new Date();
 
         calendar.option('currentDate', new Date(today.getFullYear() + 2, 2, 7));
@@ -1621,7 +1617,7 @@ QUnit.module('Calendar footer', {
                 return $.Deferred().resolve().promise();
             };
 
-            const $todayButton = $(calendar.$element().find(toSelector(CALENDAR_TODAY_BUTTON_CLASS)));
+            const $todayButton = $(calendar.$element().find(`.${CALENDAR_TODAY_BUTTON_CLASS}`));
 
             $($todayButton).trigger('dxclick');
         } finally {
@@ -1634,7 +1630,7 @@ QUnit.module('Calendar footer', {
         QUnit.test(`correct views are rendered after animation (viewsCount = ${viewsCount}`, function(assert) {
             const calendar = this.calendar;
             calendar.option('viewsCount', viewsCount);
-            const $todayButton = this.$element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS));
+            const $todayButton = this.$element.find(`.${CALENDAR_TODAY_BUTTON_CLASS}`);
 
             $($todayButton).trigger('dxclick');
 
@@ -1671,7 +1667,7 @@ QUnit.module('Calendar footer', {
                     return origAnimate.apply(fx, args);
                 };
 
-                $(this.$element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS))).trigger('dxclick');
+                $(this.$element.find(`.${CALENDAR_TODAY_BUTTON_CLASS}`)).trigger('dxclick');
 
                 assert.equal(animationCount, viewsCount, 'only one animation was made for view change');
             } finally {
@@ -1807,7 +1803,7 @@ QUnit.module('Options', {
             currentDate: new Date(2020, 0, 0)
         });
 
-        const $cell = this.$element.find(toSelector(CALENDAR_CELL_CLASS)).eq(4);
+        const $cell = this.$element.find(`.${CALENDAR_CELL_CLASS}`).eq(4);
         $($cell).trigger('dxclick');
 
         const selectedFormattedValue = '2019-11-28';
@@ -1823,7 +1819,7 @@ QUnit.module('Options', {
             currentDate: new Date(2020, 0, 0)
         });
 
-        const $cell = this.$element.find(toSelector(CALENDAR_CELL_CLASS)).eq(4);
+        const $cell = this.$element.find(`.${CALENDAR_CELL_CLASS}`).eq(4);
         const cellContent = $cell.text();
 
         assert.strictEqual(cellContent, 'Custom template', 'cell content is correct after cellTemplate runtime change');
@@ -1838,14 +1834,14 @@ QUnit.module('Options', {
             showWeekNumbers: true
         });
 
-        const $cell = this.$element.find(toSelector(CALENDAR_WEEK_NUMBER_CELL_CLASS)).eq(0);
+        const $cell = this.$element.find(`.${CALENDAR_WEEK_NUMBER_CELL_CLASS}`).eq(0);
         const cellContent = $cell.text();
 
         assert.strictEqual(cellContent, 'Week cell template');
     });
 
     QUnit.test('showTodayButton option', function(assert) {
-        const getTodayButton = () => this.$element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS)).get(0);
+        const getTodayButton = () => this.$element.find(`.${CALENDAR_TODAY_BUTTON_CLASS}`).get(0);
 
         this.calendar.option('showTodayButton', true);
 
@@ -1858,7 +1854,7 @@ QUnit.module('Options', {
     });
 
     QUnit.test('todayButtonText option initialize', function(assert) {
-        const getTodayButton = () => this.$element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS)).get(0);
+        const getTodayButton = () => this.$element.find(`.${CALENDAR_TODAY_BUTTON_CLASS}`).get(0);
 
         this.reinit({
             showTodayButton: true,
@@ -1870,7 +1866,7 @@ QUnit.module('Options', {
     });
 
     QUnit.test('todayButtonText option', function(assert) {
-        const getTodayButton = () => this.$element.find(toSelector(CALENDAR_TODAY_BUTTON_CLASS)).get(0);
+        const getTodayButton = () => this.$element.find(`.${CALENDAR_TODAY_BUTTON_CLASS}`).get(0);
 
         this.calendar.option({
             showTodayButton: true,
@@ -1882,7 +1878,7 @@ QUnit.module('Options', {
     });
 
     QUnit.test('onCellClick option runtime change', function(assert) {
-        const getCellElement = () => this.$element.find(toSelector(CALENDAR_CELL_CLASS)).eq(4);
+        const getCellElement = () => this.$element.find(`.${CALENDAR_CELL_CLASS}`).eq(4);
 
         const firstClickHandler = sinon.spy();
         const secondClickHandler = sinon.spy();
@@ -1903,7 +1899,7 @@ QUnit.module('Options', {
     });
 
     QUnit.test('onCellClick option - subscription by "on" method', function(assert) {
-        const getCellElement = () => this.$element.find(toSelector(CALENDAR_CELL_CLASS)).eq(4);
+        const getCellElement = () => this.$element.find(`.${CALENDAR_CELL_CLASS}`).eq(4);
 
         const clickHandler = sinon.spy();
 
@@ -1943,7 +1939,7 @@ QUnit.module('Options', {
 
     QUnit.test('onContouredChanged option - subscription by "on" method', function(assert) {
         const goNextView = () => {
-            $(this.$element.find(toSelector(CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS))).trigger('dxclick');
+            $(this.$element.find(`.${CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS}`)).trigger('dxclick');
         };
 
         const handler = sinon.spy();
@@ -1970,7 +1966,7 @@ QUnit.module('Options', {
             onCellClick: clickHandler
         });
 
-        const $cell = this.$element.find(toSelector(CALENDAR_CELL_CLASS)).eq(4);
+        const $cell = this.$element.find(`.${CALENDAR_CELL_CLASS}`).eq(4);
         $($cell).trigger('dxclick');
 
         assert.ok(clickHandler.calledOnce, 'onCellClick called once');
@@ -2096,7 +2092,7 @@ QUnit.module('Options', {
                         selectionMode,
                         value
                     });
-                    const $cells = $(getCurrentViewInstance(this.calendar).$element().find(toSelector(CALENDAR_SELECTED_DATE_CLASS)));
+                    const $cells = $(getCurrentViewInstance(this.calendar).$element().find(`.${CALENDAR_SELECTED_DATE_CLASS}`));
 
                     assert.strictEqual($($cells[0]).data('value'), '2023/01/05');
                     assert.strictEqual($($cells[1]).data('value'), '2023/02/01');
@@ -2225,7 +2221,7 @@ QUnit.module('Options', {
 
                 this.calendar.option('currentDate', new Date('2025-12-31'));
 
-                const $prevButton = $(this.$element.find(toSelector(CALENDAR_NAVIGATOR_PREVIOUS_VIEW_CLASS)));
+                const $prevButton = $(this.$element.find(`.${CALENDAR_NAVIGATOR_PREVIOUS_VIEW_CLASS}`));
                 $prevButton.trigger('dxclick');
 
                 const $cell = $(getCurrentViewInstance(this.calendar).$element().find('*[data-value="2025/11/01"]'));
@@ -2343,7 +2339,7 @@ QUnit.module('Options', {
 
                 assert.strictEqual(getCurrentViewInstance(this.calendar).option('hoveredRange').length, 3, 'hovered range is correct');
 
-                const $viewsWrapper = $(this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS)));
+                const $viewsWrapper = $(this.$element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS}`));
 
                 $viewsWrapper.trigger('mouseleave');
 
@@ -2580,7 +2576,7 @@ QUnit.module('Options', {
 
                 this.calendar.option('selectionMode', newSelectionMode);
 
-                const $cells = $(getCurrentViewInstance(this.calendar).$element().find(toSelector(CALENDAR_SELECTED_DATE_CLASS)));
+                const $cells = $(getCurrentViewInstance(this.calendar).$element().find(`.${CALENDAR_SELECTED_DATE_CLASS}`));
 
                 assert.strictEqual($cells.length, 0);
             });
@@ -2887,7 +2883,7 @@ QUnit.module('Options', {
 
                 const currentDate = this.calendar.option('currentDate');
                 const navigatorButtonClass = button === 'next' ? CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS : CALENDAR_NAVIGATOR_PREVIOUS_VIEW_CLASS;
-                const $navigatorButton = this.$element.find(toSelector(navigatorButtonClass));
+                const $navigatorButton = this.$element.find(`.${navigatorButtonClass}`);
 
                 $navigatorButton.trigger('dxclick');
 
@@ -2977,10 +2973,10 @@ QUnit.module('ZoomLevel option', {
             zoomLevel: 'decade'
         }).dxCalendar('instance');
 
-        $(this.$element.find(toSelector(CALENDAR_CELL_CLASS)).eq(5)).trigger('dxclick');
+        $(this.$element.find(`.${CALENDAR_CELL_CLASS}`).eq(5)).trigger('dxclick');
         assert.equal(calendar.option('zoomLevel'), 'year', '\'zoomLevel\' changed');
 
-        $(this.$element.find(toSelector(CALENDAR_CELL_CLASS)).eq(5)).trigger('dxclick');
+        $(this.$element.find(`.${CALENDAR_CELL_CLASS}`).eq(5)).trigger('dxclick');
         assert.equal(calendar.option('zoomLevel'), 'year', '\'zoomLevel\' did not change');
     });
 
@@ -3016,15 +3012,15 @@ QUnit.module('ZoomLevel option', {
             value: new Date(2015, 2, 15)
         }).dxCalendar('instance');
 
-        $(this.$element.find(toSelector(CALENDAR_CELL_CLASS)).eq(5)).trigger('dxclick');
+        $(this.$element.find(`.${CALENDAR_CELL_CLASS}`).eq(5)).trigger('dxclick');
         assert.deepEqual(calendar.option('value'), new Date(2015, 5, 1), '\'zoomLevel\' changed');
 
         calendar.option('maxZoomLevel', 'decade');
-        $(this.$element.find(toSelector(CALENDAR_CELL_CLASS)).eq(5)).trigger('dxclick');
+        $(this.$element.find(`.${CALENDAR_CELL_CLASS}`).eq(5)).trigger('dxclick');
         assert.deepEqual(calendar.option('value'), new Date(2014, 0, 1), '\'zoomLevel\' changed');
 
         calendar.option('maxZoomLevel', 'century');
-        $(this.$element.find(toSelector(CALENDAR_CELL_CLASS)).eq(5)).trigger('dxclick');
+        $(this.$element.find(`.${CALENDAR_CELL_CLASS}`).eq(5)).trigger('dxclick');
         assert.deepEqual(calendar.option('value'), new Date(2040, 0, 1), '\'zoomLevel\' changed');
     });
 
@@ -3038,7 +3034,7 @@ QUnit.module('ZoomLevel option', {
                 zoomLevel: type
             });
 
-            $(toSelector(CALENDAR_CAPTION_BUTTON_CLASS)).trigger('dxclick');
+            $(`.${CALENDAR_CAPTION_BUTTON_CLASS}`).trigger('dxclick');
             assert.equal(instance.option('zoomLevel'), type, 'zoom level did not change');
         });
     });
@@ -3064,7 +3060,7 @@ QUnit.module('ZoomLevel option', {
             value: new Date(2015, 2, 15)
         }).dxCalendar('instance');
 
-        const $captionButton = this.$element.find(toSelector(CALENDAR_CAPTION_BUTTON_CLASS));
+        const $captionButton = this.$element.find(`.${CALENDAR_CAPTION_BUTTON_CLASS}`);
 
         $($captionButton).trigger('dxclick');
         assert.equal(calendar.option('zoomLevel'), 'month', 'view is not changed (month)');
@@ -3090,7 +3086,7 @@ QUnit.module('ZoomLevel option', {
         $.each(['century', 'decade'], (_, type) => {
             calendar.option('zoomLevel', type);
 
-            $($element.find(toSelector(CALENDAR_CELL_CLASS)).not(toSelector(CALENDAR_OTHER_VIEW_CLASS)).eq(3)).trigger('dxclick');
+            $($element.find(`.${CALENDAR_CELL_CLASS}`).not(`.${CALENDAR_OTHER_VIEW_CLASS}`).eq(3)).trigger('dxclick');
             assert.notStrictEqual(calendar.option('zoomLevel'), type, 'zoomLevel option view is changed');
         });
     });
@@ -3121,7 +3117,7 @@ QUnit.module('ZoomLevel option', {
         $.each(['century', 'decade'], (_, type) => {
             calendar.option('zoomLevel', type);
 
-            $($element.find(toSelector(CALENDAR_OTHER_VIEW_CLASS)).first()).trigger('dxclick');
+            $($element.find(`.${CALENDAR_OTHER_VIEW_CLASS}`).first()).trigger('dxclick');
             assert.notStrictEqual(calendar.option('zoomLevel'), type, 'zoomLevel option view is changed');
         });
     });
@@ -3139,12 +3135,12 @@ QUnit.module('ZoomLevel option', {
         try {
             fx.off = false;
             this.clock = sinon.useFakeTimers();
-            $($element.find(toSelector(CALENDAR_CELL_CLASS)).first()).trigger('dxclick');
+            $($element.find(`.${CALENDAR_CELL_CLASS}`).first()).trigger('dxclick');
 
             this.clock.tick(1000);
 
-            const navigatorCaptionText = $element.find(toSelector(CALENDAR_CAPTION_BUTTON_CLASS)).text();
-            const dataCell = $element.find(toSelector(CALENDAR_CELL_CLASS)).first().data('value');
+            const navigatorCaptionText = $element.find(`.${CALENDAR_CAPTION_BUTTON_CLASS}`).text();
+            const dataCell = $element.find(`.${CALENDAR_CELL_CLASS}`).first().data('value');
 
             assert.equal(navigatorCaptionText, '2009', 'navigator caption text is correct');
             assert.equal(dataCell, '2009/01/01', 'cell data is correct');
@@ -3326,7 +3322,7 @@ QUnit.module('Min & Max options', {
         this.calendar.option('max', max);
         assert.deepEqual(this.calendar.option('currentDate'), max, 'currentDate and max are equal');
         assert.equal(spy.callCount, 0, 'there was no navigation');
-        assert.equal(this.$element.find(toSelector(CALENDAR_CAPTION_BUTTON_CLASS)).text(), 'May 2015', 'navigator caption is changed');
+        assert.equal(this.$element.find(`.${CALENDAR_CAPTION_BUTTON_CLASS}`).text(), 'May 2015', 'navigator caption is changed');
     });
 
     QUnit.test('change currentDate without navigation if became out of range after min is set', function(assert) {
@@ -3340,7 +3336,7 @@ QUnit.module('Min & Max options', {
         this.calendar.option('min', min);
         assert.deepEqual(this.calendar.option('currentDate'), min, 'currentDate and min are equal');
         assert.equal(spy.callCount, 0, 'there was no navigation');
-        assert.equal(this.$element.find(toSelector(CALENDAR_CAPTION_BUTTON_CLASS)).text(), 'July 2015', 'navigator caption is changed');
+        assert.equal(this.$element.find(`.${CALENDAR_CAPTION_BUTTON_CLASS}`).text(), 'July 2015', 'navigator caption is changed');
     });
 
     QUnit.test('current date is not changed when min or max option is changed and current value is in range', function(assert) {
@@ -3404,7 +3400,7 @@ QUnit.module('Min & Max options', {
         });
 
         const calendar = this.calendar;
-        const $viewsWrapper = $(calendar.$element().find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS)));
+        const $viewsWrapper = $(calendar.$element().find(`.${CALENDAR_VIEWS_WRAPPER_CLASS}`));
 
         assert.equal($viewsWrapper.children().length, 2, 'the number of views is correct when current view contain min date');
         assert.ok(!getBeforeViewInstance(calendar), 'there is no after view');
@@ -3423,7 +3419,7 @@ QUnit.module('Min & Max options', {
         });
 
         const calendar = this.calendar;
-        const $views = $(calendar.$element().find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS)).children());
+        const $views = $(calendar.$element().find(`.${CALENDAR_VIEWS_WRAPPER_CLASS}`).children());
 
         assert.equal($views.length, 2, 'the number of views is correct when current view contain min date');
     });
@@ -3438,7 +3434,7 @@ QUnit.module('Min & Max options', {
         $.each(['year', 'decade', 'century'], $.proxy((_, type) => {
             this.reinit($.extend({}, params[type], { zoomLevel: type }));
 
-            const $views = this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS)).children();
+            const $views = this.$element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS}`).children();
             assert.equal($views.length, 3, 'all three views are rendered');
         }, this));
     });
@@ -3453,7 +3449,7 @@ QUnit.module('Min & Max options', {
         $.each(['year', 'decade', 'century'], $.proxy((_, type) => {
             this.reinit($.extend({}, params[type], { zoomLevel: type }));
 
-            const $views = this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS)).children();
+            const $views = this.$element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS}`).children();
             assert.equal($views.length, 3, 'all three views are rendered');
         }, this));
     });
@@ -3531,12 +3527,12 @@ QUnit.module('disabledDates option', {
             assert.deepEqual(calendar.option('currentDate'), new Date(2010, 11, 10), 'same date has been focused');
             assert.equal(animationSpy.callCount, 5, 'view is changed after the \'page down\' key press the third time');
 
-            $(this.$element.find(toSelector(CALENDAR_NAVIGATOR_PREVIOUS_VIEW_CLASS))).trigger('dxclick');
+            $(this.$element.find(`.${CALENDAR_NAVIGATOR_PREVIOUS_VIEW_CLASS}`)).trigger('dxclick');
             this.clock.tick(VIEW_ANIMATION_DURATION);
             assert.deepEqual(this.calendar.option('currentDate'), new Date(2010, 10, 10), 'same date has been focused');
             assert.equal(animationSpy.callCount, 6, 'view is changed after the click on previous arrow on UI');
 
-            $(this.$element.find(toSelector(CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS))).trigger('dxclick');
+            $(this.$element.find(`.${CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS}`)).trigger('dxclick');
             this.clock.tick(VIEW_ANIMATION_DURATION);
             assert.deepEqual(calendar.option('currentDate'), new Date(2010, 11, 10), 'same date has been focused');
             assert.equal(animationSpy.callCount, 7, 'view is changed after the click on next arrow on UI');
@@ -3589,12 +3585,12 @@ QUnit.module('disabledDates option', {
             assert.deepEqual(calendar.option('currentDate'), lastAvailableDateOnJanuary, 'closest available date has been focused');
             assert.equal(animationSpy.callCount, 4, 'view has been changed');
 
-            $(this.$element.find(toSelector(CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS))).trigger('dxclick');
+            $(this.$element.find(`.${CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS}`)).trigger('dxclick');
             this.clock.tick(VIEW_ANIMATION_DURATION);
             assert.deepEqual(calendar.option('currentDate'), firstAvailableDateOnFebruary, 'closest available date has been focused');
             assert.equal(animationSpy.callCount, 5, 'view has been changed');
 
-            $(this.$element.find(toSelector(CALENDAR_NAVIGATOR_PREVIOUS_VIEW_CLASS))).trigger('dxclick');
+            $(this.$element.find(`.${CALENDAR_NAVIGATOR_PREVIOUS_VIEW_CLASS}`)).trigger('dxclick');
             this.clock.tick(VIEW_ANIMATION_DURATION);
             assert.deepEqual(calendar.option('currentDate'), lastAvailableDateOnJanuary, 'closest available date has been focused');
             assert.equal(animationSpy.callCount, 6, 'view has been changed');
@@ -4236,7 +4232,7 @@ QUnit.module('Current date', {
             calendar.option('zoomLevel', type);
             $(calendar._$viewsWrapper).trigger('focus');
 
-            const $contouredElement = $element.find(toSelector(CALENDAR_CONTOURED_DATE_CLASS));
+            const $contouredElement = $element.find(`.${CALENDAR_CONTOURED_DATE_CLASS}`);
             assert.equal($contouredElement.length, 1, 'there is a contoured element');
         });
     });
@@ -4284,7 +4280,7 @@ QUnit.module('Current date', {
             focusStateEnabled: true
         }).dxCalendar('instance');
 
-        $(this.$element.find(toSelector(CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS))).trigger('dxclick');
+        $(this.$element.find(`.${CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS}`)).trigger('dxclick');
         assert.deepEqual(calendar.option('currentDate'), new Date(2015, 1, 28));
     });
 
@@ -4414,7 +4410,7 @@ QUnit.module('Navigation - click on other view cell', {
             calendar.option('maxZoomLevel', type);
             calendar.option('zoomLevel', type);
 
-            const $cell = $(calendar.$element().find(toSelector(CALENDAR_OTHER_VIEW_CLASS)).first());
+            const $cell = $(calendar.$element().find(`.${CALENDAR_OTHER_VIEW_CLASS}`).first());
             const date = dataUtils.data($cell.get(0), CALENDAR_DATE_VALUE_KEY);
 
             $($cell).trigger('dxclick');
@@ -4432,7 +4428,7 @@ QUnit.module('Navigation - click on other view cell', {
         }).dxCalendar('instance');
         const $element = this.$element;
 
-        const $cell = $element.find(toSelector(CALENDAR_CELL_CLASS)).eq(2);
+        const $cell = $element.find(`.${CALENDAR_CELL_CLASS}`).eq(2);
         const expectedDate = dataUtils.data($cell.get(0), CALENDAR_DATE_VALUE_KEY);
 
         expectedDate.setDate(1);
@@ -4450,7 +4446,7 @@ QUnit.module('Navigation - click on other view cell', {
         }).dxCalendar('instance');
         const $element = this.$element;
 
-        const $cell = $element.find(toSelector(CALENDAR_CELL_CLASS)).eq(1);
+        const $cell = $element.find(`.${CALENDAR_CELL_CLASS}`).eq(1);
         const expectedDate = dataUtils.data($cell.get(0), CALENDAR_DATE_VALUE_KEY);
 
         calendar.focus();
@@ -4469,7 +4465,7 @@ QUnit.module('Navigation - click on other view cell', {
         for(let year = 2015; year < 2017; year++) {
             for(let month = 11; month > 0; month--) {
                 calendar.option('value', new Date(year, month, 1));
-                const $cellLastPrevMonth = $(calendar._view.$element().find(toSelector(CALENDAR_CELL_CLASS)).not(toSelector(CALENDAR_OTHER_VIEW_CLASS)).first().prev());
+                const $cellLastPrevMonth = $(calendar._view.$element().find(`.${CALENDAR_CELL_CLASS}`).not(`.${CALENDAR_OTHER_VIEW_CLASS}`).first().prev());
 
                 if($cellLastPrevMonth.length) {
                     const expected = dataUtils.data($cellLastPrevMonth.get(0), CALENDAR_DATE_VALUE_KEY);
@@ -4525,8 +4521,8 @@ QUnit.module('Navigation - click on other view cell', {
 
                 this.pointer.swipeStart().swipe(0.5 * directionMultiplayer);
 
-                const $tables = this.$element.find(toSelector(CALENDAR_BODY_CLASS) + ' .dx-widget');
-                const $wrapper = this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS)).eq(0);
+                const $tables = this.$element.find(`.${CALENDAR_BODY_CLASS} .dx-widget`);
+                const $wrapper = this.$element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS}`).eq(0);
 
                 assert.roughEqual(translator.locate($wrapper).left, offset * directionMultiplayer, 1, 'Views wrapper position is correct');
                 assert.roughEqual(translator.locate($tables.eq(0)).left, 0, 1, 'Main view position is correct');
@@ -4544,7 +4540,7 @@ QUnit.module('Navigation - click on other view cell', {
                 this.pointer.swipeStart().swipeEnd(0, 0.4 * directionMultiplayer);
 
                 assert.equal(this.$element.find('table').length, 2 + viewsCount, 'Calendar contains one view after swipe end');
-                assert.equal(this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS)).position().left, 0, 'Views wrapper position is correct');
+                assert.equal(this.$element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS}`).position().left, 0, 'Views wrapper position is correct');
                 assert.equal(getCurrentViewInstance(this.calendar).$element().position().left, 0, 'View position is correct');
                 assert.equal(this.calendar.option('currentDate').getMonth(), currentDate.getMonth(), 'Current month is correct');
             });
@@ -4556,7 +4552,7 @@ QUnit.module('Navigation - click on other view cell', {
                 this.pointer.swipeStart().swipe(0.6 * directionMultiplayer).swipeEnd(1, 0.6 * directionMultiplayer);
 
                 assert.equal(this.$element.find('table').length, 2 + viewsCount, 'Calendar contains one view after long right swipe end');
-                assert.equal(this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS)).position().left, 0, 'Views wrapper position is correct');
+                assert.equal(this.$element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS}`).position().left, 0, 'Views wrapper position is correct');
                 assert.equal(getCurrentViewInstance(this.calendar).$element().position().left, 0, 'View position is correct');
                 assert.equal(this.calendar.option('currentDate').getMonth(), currentDate.getMonth(), 'Current month is correct');
             });
@@ -4569,7 +4565,7 @@ QUnit.module('Navigation - click on other view cell', {
                 this.pointer.swipeStart().swipe(0.4 * directionMultiplayer).swipeEnd(1 * directionMultiplayer, 0.4 * directionMultiplayer);
 
                 assert.equal(this.$element.find('table').length, 2 + viewsCount, 'Calendar contains one view after short right swipe end');
-                assert.equal(this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS)).position().left, 0, 'Views wrapper position is correct');
+                assert.equal(this.$element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS}`).position().left, 0, 'Views wrapper position is correct');
                 assert.equal(getCurrentViewInstance(this.calendar).$element().position().left, 0, 'View position is correct');
                 assert.equal(this.calendar.option('currentDate').getMonth(), currentDate.getMonth(), 'Current month is correct');
             });
@@ -4599,7 +4595,7 @@ QUnit.module('Navigation - click on other view cell', {
                 const origAnimate = fx.animate;
 
                 try {
-                    const $views = this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS) + ' .dx-widget');
+                    const $views = this.$element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS} .dx-widget`);
                     const viewWidth = $views.eq(0).width();
 
                     fx.animate = (_, config) => {
@@ -4618,7 +4614,7 @@ QUnit.module('Navigation - click on other view cell', {
         QUnit.test('should not overlap during multidirectional swipe', function(assert) {
             this.pointer.swipeStart().swipe(-0.1).swipe(0.01);
 
-            const $views = this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS) + ' .dx-widget');
+            const $views = this.$element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS} .dx-widget`);
 
             assert.equal($views.length, 2 + viewsCount, 'correct views count');
             assert.ok($views.eq(1).position().left < 0, 'first additional view located at right');
@@ -4640,7 +4636,7 @@ QUnit.module('Navigation - click on other view cell', {
                 max: new Date(2015, 8, 26)
             });
 
-            const $viewsWrapper = this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS));
+            const $viewsWrapper = this.$element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS}`);
 
             this.pointer.swipeStart().swipe(-0.8).swipeEnd(0, -0.8);
             assert.equal($viewsWrapper.position().left, 0, 'views wrapper position is correct');
@@ -4656,7 +4652,7 @@ QUnit.module('Navigation - click on other view cell', {
                 max: new Date(2015, 8, 26)
             });
 
-            const $viewsWrapper = this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS));
+            const $viewsWrapper = this.$element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS}`);
 
             this.pointer.swipeStart().swipe(-0.2).swipeEnd(0, -0.2);
             assert.equal($viewsWrapper.position().left, 0, 'views wrapper position is correct');
@@ -4779,7 +4775,7 @@ QUnit.module('Aria accessibility', {
 
         calendar.focus();
 
-        const $cell = $element.find(toSelector(CALENDAR_CONTOURED_DATE_CLASS));
+        const $cell = $element.find(`.${CALENDAR_CONTOURED_DATE_CLASS}`);
 
         assert.notEqual($cell.attr('id'), undefined, 'id exists');
         assert.equal($viewsWrapper.attr('aria-activedescendant'), $cell.attr('id'), 'cell\'s id and element\'s activedescendant are equal');
@@ -4835,15 +4831,15 @@ QUnit.module('Aria accessibility', {
 
         calendar.focus();
 
-        let $cell = $element.find(toSelector(CALENDAR_CONTOURED_DATE_CLASS));
+        let $cell = $element.find(`.${CALENDAR_CONTOURED_DATE_CLASS}`);
         assert.equal($viewsWrapper.attr('aria-activedescendant'), $cell.attr('id'), 'contoured date cell id and activedescendant are equal');
 
         keyboard.press('right');
-        $cell = $element.find(toSelector(CALENDAR_CONTOURED_DATE_CLASS));
+        $cell = $element.find(`.${CALENDAR_CONTOURED_DATE_CLASS}`);
         assert.equal($viewsWrapper.attr('aria-activedescendant'), $cell.attr('id'), 'new contoured date cell id and activedescendant are equal');
 
         keyboard.press('enter');
-        $cell = $element.find(toSelector(CALENDAR_SELECTED_DATE_CLASS));
+        $cell = $element.find(`.${CALENDAR_SELECTED_DATE_CLASS}`);
         assert.equal($viewsWrapper.attr('aria-activedescendant'), $cell.attr('id'), 'selected cell id and activedescendant are equal');
     });
 
@@ -4851,7 +4847,7 @@ QUnit.module('Aria accessibility', {
         this.$element.dxCalendar();
 
         const $row = this.$element.find('tr').last();
-        const $cell = this.$element.find(toSelector(CALENDAR_CELL_CLASS)).first();
+        const $cell = this.$element.find(`.${CALENDAR_CELL_CLASS}`).first();
 
         assert.equal($row.attr('role'), 'row', 'Row: aria role is correct');
         assert.equal($cell.attr('role'), 'gridcell', 'Cell: aria role is correct');
@@ -4861,7 +4857,7 @@ QUnit.module('Aria accessibility', {
         this.$element.dxCalendar({
             readOnly: true,
         });
-        const $viewsWrapper = $(this.$element.find(toSelector(CALENDAR_VIEWS_WRAPPER_CLASS)));
+        const $viewsWrapper = $(this.$element.find(`.${CALENDAR_VIEWS_WRAPPER_CLASS}`));
 
         assert.equal($viewsWrapper.attr('aria-readonly'), undefined);
     });
@@ -4877,7 +4873,7 @@ QUnit.module('Aria accessibility', {
         calendar.focus();
 
         const viewElement = getCurrentViewInstance(calendar).$element();
-        let $cell = $(viewElement.find(toSelector(CALENDAR_CONTOURED_DATE_CLASS)));
+        let $cell = $(viewElement.find(`.${CALENDAR_CONTOURED_DATE_CLASS}`));
         const cellId = $cell.attr('id');
 
         assert.strictEqual($cell.attr('aria-selected'), 'true', 'aria-selected is true');
@@ -4886,13 +4882,13 @@ QUnit.module('Aria accessibility', {
         keyboard.press('right');
         assert.strictEqual($cell.attr('id'), undefined, 'id was removed from old contoured date cell');
 
-        $cell = $(viewElement.find(toSelector(CALENDAR_CONTOURED_DATE_CLASS)));
+        $cell = $(viewElement.find(`.${CALENDAR_CONTOURED_DATE_CLASS}`));
         const newCellId = $cell.attr('id');
         assert.notEqual(cellId, undefined, 'id was added to new contoured date cell');
         assert.notEqual(cellId, newCellId, 'id was refreshed');
 
         keyboard.press('enter');
-        $cell = $(viewElement.find(toSelector(CALENDAR_CONTOURED_DATE_CLASS)));
+        $cell = $(viewElement.find(`.${CALENDAR_CONTOURED_DATE_CLASS}`));
         assert.notEqual($cell.attr('id'), undefined, 'id was not remove when cell was selected');
         assert.notEqual($cell.attr('id'), newCellId, 'id was refreshed again');
     });
@@ -4911,7 +4907,7 @@ QUnit.module('Aria accessibility', {
 
         assert.strictEqual($cell.attr('aria-selected'), 'false', 'aria-selected is false on not selected cell');
 
-        $cell = $(viewElement.find(toSelector(CALENDAR_SELECTED_DATE_CLASS)));
+        $cell = $(viewElement.find(`.${CALENDAR_SELECTED_DATE_CLASS}`));
         assert.strictEqual($cell.attr('aria-selected'), 'true', 'aria-selected is true');
 
         keyboard.press('right');
@@ -4920,7 +4916,7 @@ QUnit.module('Aria accessibility', {
         keyboard.press('enter');
         assert.strictEqual($cell.attr('aria-selected'), 'false', 'aria-selected is false on the old cell');
 
-        $cell = $(viewElement.find(toSelector(CALENDAR_SELECTED_DATE_CLASS)));
+        $cell = $(viewElement.find(`.${CALENDAR_SELECTED_DATE_CLASS}`));
         assert.strictEqual($cell.attr('aria-selected'), 'true', 'aria-selected is true on the new cell');
     });
 
@@ -4930,10 +4926,10 @@ QUnit.module('Aria accessibility', {
             viewsCount: 2
         }).dxCalendar('instance');
 
-        let $cell = $(getCurrentViewInstance(calendar).$element().find(toSelector(CALENDAR_SELECTED_DATE_CLASS)));
+        let $cell = $(getCurrentViewInstance(calendar).$element().find(`.${CALENDAR_SELECTED_DATE_CLASS}`));
         assert.strictEqual($cell.attr('aria-selected'), 'true', 'aria-selected is true on the main view cell');
 
-        $cell = $(getAdditionalViewInstance(calendar).$element().find(toSelector(CALENDAR_SELECTED_DATE_CLASS)));
+        $cell = $(getAdditionalViewInstance(calendar).$element().find(`.${CALENDAR_SELECTED_DATE_CLASS}`));
         assert.strictEqual($cell.attr('aria-selected'), 'true', 'aria-selected is true on the additional view cell');
     });
 
@@ -4952,7 +4948,7 @@ QUnit.module('Aria accessibility', {
 
             assert.strictEqual($cell.attr('aria-selected'), 'false', 'aria-selected is false on not selected cell');
 
-            $cell = $(viewElement.find(toSelector(CALENDAR_SELECTED_DATE_CLASS)));
+            $cell = $(viewElement.find(`.${CALENDAR_SELECTED_DATE_CLASS}`));
             assert.strictEqual($cell.attr('aria-selected'), 'true', 'aria-selected is true on the cell');
 
             keyboard.press('right');
@@ -4960,7 +4956,7 @@ QUnit.module('Aria accessibility', {
 
             assert.strictEqual($cell.attr('aria-selected'), 'true', 'aria-selected is true on the old cell');
 
-            $cell = $(viewElement.find(toSelector(CALENDAR_SELECTED_DATE_CLASS)));
+            $cell = $(viewElement.find(`.${CALENDAR_SELECTED_DATE_CLASS}`));
             assert.strictEqual($cell.attr('aria-selected'), 'true', 'aria-selected is true on the new cell');
         });
     });
@@ -4975,13 +4971,13 @@ QUnit.module('Aria accessibility', {
 
             const keyboard = keyboardMock($(calendar._$viewsWrapper));
 
-            let $cell = $(getCurrentViewInstance(calendar).$element().find(toSelector(CALENDAR_SELECTED_DATE_CLASS)));
+            let $cell = $(getCurrentViewInstance(calendar).$element().find(`.${CALENDAR_SELECTED_DATE_CLASS}`));
             assert.equal($cell.attr('aria-selected'), 'true', 'aria-selected is true on the cell');
 
             keyboard.press('up');
             keyboard.press('down');
 
-            $cell = $(getCurrentViewInstance(calendar).$element().find(toSelector(CALENDAR_SELECTED_DATE_CLASS)));
+            $cell = $(getCurrentViewInstance(calendar).$element().find(`.${CALENDAR_SELECTED_DATE_CLASS}`));
             assert.equal($cell.attr('aria-selected'), 'true', 'aria-selected is true on the cell');
         });
     });
@@ -5054,7 +5050,7 @@ QUnit.module('Aria accessibility', {
 
     QUnit.test('table should have correct role after navigation to another view or zoom level', function(assert) {
         const calendar = this.$element.dxCalendar().dxCalendar('instance');
-        const $navigatorNext = this.$element.find(toSelector(CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS));
+        const $navigatorNext = this.$element.find(`.${CALENDAR_NAVIGATOR_NEXT_VIEW_CLASS}`);
 
         ['month', 'year', 'decade', 'century'].forEach((zoomLevel) => {
             calendar.option({ zoomLevel });
@@ -5082,7 +5078,7 @@ QUnit.module('Aria accessibility', {
                 showWeekNumbers: true
             });
 
-            const $cell = this.$element.find(toSelector(CALENDAR_WEEK_NUMBER_CELL_CLASS)).first();
+            const $cell = this.$element.find(`.${CALENDAR_WEEK_NUMBER_CELL_CLASS}`).first();
 
             assert.equal($cell.attr(attr), value);
         });
@@ -5188,7 +5184,7 @@ QUnit.module('Regression', {
             value: new Date(2013, 11, 31)
         }).dxCalendar('instance');
 
-        const $nextMonthButton = this.$element.find(toSelector(CALENDAR_NAVIGATOR_NEXT_MONTH_CLASS));
+        const $nextMonthButton = this.$element.find(`.${CALENDAR_NAVIGATOR_NEXT_MONTH_CLASS}`);
 
         $($nextMonthButton).trigger('dxclick');
         assert.equal(calendar.option('currentDate').getMonth(), 0);
@@ -5200,7 +5196,7 @@ QUnit.module('Regression', {
         }).dxCalendar('instance');
         const $view = $(getCurrentViewInstance(calendar).$element());
 
-        const $cells = $view.find(toSelector(CALENDAR_CELL_CLASS));
+        const $cells = $view.find(`.${CALENDAR_CELL_CLASS}`);
         assert.equal($cells.filter((index, element) => {
             return $(element).text() === '31';
         }).length, 1);
@@ -5211,7 +5207,7 @@ QUnit.module('Regression', {
             currentDate: new Date(2013, 11, 31)
         }).dxCalendar('instance');
 
-        $(this.$element.find(toSelector(CALENDAR_CELL_CLASS) + '[data-value=\'2014/01/01\']')).trigger('dxclick');
+        $(this.$element.find(`.${CALENDAR_CELL_CLASS}[data-value=\'2014/01/01\']`)).trigger('dxclick');
         assert.equal(calendar.option('currentDate').getMonth(), 0);
     });
 

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
@@ -97,10 +97,6 @@ const CANCEL_BUTTON_SELECTOR = '.dx-popup-cancel.dx-button';
 
 const WINDOW_RATIO = 0.8;
 
-const toSelector = function(val) {
-    return '.' + val;
-};
-
 const openPopupWithList = function(lookup) {
     $(lookup._$field).trigger('dxclick');
 };
@@ -2077,7 +2073,7 @@ QUnit.module('options', {
     });
 
     QUnit.test('clear button option runtime change', function(assert) {
-        const getClearButton = (instance) => $(instance.content()).parent().find(toSelector(CLEAR_BUTTON_CLASS)).get(0);
+        const getClearButton = (instance) => $(instance.content()).parent().find(`.${CLEAR_BUTTON_CLASS}`).get(0);
 
         const lookup = $('#lookup')
             .dxLookup({
@@ -2168,7 +2164,7 @@ QUnit.module('popup options', {
         }).dxLookup('instance');
 
         openPopupWithList(instance);
-        const $wrapper = $(toSelector(OVERLAY_WRAPPER_CLASS));
+        const $wrapper = $(`.${OVERLAY_WRAPPER_CLASS}`);
 
         assert.ok($wrapper.hasClass(OVERLAY_SHADER_CLASS));
 
@@ -2184,7 +2180,7 @@ QUnit.module('popup options', {
 
         openPopupWithList(instance);
 
-        const $overlay = $(toSelector(OVERLAY_CONTENT_CLASS)).eq(0);
+        const $overlay = $(`.${OVERLAY_CONTENT_CLASS}`).eq(0);
 
         $(document).trigger('dxpointerdown');
         assert.equal($overlay.is(':visible'), false, 'overlay is hidden');
@@ -2200,7 +2196,7 @@ QUnit.module('popup options', {
 
         openPopupWithList(instance);
 
-        const $overlay = $(toSelector(OVERLAY_CONTENT_CLASS)).eq(0);
+        const $overlay = $(`.${OVERLAY_CONTENT_CLASS}`).eq(0);
 
         $($overlay).trigger('dxpointerdown');
         assert.equal($overlay.is(':visible'), true, 'overlay is not hidden');
@@ -2248,7 +2244,7 @@ QUnit.module('popup options', {
 
         openPopupWithList($lookup.dxLookup('instance'));
 
-        const $title = $(toSelector(POPUP_TITLE_CLASS));
+        const $title = $(`.${POPUP_TITLE_CLASS}`);
 
         assert.equal($title.text().trim(), 'testTitle', 'title text is correct');
     });
@@ -2267,9 +2263,9 @@ QUnit.module('popup options', {
 
         openPopupWithList(instance);
 
-        const $title = $(toSelector(POPUP_TITLE_CLASS));
+        const $title = $(`.${POPUP_TITLE_CLASS}`);
 
-        assert.ok($title.find(toSelector('test-title-renderer')).length, 'option \'titleTemplate\' was set successfully');
+        assert.ok($title.find('.test-title-renderer').length, 'option \'titleTemplate\' was set successfully');
     });
 
     QUnit.test('custom titleTemplate and onTitleRendered option is set correctly by options', function(assert) {
@@ -2291,9 +2287,9 @@ QUnit.module('popup options', {
         });
 
         openPopupWithList(instance);
-        const $title = $(toSelector(POPUP_TITLE_CLASS));
+        const $title = $(`.${POPUP_TITLE_CLASS}`);
 
-        assert.ok($title.find(toSelector('changed-test-title-renderer')).length, 'option \'titleTemplate\' successfully passed to the popup widget');
+        assert.ok($title.find('.changed-test-title-renderer').length, 'option \'titleTemplate\' successfully passed to the popup widget');
     });
 
     QUnit.test('popup does not close when filtering datasource has item equal selected item', function(assert) {
@@ -2305,7 +2301,7 @@ QUnit.module('popup options', {
 
         $lookup.dxLookup('option', 'opened', true);
 
-        const $popupContent = $(toSelector(POPUP_CONTENT_CLASS));
+        const $popupContent = $(`.${POPUP_CONTENT_CLASS}`);
         keyboardMock($popupContent.find('.' + TEXTEDITOR_INPUT_CLASS)).type('y');
 
         assert.ok($lookup.dxLookup('option', 'opened'), 'lookup stays opened');
@@ -2618,7 +2614,8 @@ QUnit.module('list options', {
 
         openPopupWithList(instance);
 
-        const $list = $(toSelector(LIST_CLASS)); const list = $list.dxList('instance');
+        const $list = $(`.${LIST_CLASS}`);
+        const list = $list.dxList('instance');
 
         assert.equal(list.option('pageLoadMode'), 'scrollBottom', 'pageLoadMode was bounced');
         instance.option('pageLoadMode', 'nextButton');
@@ -2661,11 +2658,12 @@ QUnit.module('list options', {
 
         openPopupWithList(instance);
 
-        const $list = $(toSelector(LIST_CLASS)); const list = $list.dxList('instance');
+        const $list = $(`.${LIST_CLASS}`);
+        const list = $list.dxList('instance');
 
         assert.equal(list.option('grouped'), true, 'grouped was bounced');
 
-        let $title = $(toSelector(LIST_GROUP_HEADER_CLASS));
+        let $title = $(`.${LIST_GROUP_HEADER_CLASS}`);
         assert.equal($title.length, 2, 'there are 2 group titles');
         $title = $title.eq(0);
         assert.equal($title.text().trim(), 'testGroupTemplate', 'title text is correct');
@@ -2675,7 +2673,7 @@ QUnit.module('list options', {
             return 'test';
         });
 
-        $title = $(toSelector(LIST_GROUP_HEADER_CLASS)).eq(0);
+        $title = $(`.${LIST_GROUP_HEADER_CLASS}`).eq(0);
         assert.equal($title.text().trim(), 'test', 'title text is correct');
     });
 });
@@ -3304,7 +3302,7 @@ QUnit.module('dataSource integration', {
             searchMode: 'contains'
         });
 
-        const $input = $(toSelector(POPUP_CONTENT_CLASS) + ' ' + toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $(`.${POPUP_CONTENT_CLASS} .${TEXTEDITOR_INPUT_CLASS}`);
         $($input.val('o')).trigger('input');
         this.clock.tick(10);
         assert.equal($('.dx-list-item').length, 2, 'filters execute on input event');

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/radioButton.markup.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/radioButton.markup.tests.js
@@ -11,8 +11,6 @@ QUnit.testStart(() => {
     $('#qunit-fixture').html(markup);
 });
 
-const toSelector = cssClass => '.' + cssClass;
-
 QUnit.module('button rendering', () => {
     QUnit.test('widget should be rendered', function(assert) {
         const $radioButton = $('#radioButton').dxRadioButton();
@@ -22,7 +20,7 @@ QUnit.module('button rendering', () => {
 
     QUnit.test('icon should be rendered', function(assert) {
         const $radioButton = $('#radioButton').dxRadioButton();
-        const $icon = $radioButton.children(toSelector(RADIO_BUTTON_ICON_CLASS));
+        const $icon = $radioButton.children(`.${RADIO_BUTTON_ICON_CLASS}`);
 
         assert.ok($icon.length, 'icon rendered');
     });

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/radioGroup.markup.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/radioGroup.markup.tests.js
@@ -22,8 +22,6 @@ const RADIO_BUTTON_CHECKED_CLASS = 'dx-radiobutton-checked';
 const RADIO_GROUP_VERTICAL_CLASS = 'dx-radiogroup-vertical';
 const RADIO_GROUP_HORIZONTAL_CLASS = 'dx-radiogroup-horizontal';
 
-const toSelector = cssClass => '.' + cssClass;
-
 const moduleConfig = {
     beforeEach: function() {
         executeAsyncMock.setup();
@@ -49,7 +47,7 @@ QUnit.module('buttons group rendering', moduleConfig, () => {
             ]
         });
 
-        assert.equal($radioGroup.find(toSelector(RADIO_BUTTON_CLASS)).length, 3, 'buttons generated');
+        assert.equal($radioGroup.find(`.${RADIO_BUTTON_CLASS}`).length, 3, 'buttons generated');
     });
 
     QUnit.test('empty message should not be generated if no items', function(assert) {
@@ -112,7 +110,7 @@ QUnit.module('buttons rendering', moduleConfig, () => {
             valueExpr: 'value'
         });
 
-        const $radioButton = $radioGroup.find(toSelector(RADIO_BUTTON_CLASS)).eq(0);
+        const $radioButton = $radioGroup.find(`.${RADIO_BUTTON_CLASS}`).eq(0);
         assert.equal($radioButton.text(), '0', 'text rendered correctly');
     });
 
@@ -124,7 +122,7 @@ QUnit.module('buttons rendering', moduleConfig, () => {
             valueExpr: 'value'
         });
 
-        const $radioButton = $radioGroup.find(toSelector(RADIO_BUTTON_CLASS)).eq(0);
+        const $radioButton = $radioGroup.find(`.${RADIO_BUTTON_CLASS}`).eq(0);
         assert.equal($radioButton.text(), '0', 'text rendered correctly');
     });
 
@@ -135,7 +133,7 @@ QUnit.module('buttons rendering', moduleConfig, () => {
             ]
         });
 
-        const $radioButton = $radioGroup.find(toSelector(RADIO_BUTTON_CLASS)).eq(0);
+        const $radioButton = $radioGroup.find(`.${RADIO_BUTTON_CLASS}`).eq(0);
         assert.equal($radioButton.text(), '0', 'text rendered correctly');
     });
 
@@ -146,7 +144,7 @@ QUnit.module('buttons rendering', moduleConfig, () => {
             ]
         });
 
-        const $radioButton = $radioGroup.find(toSelector(RADIO_BUTTON_CLASS)).find('input');
+        const $radioButton = $radioGroup.find(`.${RADIO_BUTTON_CLASS}`).find('input');
 
         assert.equal($radioButton.prop('type'), 'radio', 'input type rendered correctly');
         assert.equal($radioButton.prop('value'), 'foo', 'input value rendered correctly');
@@ -225,7 +223,7 @@ QUnit.module('value', moduleConfig, () => {
         const radioGroup = $radioGroup.dxRadioGroup('instance');
 
         setTimeout(function() {
-            assert.equal($(radioGroup.itemElements()).filter(toSelector(RADIO_BUTTON_CHECKED_CLASS)).length, 1, 'one item checked');
+            assert.equal($(radioGroup.itemElements()).filter(`.${RADIO_BUTTON_CHECKED_CLASS}`).length, 1, 'one item checked');
             done();
         });
     });

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/selectBox.tests.js
@@ -85,10 +85,6 @@ const KEY_SPACE = ' ';
 
 const TIME_TO_WAIT = 500;
 
-const toSelector = (className) => {
-    return '.' + className;
-};
-
 const moduleSetup = {
     beforeEach: function() {
         SelectBox.defaultOptions({ options: { deferRendering: false } });
@@ -161,7 +157,7 @@ QUnit.module('functionality', moduleSetup, () => {
             placeholder: 'test'
         });
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         assert.strictEqual(instance.option('value'), 'first', 'value set correct');
         assert.strictEqual($input.val(), 'first', 'value displayed correct');
@@ -203,9 +199,9 @@ QUnit.module('functionality', moduleSetup, () => {
         assert.ok(!instance.option('value'));
 
         this.clock.tick(TIME_TO_WAIT);
-        assert.strictEqual($element.find(toSelector(LIST_ITEM_CLASS)).length, 3, 'found 3 items');
+        assert.strictEqual($element.find(`.${LIST_ITEM_CLASS}`).length, 3, 'found 3 items');
 
-        $($element.find(toSelector(LIST_ITEM_CLASS)).first()).trigger('dxclick');
+        $($element.find(`.${LIST_ITEM_CLASS}`).first()).trigger('dxclick');
         this.clock.tick(TIME_TO_WAIT);
         assert.strictEqual(instance.option('value'), 'first', 'widget value was set');
 
@@ -219,14 +215,14 @@ QUnit.module('functionality', moduleSetup, () => {
         const $list = $element.find('.dx-list');
 
         this.clock.tick(TIME_TO_WAIT);
-        $($list.find(toSelector(LIST_ITEM_CLASS)).eq(1)).trigger('dxclick');
+        $($list.find(`.${LIST_ITEM_CLASS}`).eq(1)).trigger('dxclick');
 
-        assert.ok($list.find(toSelector(LIST_ITEM_CLASS)).eq(1).hasClass(LIST_ITEM_SELECTED_CLASS), 'selected item has selected class, after click on it');
+        assert.ok($list.find(`.${LIST_ITEM_CLASS}`).eq(1).hasClass(LIST_ITEM_SELECTED_CLASS), 'selected item has selected class, after click on it');
 
-        $($list.find(toSelector(LIST_ITEM_CLASS)).eq(2)).trigger('dxclick');
+        $($list.find(`.${LIST_ITEM_CLASS}`).eq(2)).trigger('dxclick');
 
-        assert.ok(!$list.find(toSelector(LIST_ITEM_CLASS)).eq(1).hasClass(LIST_ITEM_SELECTED_CLASS), 'previously selected item has no selected class, after click on other');
-        assert.ok($list.find(toSelector(LIST_ITEM_CLASS)).eq(2).hasClass(LIST_ITEM_SELECTED_CLASS), 'selected item has selected class, after click on it');
+        assert.ok(!$list.find(`.${LIST_ITEM_CLASS}`).eq(1).hasClass(LIST_ITEM_SELECTED_CLASS), 'previously selected item has no selected class, after click on other');
+        assert.ok($list.find(`.${LIST_ITEM_CLASS}`).eq(2).hasClass(LIST_ITEM_SELECTED_CLASS), 'selected item has selected class, after click on it');
     });
 
     QUnit.test('changing the "value" option must invoke the "onValueChanged" action', function(assert) {
@@ -249,11 +245,11 @@ QUnit.module('functionality', moduleSetup, () => {
 
         this.clock.tick(TIME_TO_WAIT);
 
-        assert.ok(!$list.find(toSelector(LIST_ITEM_CLASS)).eq(1).hasClass(LIST_ITEM_SELECTED_CLASS), 'second item has no selected class');
+        assert.ok(!$list.find(`.${LIST_ITEM_CLASS}`).eq(1).hasClass(LIST_ITEM_SELECTED_CLASS), 'second item has no selected class');
         instance.option('value', 'second');
 
-        assert.ok(!$list.find(toSelector(LIST_ITEM_CLASS)).eq(0).hasClass(LIST_ITEM_SELECTED_CLASS), 'first item has no selected class, after change value');
-        assert.ok($list.find(toSelector(LIST_ITEM_CLASS)).eq(1).hasClass(LIST_ITEM_SELECTED_CLASS), 'second item has selected class, after change value on it');
+        assert.ok(!$list.find(`.${LIST_ITEM_CLASS}`).eq(0).hasClass(LIST_ITEM_SELECTED_CLASS), 'first item has no selected class, after change value');
+        assert.ok($list.find(`.${LIST_ITEM_CLASS}`).eq(1).hasClass(LIST_ITEM_SELECTED_CLASS), 'second item has selected class, after change value on it');
     });
 
     QUnit.test('click on 0 in list ["", 0] sets value 0', function(assert) {
@@ -262,7 +258,7 @@ QUnit.module('functionality', moduleSetup, () => {
 
         this.clock.tick(TIME_TO_WAIT);
 
-        $($element.find(toSelector(LIST_ITEM_CLASS)).last()).trigger('dxclick');
+        $($element.find(`.${LIST_ITEM_CLASS}`).last()).trigger('dxclick');
 
         assert.strictEqual(instance.option('value'), 0, 'click on list item, and its value replaces widget value');
     });
@@ -270,7 +266,7 @@ QUnit.module('functionality', moduleSetup, () => {
     QUnit.test('click on textbox toggle popup visibility', function(assert) {
         const $element = $('#selectBox').dxSelectBox({ items: [0, 1, 2] });
         const $list = $element.find('.dx-list');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         assert.ok($list.is(':hidden'), 'when start list is hidden');
         pointerMock($input).start().click();
@@ -296,7 +292,7 @@ QUnit.module('functionality', moduleSetup, () => {
     QUnit.test('click on disabled selectbox doesn\'t toggle popup visibility', function(assert) {
         const $element = $('#selectBox').dxSelectBox({ items: [0, 1, 2], disabled: true });
         const $list = $element.find('.dx-dropdowneditor-overlay');
-        const $textBox = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $textBox = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         assert.ok($list.is(':hidden'), 'when start list is hidden');
 
@@ -307,7 +303,7 @@ QUnit.module('functionality', moduleSetup, () => {
     QUnit.test('click on disabled selectbox arrow doesn\'t toggle popup visibility', function(assert) {
         const $element = $('#selectBox').dxSelectBox({ items: [0, 1, 2], disabled: true });
         const $list = $element.find('.dx-dropdowneditor-overlay');
-        const $arrow = $element.find(toSelector(TEXTEDITOR_BUTTONS_CONTAINER_CLASS));
+        const $arrow = $element.find(`.${TEXTEDITOR_BUTTONS_CONTAINER_CLASS}`);
 
         assert.ok($list.is(':hidden'), 'when start list is hidden');
 
@@ -318,7 +314,7 @@ QUnit.module('functionality', moduleSetup, () => {
     QUnit.test('click on readOnly selectbox doesn\'t toggle popup visibility', function(assert) {
         const $element = $('#selectBox').dxSelectBox({ items: [0, 1, 2], readOnly: true });
         const $list = $element.find('.dx-dropdowneditor-overlay');
-        const $textBox = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $textBox = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         assert.ok($list.is(':hidden'), 'when start list is hidden');
 
@@ -329,7 +325,7 @@ QUnit.module('functionality', moduleSetup, () => {
     QUnit.test('click on readOnly selectbox arrow doesn\'t toggle popup visibility', function(assert) {
         const $element = $('#selectBox').dxSelectBox({ items: [0, 1, 2], readOnly: true });
         const $list = $element.find('.dx-dropdowneditor-overlay');
-        const $arrow = $element.find(toSelector(TEXTEDITOR_BUTTONS_CONTAINER_CLASS));
+        const $arrow = $element.find(`.${TEXTEDITOR_BUTTONS_CONTAINER_CLASS}`);
 
         assert.ok($list.is(':hidden'), 'when start list is hidden');
 
@@ -340,7 +336,7 @@ QUnit.module('functionality', moduleSetup, () => {
     QUnit.test('select box should not hide popup after focusout', function(assert) {
         const $element = $('#selectBox').dxSelectBox({ items: [0, 1, 2] });
         const $list = $element.find('.dx-list');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         assert.ok($list.is(':hidden'), 'when start list is hidden');
 
@@ -402,7 +398,7 @@ QUnit.module('functionality', moduleSetup, () => {
             value: 'longer than first'
         });
 
-        $($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS))).trigger('dxclick');
+        $($selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`)).trigger('dxclick');
         this.clock.tick(TIME_TO_WAIT);
 
         assert.equal($selectBox.dxSelectBox('option', 'opened'), true, 'selectbox is opened');
@@ -414,10 +410,10 @@ QUnit.module('functionality', moduleSetup, () => {
         }
 
         const $selectBox = $('#selectBox').dxSelectBox({});
-        const $dropDownButton = $selectBox.find(toSelector(DX_DROP_DOWN_BUTTON));
+        const $dropDownButton = $selectBox.find(`.${DX_DROP_DOWN_BUTTON}`);
 
         $($dropDownButton).trigger('dxclick');
-        assert.ok($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)).is(':focus'), 'input focused');
+        assert.ok($selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`).is(':focus'), 'input focused');
     });
 
     QUnit.test('dataSource loaded after create dxSelectBox', function(assert) {
@@ -441,7 +437,7 @@ QUnit.module('functionality', moduleSetup, () => {
         this.clock.tick(timeout);
 
         $selectBox.dxSelectBox('option', 'opened', true);
-        const listItems = $(toSelector(POPUP_CONTENT_CLASS) + ' ' + toSelector(LIST_ITEM_CLASS));
+        const listItems = $(`.${POPUP_CONTENT_CLASS} .${LIST_ITEM_CLASS}`);
 
         assert.equal(listItems.length, 0, 'items is not yet loaded');
     });
@@ -457,7 +453,7 @@ QUnit.module('functionality', moduleSetup, () => {
 
         assert.deepEqual(selectBox._list.option('items'), data);
 
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         keyboardMock($input)
             .focus()
@@ -481,7 +477,7 @@ QUnit.module('functionality', moduleSetup, () => {
                 searchEnabled: true
             }).dxSelectBox('instance');
 
-            const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+            const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
             const keyboard = keyboardMock($input);
 
             keyboard
@@ -512,10 +508,10 @@ QUnit.module('functionality', moduleSetup, () => {
         const selectBox = $('#selectBox').dxSelectBox('instance');
 
         this.clock.tick(TIME_TO_WAIT);
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         keyboardMock($input).press('down');
-        const $firstItemList = $(toSelector(LIST_ITEM_CLASS)).eq(0);
+        const $firstItemList = $(`.${LIST_ITEM_CLASS}`).eq(0);
         assert.equal(isRenderer(selectBox._list.option('focusedElement')), !!config().useJQuery, 'focusedElement is correct');
         assert.ok($firstItemList.hasClass(STATE_FOCUSED_CLASS), 'first list item obtained focus');
     });
@@ -528,7 +524,7 @@ QUnit.module('functionality', moduleSetup, () => {
 
         this.clock.tick(TIME_TO_WAIT);
 
-        const $listItems = $(toSelector(LIST_ITEM_CLASS));
+        const $listItems = $(`.${LIST_ITEM_CLASS}`);
 
         $($listItems.eq(0)).trigger('dxclick');
         this.clock.tick(TIME_TO_WAIT);
@@ -557,7 +553,7 @@ QUnit.module('functionality', moduleSetup, () => {
         selectBox.option('opened', true);
 
         const $popupContent = $(selectBox.content());
-        const $selectedItem = $popupContent.find(toSelector(LIST_ITEM_SELECTED_CLASS));
+        const $selectedItem = $popupContent.find(`.${LIST_ITEM_SELECTED_CLASS}`);
 
         assert.ok($popupContent.offset().top + $popupContent.height() > $selectedItem.offset().top, 'selected item is visible');
     });
@@ -575,7 +571,7 @@ QUnit.module('functionality', moduleSetup, () => {
         });
 
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         selectBox.option('opened', true);
         const $popupContent = $(selectBox.content());
 
@@ -583,10 +579,10 @@ QUnit.module('functionality', moduleSetup, () => {
             .focus()
             .type('50')
             .change();
-        $popupContent.find(toSelector(LIST_ITEM_CLASS)).eq(0).trigger('dxclick');
+        $popupContent.find(`.${LIST_ITEM_CLASS}`).eq(0).trigger('dxclick');
         selectBox.option('opened', true);
 
-        const $selectedItem = $popupContent.find(toSelector(LIST_ITEM_SELECTED_CLASS));
+        const $selectedItem = $popupContent.find(`.${LIST_ITEM_SELECTED_CLASS}`);
         assert.ok($popupContent.offset().top + $popupContent.height() > $selectedItem.offset().top, 'selected item is visible after search');
     });
 
@@ -620,7 +616,7 @@ QUnit.module('functionality', moduleSetup, () => {
 
             selectBox.open();
             this.clock.tick(TIME_TO_WAIT);
-            const list = $(selectBox.content()).find(toSelector(LIST_CLASS)).dxList('instance');
+            const list = $(selectBox.content()).find(`.${LIST_CLASS}`).dxList('instance');
 
             assert.strictEqual(list.option('selectedItem'), 1, 'list item is selected');
         });
@@ -647,7 +643,7 @@ QUnit.module('functionality', moduleSetup, () => {
         selectBox.option('opened', true);
 
         const $popupContent = $(selectBox.content());
-        const $firstItem = $popupContent.find(toSelector(LIST_ITEM_CLASS)).eq(0);
+        const $firstItem = $popupContent.find(`.${LIST_ITEM_CLASS}`).eq(0);
 
         assert.ok($popupContent.offset().top <= $firstItem.offset().top, 'first item is visible');
     });
@@ -674,7 +670,7 @@ QUnit.module('functionality', moduleSetup, () => {
         selectBox.option('opened', true);
 
         const $popupContent = $(selectBox.content());
-        const $selectedItem = $popupContent.find(toSelector(LIST_ITEM_CLASS)).eq(98);
+        const $selectedItem = $popupContent.find(`.${LIST_ITEM_CLASS}`).eq(98);
         const itemBottom = $selectedItem.offset().top + $selectedItem.outerHeight();
         const contentBottom = $popupContent.offset().top + $popupContent.outerHeight();
 
@@ -697,7 +693,7 @@ QUnit.module('functionality', moduleSetup, () => {
 
         this.clock.tick(10);
 
-        assert.equal($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)).val(), '', 'selected item');
+        assert.equal($selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`).val(), '', 'selected item');
         assert.strictEqual(selectBox.option('selectedItem'), null, 'selected item');
     });
 
@@ -722,7 +718,7 @@ QUnit.module('functionality', moduleSetup, () => {
             }
         });
 
-        assert.strictEqual($(toSelector(LIST_ITEM_CLASS)).length, 1, 'dropDown is shown in fullScreen mode');
+        assert.strictEqual($(`.${LIST_ITEM_CLASS}`).length, 1, 'dropDown is shown in fullScreen mode');
     });
 
     QUnit.test('selectBox should display value when item is 0 or boolean false', function(assert) {
@@ -740,19 +736,19 @@ QUnit.module('functionality', moduleSetup, () => {
                 }
             }
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         this.clock.tick(TIME_TO_WAIT);
 
-        $($selectBox.find(toSelector(LIST_ITEM_CLASS) + ':eq(1)')).trigger('dxclick');
+        $($selectBox.find(`.${LIST_ITEM_CLASS}:eq(1)`)).trigger('dxclick');
         assert.equal($input.val(), 'Zero', '0 value is shown correctly');
 
-        $($selectBox.find(toSelector(LIST_ITEM_CLASS) + ':eq(2)')).trigger('dxclick');
+        $($selectBox.find(`.${LIST_ITEM_CLASS}:eq(2)`)).trigger('dxclick');
         assert.equal($input.val(), 'True', 'True value is shown correctly');
 
-        $($selectBox.find(toSelector(LIST_ITEM_CLASS) + ':eq(3)')).trigger('dxclick');
+        $($selectBox.find(`.${LIST_ITEM_CLASS}:eq(3)`)).trigger('dxclick');
         assert.equal($input.val(), 'False', 'False value is shown correctly');
 
-        $($selectBox.find(toSelector(LIST_ITEM_CLASS) + ':eq(0)')).trigger('dxclick');
+        $($selectBox.find(`.${LIST_ITEM_CLASS}:eq(0)`)).trigger('dxclick');
         assert.equal($input.val(), 'None', 'Null value is shown correctly');
     });
 
@@ -778,7 +774,7 @@ QUnit.module('functionality', moduleSetup, () => {
             searchTimeout: 0
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard
@@ -804,7 +800,7 @@ QUnit.module('functionality', moduleSetup, () => {
             encodeNoDataText: true,
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard
@@ -824,7 +820,7 @@ QUnit.module('functionality', moduleSetup, () => {
             deferRendering: false
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.type('b');
@@ -842,7 +838,7 @@ QUnit.module('functionality', moduleSetup, () => {
 
         const loadSpy = sinon.spy(DataSource.prototype, 'load');
         try {
-            $($selectBox.find(toSelector(DX_DROP_DOWN_BUTTON))).trigger('dxclick');
+            $($selectBox.find(`.${DX_DROP_DOWN_BUTTON}`)).trigger('dxclick');
 
             assert.ok(!loadSpy.called, 'data source load was not fired on open');
         } finally {
@@ -884,7 +880,7 @@ QUnit.module('functionality', moduleSetup, () => {
             searchTimeout: 0
         });
         const instance = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.type('2');
@@ -918,7 +914,7 @@ QUnit.module('functionality', moduleSetup, () => {
             opened: true
         });
         const instance = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.type('4');
@@ -939,12 +935,12 @@ QUnit.module('functionality', moduleSetup, () => {
         }).dxSelectBox('instance');
         const $list = $(selectBox._list.$element());
 
-        assert.ok($list.find(toSelector(LIST_ITEM_CLASS)).eq(1).hasClass(STATE_FOCUSED_CLASS), 'the selected item is focused');
+        assert.ok($list.find(`.${LIST_ITEM_CLASS}`).eq(1).hasClass(STATE_FOCUSED_CLASS), 'the selected item is focused');
 
-        $($list.find(toSelector(LIST_ITEM_CLASS)).eq(0)).trigger('dxclick');
+        $($list.find(`.${LIST_ITEM_CLASS}`).eq(0)).trigger('dxclick');
         selectBox.open();
 
-        assert.ok($list.find(toSelector(LIST_ITEM_CLASS)).eq(0).hasClass(STATE_FOCUSED_CLASS), 'the selected item is focused after popup is opened second time');
+        assert.ok($list.find(`.${LIST_ITEM_CLASS}`).eq(0).hasClass(STATE_FOCUSED_CLASS), 'the selected item is focused after popup is opened second time');
     });
 
     QUnit.test('no items should be focused if input value is changed', function(assert) {
@@ -959,16 +955,16 @@ QUnit.module('functionality', moduleSetup, () => {
             searchTimeout: 0
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const $list = $(selectBox._list.$element());
 
         keyboardMock($input)
             .focus()
             .type('aa');
 
-        $($selectBox.find(toSelector(DX_DROP_DOWN_BUTTON))).trigger('dxclick');
+        $($selectBox.find(`.${DX_DROP_DOWN_BUTTON}`)).trigger('dxclick');
 
-        assert.equal($list.find(toSelector(STATE_FOCUSED_CLASS)).length, 0, 'no items are focused');
+        assert.equal($list.find(`.${STATE_FOCUSED_CLASS}`).length, 0, 'no items are focused');
     });
 });
 
@@ -1085,9 +1081,9 @@ QUnit.module('widget options', moduleSetup, () => {
         const instance = $element.dxSelectBox('instance');
 
         this.clock.tick(TIME_TO_WAIT);
-        assert.strictEqual($element.find(toSelector(LIST_ITEM_CLASS)).length, 2);
+        assert.strictEqual($element.find(`.${LIST_ITEM_CLASS}`).length, 2);
 
-        $($element.find(toSelector(LIST_ITEM_CLASS)).first()).trigger('dxclick');
+        $($element.find(`.${LIST_ITEM_CLASS}`).first()).trigger('dxclick');
         this.clock.tick(TIME_TO_WAIT);
 
         assert.equal(instance._input().val(), 'one');
@@ -1120,9 +1116,9 @@ QUnit.module('widget options', moduleSetup, () => {
         const instance = $element.dxSelectBox('instance');
 
         this.clock.tick(TIME_TO_WAIT);
-        assert.strictEqual($element.find(toSelector(LIST_ITEM_CLASS)).length, 2);
+        assert.strictEqual($element.find(`.${LIST_ITEM_CLASS}`).length, 2);
 
-        $($element.find(toSelector(LIST_ITEM_CLASS)).first()).trigger('dxclick');
+        $($element.find(`.${LIST_ITEM_CLASS}`).first()).trigger('dxclick');
         this.clock.tick(TIME_TO_WAIT);
 
         assert.equal(instance._input().val(), 'number 1');
@@ -1197,10 +1193,10 @@ QUnit.module('widget options', moduleSetup, () => {
             });
         const instance = $element.dxSelectBox('instance');
 
-        assert.equal($element.find(toSelector(PLACEHOLDER_CLASS)).attr('data-dx_placeholder'), 'John Doe');
+        assert.equal($element.find(`.${PLACEHOLDER_CLASS}`).attr('data-dx_placeholder'), 'John Doe');
 
         instance.option('placeholder', 'John Jr. Doe');
-        assert.equal($element.find(toSelector(PLACEHOLDER_CLASS)).attr('data-dx_placeholder'), 'John Jr. Doe');
+        assert.equal($element.find(`.${PLACEHOLDER_CLASS}`).attr('data-dx_placeholder'), 'John Jr. Doe');
     });
 
     QUnit.test('the "fieldTemplate" function should be called only once on init and value change', function(assert) {
@@ -1233,7 +1229,7 @@ QUnit.module('widget options', moduleSetup, () => {
             opened: true
         });
         const instance = $selectBox.dxSelectBox('instance');
-        const $dropDownButton = $selectBox.find(toSelector(DX_DROP_DOWN_BUTTON));
+        const $dropDownButton = $selectBox.find(`.${DX_DROP_DOWN_BUTTON}`);
         const $inputWrapper = $selectBox.find('.dx-dropdowneditor-input-wrapper');
 
         $dropDownButton.trigger('dxpointerdown');
@@ -1270,22 +1266,22 @@ QUnit.module('widget options', moduleSetup, () => {
             opened: true
         });
 
-        $(toSelector(LIST_ITEM_CLASS)).eq(0).trigger('dxclick');
+        $(`.${LIST_ITEM_CLASS}`).eq(0).trigger('dxclick');
 
-        const $input = $(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         assert.equal($input.val(), '1 - First', 'value is correct');
 
         $input.triggerHandler('focusout');
 
-        assert.equal($(toSelector(TEXTEDITOR_INPUT_CLASS)).val(), '1 - First', 'value is correct');
+        assert.equal($(`.${TEXTEDITOR_INPUT_CLASS}`).val(), '1 - First', 'value is correct');
 
         const instance = $element.dxSelectBox('instance');
         instance.option('opened', true);
 
-        $(toSelector(LIST_ITEM_CLASS)).eq(0).trigger('dxclick');
+        $(`.${LIST_ITEM_CLASS}`).eq(0).trigger('dxclick');
 
-        assert.equal($(toSelector(TEXTEDITOR_INPUT_CLASS)).val(), '1 - First', 'value is correct');
+        assert.equal($(`.${TEXTEDITOR_INPUT_CLASS}`).val(), '1 - First', 'value is correct');
 
     });
 
@@ -1306,9 +1302,9 @@ QUnit.module('widget options', moduleSetup, () => {
             opened: true
         });
 
-        $(toSelector(LIST_ITEM_CLASS)).eq(1).trigger('dxclick');
+        $(`.${LIST_ITEM_CLASS}`).eq(1).trigger('dxclick');
 
-        const $input = $(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         assert.equal($input.val(), 'Second', 'value is correct');
 
@@ -1316,7 +1312,7 @@ QUnit.module('widget options', moduleSetup, () => {
 
         instance.option('value', 'First');
 
-        assert.equal($(toSelector(TEXTEDITOR_INPUT_CLASS)).val(), 'First', 'value is correct');
+        assert.equal($(`.${TEXTEDITOR_INPUT_CLASS}`).val(), 'First', 'value is correct');
     });
 
     QUnit.test('dropdown button should not be hidden after the focusout when fieldTemplate and searchEnabled is used', function(assert) {
@@ -1332,12 +1328,12 @@ QUnit.module('widget options', moduleSetup, () => {
             },
             searchEnabled: true
         });
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         $input.focus();
         $input.triggerHandler('focusout');
 
-        assert.equal($element.find(toSelector(DX_DROP_DOWN_BUTTON)).length, 1, 'dropdown button was not hidden');
+        assert.equal($element.find(`.${DX_DROP_DOWN_BUTTON}`).length, 1, 'dropdown button was not hidden');
     });
 
     QUnit.test('item template', function(assert) {
@@ -1366,11 +1362,11 @@ QUnit.module('widget options', moduleSetup, () => {
 
         this.clock.tick(TIME_TO_WAIT);
 
-        $($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS))).trigger('dxclick');
+        $($selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`)).trigger('dxclick');
 
         this.clock.tick(TIME_TO_WAIT);
 
-        assert.equal($(toSelector(LIST_ITEM_CLASS)).first().text().trim(), '0', 'first item is loaded');
+        assert.equal($(`.${LIST_ITEM_CLASS}`).first().text().trim(), '0', 'first item is loaded');
     });
 
     QUnit.test('change displayCustomValue', function(assert) {
@@ -1384,7 +1380,7 @@ QUnit.module('widget options', moduleSetup, () => {
         $selectBox.dxSelectBox('option', 'value', 'test2');
         this.clock.tick(TIME_TO_WAIT);
 
-        assert.equal($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)).val(), 'test2', 'custom value displayed after value changed');
+        assert.equal($selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`).val(), 'test2', 'custom value displayed after value changed');
     });
 
     QUnit.test('displayCustomValue should not reset selected value on dataSource change', function(assert) {
@@ -1410,7 +1406,7 @@ QUnit.module('widget options', moduleSetup, () => {
 
         this.clock.tick(TIME_TO_WAIT);
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         assert.equal($input.val(), '', 'input value is reset');
     });
 
@@ -1425,7 +1421,7 @@ QUnit.module('widget options', moduleSetup, () => {
 
         this.clock.tick(TIME_TO_WAIT);
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         assert.equal($input.val(), '', 'input value is reset');
     });
 
@@ -1436,7 +1432,7 @@ QUnit.module('widget options', moduleSetup, () => {
             value: 1
         });
         const element = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         $input.trigger('focusin');
         $input.val('');
@@ -1454,7 +1450,7 @@ QUnit.module('widget options', moduleSetup, () => {
             searchTimeout: 0,
             opened: true
         });
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         this.clock.tick(TIME_TO_WAIT);
         keyboardMock($input)
@@ -1463,11 +1459,11 @@ QUnit.module('widget options', moduleSetup, () => {
             .change();
         this.clock.tick(TIME_TO_WAIT);
 
-        $(toSelector(OVERLAY_CONTENT_CLASS)).focus();
+        $(`.${OVERLAY_CONTENT_CLASS}`).focus();
         assert.notOk($input.is(':focus'), 'input is not focused');
         assert.strictEqual($input.val(), '1', 'input text has not been cleared');
 
-        const items = $(toSelector(LIST_ITEM_CLASS));
+        const items = $(`.${LIST_ITEM_CLASS}`);
         assert.strictEqual(items.length, 1, 'items are filtered');
     });
 
@@ -1489,7 +1485,7 @@ QUnit.module('widget options', moduleSetup, () => {
             value: 4
         });
         const element = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         $input.trigger('focusin');
         $input.trigger('blur');
@@ -1507,7 +1503,7 @@ QUnit.module('widget options', moduleSetup, () => {
             value: 1
         });
         const element = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         $input.focusin();
         $input.val('');
@@ -1525,7 +1521,7 @@ QUnit.module('widget options', moduleSetup, () => {
             value: 1
         });
         const element = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         element.option('allowClearing', false);
 
@@ -1598,12 +1594,12 @@ QUnit.module('clearButton', moduleSetup, () => {
         const selectBox = $element.dxSelectBox('instance');
 
         this.clock.tick(TIME_TO_WAIT);
-        pointerMock($element.find(toSelector(CLEAR_BUTTON_AREA))).click();
+        pointerMock($element.find(`.${CLEAR_BUTTON_AREA}`)).click();
         assert.equal(selectBox.option('opened'), false, 'selectbox is closed after click on clear button');
 
         selectBox.option('searchEnabled', true);
         selectBox.option('searchTimeout', 0);
-        pointerMock($element.find(toSelector(CLEAR_BUTTON_AREA))).click();
+        pointerMock($element.find(`.${CLEAR_BUTTON_AREA}`)).click();
         assert.equal(selectBox.option('opened'), false, 'selectbox is closed after click on clear button if searchEnabled = true');
     });
 
@@ -1616,8 +1612,8 @@ QUnit.module('clearButton', moduleSetup, () => {
             searchTimeout: 3000
         });
         const selectBox = $element.dxSelectBox('instance');
-        const $clearButton = $element.find(toSelector(CLEAR_BUTTON_AREA));
-        const $dropDownButton = $element.find(toSelector(DX_DROP_DOWN_BUTTON));
+        const $clearButton = $element.find(`.${CLEAR_BUTTON_AREA}`);
+        const $dropDownButton = $element.find(`.${DX_DROP_DOWN_BUTTON}`);
 
         pointerMock($clearButton).click();
         pointerMock($dropDownButton).click();
@@ -1633,7 +1629,7 @@ QUnit.module('clearButton', moduleSetup, () => {
             searchTimeout: 0
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
         const $list = $selectBox.find(`.${LIST_CLASS}`);
 
@@ -1641,7 +1637,7 @@ QUnit.module('clearButton', moduleSetup, () => {
 
         keyboard.type('1');
 
-        assert.strictEqual($list.find(toSelector(LIST_ITEM_CLASS)).length, 1, 'items are filtered');
+        assert.strictEqual($list.find(`.${LIST_ITEM_CLASS}`).length, 1, 'items are filtered');
     });
 
     QUnit.test('drop down list should be still opened if click "clear" during the search', function(assert) {
@@ -1653,13 +1649,13 @@ QUnit.module('clearButton', moduleSetup, () => {
             value: 1
         });
         const selectBox = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         keyboardMock($input)
             .focus()
             .type('50')
             .change();
-        pointerMock($element.find(toSelector(CLEAR_BUTTON_AREA))).click();
+        pointerMock($element.find(`.${CLEAR_BUTTON_AREA}`)).click();
 
         assert.ok(selectBox.option('opened'), 'selectbox is opened');
     });
@@ -1674,11 +1670,11 @@ QUnit.module('clearButton', moduleSetup, () => {
             searchEnabled: true
         });
 
-        const $clearButton = $selectBox.find(toSelector(CLEAR_BUTTON_AREA));
+        const $clearButton = $selectBox.find(`.${CLEAR_BUTTON_AREA}`);
 
         $($clearButton).trigger('dxclick');
 
-        assert.equal($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)).val(), '', 'text is cleared');
+        assert.equal($selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`).val(), '', 'text is cleared');
     });
 
     QUnit.test('selectedItem should be reset on "clear" button', function(assert) {
@@ -1695,11 +1691,11 @@ QUnit.module('clearButton', moduleSetup, () => {
 
         this.clock.tick(10);
 
-        pointerMock($selectBox.find(toSelector(CLEAR_BUTTON_AREA))).click();
+        pointerMock($selectBox.find(`.${CLEAR_BUTTON_AREA}`)).click();
 
         this.clock.tick(10);
 
-        assert.equal($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)).val(), '', 'text field is cleared');
+        assert.equal($selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`).val(), '', 'text field is cleared');
         assert.strictEqual(selectBox.option('value'), null, 'value is null');
         assert.strictEqual(selectBox.option('selectedItem'), null, 'selected item');
     });
@@ -1718,16 +1714,16 @@ QUnit.module('clearButton', moduleSetup, () => {
             opened: true
         }).dxSelectBox('instance');
 
-        const items = $(toSelector(LIST_ITEM_CLASS));
+        const items = $(`.${LIST_ITEM_CLASS}`);
         items.eq(1).trigger('dxclick');
 
-        const $clearButton = $(toSelector(CLEAR_BUTTON_AREA));
+        const $clearButton = $(`.${CLEAR_BUTTON_AREA}`);
         $($clearButton).trigger('dxclick');
 
         assert.equal(selectBox.option('value'), null, 'value is reset after click on "clear" button');
         assert.equal(selectBox.option('text'), '', 'text is reset after click on "clear" button');
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         assert.equal($input.val(), '', 'input is empty');
     });
@@ -1742,8 +1738,8 @@ QUnit.module('clearButton', moduleSetup, () => {
                 showClearButton: true
             });
 
-        $(toSelector(CLEAR_BUTTON_AREA)).trigger('dxclick');
-        const items = $(toSelector(LIST_ITEM_CLASS));
+        $(`.${CLEAR_BUTTON_AREA}`).trigger('dxclick');
+        const items = $(`.${LIST_ITEM_CLASS}`);
 
         assert.strictEqual(items.length, 0, 'items are re-filtered, and no item is shown because of minSearchLength=1');
     });
@@ -1787,7 +1783,7 @@ QUnit.module('showSelectionControls', moduleSetup, () => {
 
         this.clock.tick(TIME_TO_WAIT);
 
-        pointerMock($(toSelector(LIST_ITEM_CLASS)).eq(1))
+        pointerMock($(`.${LIST_ITEM_CLASS}`).eq(1))
             .start()
             .click();
 
@@ -1805,7 +1801,7 @@ QUnit.module('editing', moduleSetup, () => {
         const selectBox = $selectBox.dxSelectBox('instance');
         const $list = $selectBox.find('.dx-list');
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         assert.equal($input.prop('readonly'), false, 'input is readonly');
 
         selectBox.option('readOnly', true);
@@ -1825,7 +1821,7 @@ QUnit.module('editing', moduleSetup, () => {
         });
         const selectBox = $selectBox.dxSelectBox('instance');
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         assert.equal($input.prop('readonly'), false, 'input is readonly');
 
         selectBox.option('readOnly', true);
@@ -1839,7 +1835,7 @@ QUnit.module('editing', moduleSetup, () => {
             value: 'item1'
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         selectBox.option('readOnly', true);
         keyboardMock($input).keyDown('down');
@@ -1858,12 +1854,12 @@ QUnit.module('editing', moduleSetup, () => {
 
         this.clock.tick(TIME_TO_WAIT);
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         keyboardMock($input).type('it');
 
         this.clock.tick(TIME_TO_WAIT);
 
-        assert.equal($(toSelector(LIST_ITEM_CLASS)).length, 2, 'items is filtered');
+        assert.equal($(`.${LIST_ITEM_CLASS}`).length, 2, 'items is filtered');
         assert.equal($selectBox.dxSelectBox('option', 'value'), null, 'value was not set');
     });
 
@@ -1879,7 +1875,7 @@ QUnit.module('editing', moduleSetup, () => {
             }
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         keyboardMock($input).type('test');
 
         $selectBox.dxSelectBox('blur');
@@ -1898,10 +1894,10 @@ QUnit.module('editing', moduleSetup, () => {
             }
         });
 
-        const $listItem = $(toSelector(LIST_ITEM_CLASS)).eq(0).trigger('dxclick');
+        const $listItem = $(`.${LIST_ITEM_CLASS}`).eq(0).trigger('dxclick');
         $selectBox.dxSelectBox('instance')._list._setFocusedItem($listItem); // TODO: set focused item workaround, improve it if aware how better
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.type('test');
@@ -1918,7 +1914,7 @@ QUnit.module('editing', moduleSetup, () => {
             opened: true
         });
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         let keyboard = keyboardMock($input);
         let prevented = 0;
@@ -1939,7 +1935,7 @@ QUnit.module('editing', moduleSetup, () => {
         prevented = 0;
         instance.option('opened', false);
         instance.option('acceptCustomValue', true);
-        keyboard = keyboardMock($element.find(toSelector(TEXTEDITOR_INPUT_CLASS)));
+        keyboard = keyboardMock($element.find(`.${TEXTEDITOR_INPUT_CLASS}`));
         keyboard.keyDown('enter');
 
         assert.equal(prevented, 1, 'defaults prevented on enter key when acceptCustomValue is true');
@@ -1950,7 +1946,7 @@ QUnit.module('editing', moduleSetup, () => {
             items: ['item 1', 'item 2'],
             acceptCustomValue: true
         });
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         $input.val('custom');
         $(document).trigger('dxpointerdown');
@@ -1964,7 +1960,7 @@ QUnit.module('editing', moduleSetup, () => {
             value: 'item 1',
             acceptCustomValue: true
         });
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         $element.dxSelectBox('instance').option('opened', true);
@@ -1983,10 +1979,10 @@ QUnit.module('editing', moduleSetup, () => {
             searchEnabled: true,
             searchTimeout: 0
         });
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
         const instance = $element.dxSelectBox('instance');
-        const $ddButton = $element.find(toSelector(DX_DROP_DOWN_BUTTON));
+        const $ddButton = $element.find(`.${DX_DROP_DOWN_BUTTON}`);
 
         keyboard
             .caret({ start: 0, end: 2 })
@@ -1995,7 +1991,7 @@ QUnit.module('editing', moduleSetup, () => {
         $input.trigger('dxclick');
 
         assert.strictEqual($input.val(), 'em 1', 'value has not been restored');
-        assert.strictEqual($(instance.content()).find(toSelector(LIST_ITEM_CLASS)).length, 1, 'filter has not been reseted');
+        assert.strictEqual($(instance.content()).find(`.${LIST_ITEM_CLASS}`).length, 1, 'filter has not been reseted');
     });
 
     QUnit.test('selectBox should restore old value after esc if custom value is accepted', function(assert) {
@@ -2005,7 +2001,7 @@ QUnit.module('editing', moduleSetup, () => {
             acceptCustomValue: true,
             opened: true
         });
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.press('down');
@@ -2028,11 +2024,11 @@ QUnit.module('editing', moduleSetup, () => {
         });
         const instance = $selectBox.dxSelectBox('instance');
 
-        $($selectBox.find(toSelector(DX_DROP_DOWN_BUTTON))).trigger('dxclick');
+        $($selectBox.find(`.${DX_DROP_DOWN_BUTTON}`)).trigger('dxclick');
         assert.equal(dataSourceLoadedCount, 1, 'content ready fired when content is rendered');
 
         instance.close();
-        $($selectBox.find(toSelector(DX_DROP_DOWN_BUTTON))).trigger('dxclick');
+        $($selectBox.find(`.${DX_DROP_DOWN_BUTTON}`)).trigger('dxclick');
 
         assert.equal(dataSourceLoadedCount, 1, 'content ready not fired when reopen dropdown');
     });
@@ -2052,7 +2048,7 @@ QUnit.module('editing', moduleSetup, () => {
             }
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.type('test');
@@ -2088,7 +2084,7 @@ QUnit.module('editing', moduleSetup, () => {
             value: 1
         });
         const instance = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         instance.focus();
         $input.val('');
@@ -2114,7 +2110,7 @@ QUnit.module('editing', moduleSetup, () => {
             },
             value: 'Item 2'
         });
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         assert.equal(loadMock.callCount, 0, 'load should not be called on init if defer rendering is true');
         assert.equal(byKeyMock.callCount, 1, 'bykey should be called on init if value is specified');
@@ -2161,7 +2157,7 @@ QUnit.module('editing', moduleSetup, () => {
                 data.push(options.customItem);
             }
         });
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         $input.trigger('dxclick');
@@ -2188,12 +2184,12 @@ QUnit.module('editing', moduleSetup, () => {
 
         this.clock.tick(TIME_TO_WAIT);
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         keyboardMock($input).type('it').change();
 
         this.clock.tick(TIME_TO_WAIT);
 
-        assert.equal($(toSelector(LIST_ITEM_CLASS)).length, 3, 'items is filtered');
+        assert.equal($(`.${LIST_ITEM_CLASS}`).length, 3, 'items is filtered');
         assert.equal($selectBox.dxSelectBox('option', 'value'), 'it', 'value was set');
     });
 
@@ -2209,7 +2205,7 @@ QUnit.module('editing', moduleSetup, () => {
             }
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         $input.val('');
         keyboardMock($input).type('2').change();
@@ -2270,7 +2266,7 @@ QUnit.module('editing', moduleSetup, () => {
             opened: true,
             value: 1
         });
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         $input.focusout();
 
@@ -2303,7 +2299,7 @@ QUnit.module('editing', moduleSetup, () => {
             displayExpr: 'text'
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         keyboardMock($input).type('three');
 
@@ -2319,12 +2315,12 @@ QUnit.module('editing', moduleSetup, () => {
             items: [1, 2]
         });
 
-        const $dropDownButton = $selectBox.find(toSelector(DX_DROP_DOWN_BUTTON));
+        const $dropDownButton = $selectBox.find(`.${DX_DROP_DOWN_BUTTON}`);
         $dropDownButton.addClass('test');
 
-        $($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS))).trigger('blur');
+        $($selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`)).trigger('blur');
 
-        assert.ok($selectBox.find(toSelector(DX_DROP_DOWN_BUTTON)).hasClass('test'), 'button is not rendered again');
+        assert.ok($selectBox.find(`.${DX_DROP_DOWN_BUTTON}`).hasClass('test'), 'button is not rendered again');
     });
 
     QUnit.test('T316005 - mousedown on inputWrapper should not be prevented if openOnFieldClick is true', function(assert) {
@@ -2354,7 +2350,7 @@ QUnit.module('editing', moduleSetup, () => {
                 };
             }
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
         const customValue = 'Custom value';
         const logStub = sinon.stub(errors, 'log');
@@ -2381,7 +2377,7 @@ QUnit.module('editing', moduleSetup, () => {
             searchEnabled: true,
             onCustomItemCreating: onCustomItemCreating
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard
@@ -2401,7 +2397,7 @@ QUnit.module('editing', moduleSetup, () => {
             onCustomItemCreating: onCustomItemCreating,
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.type('t');
@@ -2425,7 +2421,7 @@ QUnit.module('editing', moduleSetup, () => {
                 e.customItem = null;
             }
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard
@@ -2447,7 +2443,7 @@ QUnit.module('editing', moduleSetup, () => {
                 };
             }
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
         const customValue = 'Custom value';
 
@@ -2465,7 +2461,7 @@ QUnit.module('editing', moduleSetup, () => {
             displayExpr: 'display',
             valueExpr: 'value'
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
         const customValue = 'Custom value';
         const onCustomItemCreating = (event) => {
@@ -2496,7 +2492,7 @@ QUnit.module('editing', moduleSetup, () => {
                 e.customItem = deferred.promise();
             }
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
         const customValue = 'Custom value';
 
@@ -2531,7 +2527,7 @@ QUnit.module('editing', moduleSetup, () => {
                 e.customItem = promise;
             }
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
         const customValue = 'Custom value';
 
@@ -2565,7 +2561,7 @@ QUnit.module('editing', moduleSetup, () => {
                 e.customItem = deferred.reject().promise();
             }
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
         const customValue = 'Custom value';
 
@@ -2591,19 +2587,19 @@ QUnit.module('editing', moduleSetup, () => {
             }
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.type('4');
         this.clock.tick(TIME_TO_WAIT);
-        assert.equal($(selectBox.content()).find(toSelector(LIST_ITEM_CLASS)).length, 0, 'filter is applied');
+        assert.equal($(selectBox.content()).find(`.${LIST_ITEM_CLASS}`).length, 0, 'filter is applied');
         keyboard.change();
 
         selectBox.option('opened', true);
 
         assert.equal($selectBox.dxSelectBox('option', 'value'), null, 'value is reset');
         assert.equal($input.val(), '', 'input value is reset after deferred is rejected');
-        assert.equal($(selectBox.content()).find(toSelector(LIST_ITEM_CLASS)).length, 3, 'filter was cleared');
+        assert.equal($(selectBox.content()).find(`.${LIST_ITEM_CLASS}`).length, 3, 'filter was cleared');
     });
 
     QUnit.test('filter should be cleared if all text was removed using backspace', function(assert) {
@@ -2613,12 +2609,12 @@ QUnit.module('editing', moduleSetup, () => {
             items: [1, 2, 3]
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.type('456');
         this.clock.tick(TIME_TO_WAIT);
-        assert.equal($(selectBox.content()).find(toSelector(LIST_ITEM_CLASS)).length, 0, 'filter is applied');
+        assert.equal($(selectBox.content()).find(`.${LIST_ITEM_CLASS}`).length, 0, 'filter is applied');
 
         $input.get(0).setSelectionRange(0, 3);
         keyboard.caret({ start: 0, end: 3 });
@@ -2626,7 +2622,7 @@ QUnit.module('editing', moduleSetup, () => {
         this.clock.tick(TIME_TO_WAIT);
 
         assert.equal($input.val(), '', 'value was cleared');
-        assert.equal($(selectBox.content()).find(toSelector(LIST_ITEM_CLASS)).length, 3, 'filter was cleared');
+        assert.equal($(selectBox.content()).find(`.${LIST_ITEM_CLASS}`).length, 3, 'filter was cleared');
     });
 
     QUnit.test('search timer should not be cleared when the widget is opening', function(assert) {
@@ -2638,18 +2634,18 @@ QUnit.module('editing', moduleSetup, () => {
             items: [1, 2, 3]
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
-        const $button = $selectBox.find(toSelector(DX_DROP_DOWN_BUTTON));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const $button = $selectBox.find(`.${DX_DROP_DOWN_BUTTON}`);
         const keyboard = keyboardMock($input);
 
         keyboard.type('4');
         this.clock.tick(100);
-        assert.equal($(selectBox.content()).find(toSelector(LIST_ITEM_CLASS)).length, 0, 'items are filtered');
+        assert.equal($(selectBox.content()).find(`.${LIST_ITEM_CLASS}`).length, 0, 'items are filtered');
 
         keyboard.press('backspace');
         $button.trigger('dxclick');
         this.clock.tick(TIME_TO_WAIT);
-        assert.equal($(selectBox.content()).find(toSelector(LIST_ITEM_CLASS)).length, 3, 'filter was cleared');
+        assert.equal($(selectBox.content()).find(`.${LIST_ITEM_CLASS}`).length, 3, 'filter was cleared');
     });
 
     QUnit.test('Custom value should be selected in the list', function(assert) {
@@ -2666,7 +2662,7 @@ QUnit.module('editing', moduleSetup, () => {
             searchEnabled: true
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const kb = keyboardMock($input);
 
         kb.type('Custom value').change();
@@ -2684,7 +2680,7 @@ QUnit.module('editing', moduleSetup, () => {
             items: items
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const customValue = 'Custom value';
 
         selectBox.option('onCustomItemCreating', (e) => {
@@ -2717,13 +2713,13 @@ QUnit.module('editing', moduleSetup, () => {
             items: items
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const kb = keyboardMock($input);
 
         kb.type('2');
         selectBox.open();
 
-        const $items = $(toSelector(LIST_ITEM_CLASS));
+        const $items = $(`.${LIST_ITEM_CLASS}`);
         $($items.eq(0)).trigger('dxclick');
 
         kb.change();
@@ -2737,7 +2733,7 @@ QUnit.module('editing', moduleSetup, () => {
             acceptCustomValue: true,
             onCustomItemCreating: noop
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.type('abc');
@@ -2757,7 +2753,7 @@ QUnit.module('editing', moduleSetup, () => {
             items: items,
             value: items[0]
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         $input.val('');
@@ -2979,7 +2975,7 @@ QUnit.module('search', moduleSetup, () => {
             opened: true
         });
 
-        const $items = $(toSelector(LIST_ITEM_CLASS));
+        const $items = $(`.${LIST_ITEM_CLASS}`);
 
         assert.equal($items.length, 0, 'items is not rendered');
     });
@@ -2994,7 +2990,7 @@ QUnit.module('search', moduleSetup, () => {
         });
 
         $selectBox.dxSelectBox('instance').option('showDataBeforeSearch', true);
-        const $items = $(toSelector(LIST_ITEM_CLASS));
+        const $items = $(`.${LIST_ITEM_CLASS}`);
 
         assert.ok($items.length, 'items is shown');
     });
@@ -3008,7 +3004,7 @@ QUnit.module('search', moduleSetup, () => {
             opened: true
         });
 
-        const $items = $(toSelector(LIST_ITEM_CLASS));
+        const $items = $(`.${LIST_ITEM_CLASS}`);
 
         assert.equal($items.length, 3, 'items is not rendered');
     });
@@ -3024,12 +3020,12 @@ QUnit.module('search', moduleSetup, () => {
             opened: true
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.type('o');
 
-        const $items = $(toSelector(LIST_ITEM_CLASS));
+        const $items = $(`.${LIST_ITEM_CLASS}`);
         assert.equal($items.length, 1, 'items was filtered');
     });
 
@@ -3044,12 +3040,12 @@ QUnit.module('search', moduleSetup, () => {
             opened: true
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.type('o');
 
-        const $items = $(toSelector(LIST_ITEM_CLASS));
+        const $items = $(`.${LIST_ITEM_CLASS}`);
         assert.equal($items.length, 1, 'items was filtered');
     });
 
@@ -3068,12 +3064,12 @@ QUnit.module('search', moduleSetup, () => {
             opened: true
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.type('o');
 
-        const $items = $(toSelector(LIST_ITEM_CLASS));
+        const $items = $(`.${LIST_ITEM_CLASS}`);
         assert.equal($items.length, 1, 'items was filtered');
     });
 
@@ -3088,7 +3084,7 @@ QUnit.module('search', moduleSetup, () => {
             opened: true
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
 
         keyboard
@@ -3096,7 +3092,7 @@ QUnit.module('search', moduleSetup, () => {
             .press('backspace')
             .press('backspace');
 
-        const $items = $(toSelector(LIST_ITEM_CLASS));
+        const $items = $(`.${LIST_ITEM_CLASS}`);
 
         assert.equal($items.length, 3, 'items are not filtered');
     });
@@ -3112,7 +3108,7 @@ QUnit.module('search', moduleSetup, () => {
             opened: true
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input, true);
 
         keyboard
@@ -3120,7 +3116,7 @@ QUnit.module('search', moduleSetup, () => {
             .press('backspace')
             .press('backspace');
 
-        const $items = $(toSelector(LIST_ITEM_CLASS));
+        const $items = $(`.${LIST_ITEM_CLASS}`);
 
         assert.equal($items.length, 3, 'list of items is full');
 
@@ -3136,27 +3132,27 @@ QUnit.module('search', moduleSetup, () => {
             opened: true
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
-        let items = $(toSelector(LIST_ITEM_CLASS));
+        let items = $(`.${LIST_ITEM_CLASS}`);
         assert.equal(items.length, 3, 'all items shown');
 
         keyboard
             .type('o');
 
-        items = $(toSelector(LIST_ITEM_CLASS));
+        items = $(`.${LIST_ITEM_CLASS}`);
         assert.equal(items.length, 3, 'all items shown');
 
         keyboard
             .type('n');
 
-        items = $(toSelector(LIST_ITEM_CLASS));
+        items = $(`.${LIST_ITEM_CLASS}`);
         assert.equal(items.length, 3, 'all items shown');
         keyboard
             .type('e');
 
-        items = $(toSelector(LIST_ITEM_CLASS));
+        items = $(`.${LIST_ITEM_CLASS}`);
         assert.equal(items.length, 1, 'one item shown');
     });
 
@@ -3171,7 +3167,7 @@ QUnit.module('search', moduleSetup, () => {
             opened: true
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.type('tw');
@@ -3207,7 +3203,7 @@ QUnit.module('search', moduleSetup, () => {
             searchTimeout: 0
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.type('item');
@@ -3224,7 +3220,7 @@ QUnit.module('search', moduleSetup, () => {
         });
 
         const instance = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         keyboardMock($input)
             .type('1')
@@ -3246,7 +3242,7 @@ QUnit.module('search', moduleSetup, () => {
         });
 
         const instance = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         keyboardMock($input)
             .type('1')
@@ -3269,7 +3265,7 @@ QUnit.module('search', moduleSetup, () => {
         });
 
         $selectBox
-            .find(toSelector(TEXTEDITOR_INPUT_CLASS))
+            .find(`.${TEXTEDITOR_INPUT_CLASS}`)
             .trigger('focusin')
             .trigger('focusout');
 
@@ -3309,14 +3305,14 @@ QUnit.module('search', moduleSetup, () => {
             }
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const keyboard = keyboardMock($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)));
+        const keyboard = keyboardMock($selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`));
 
         keyboard.type('a');
 
-        const listItem = $(selectBox.content()).find(toSelector(LIST_ITEM_CLASS)).eq(1);
+        const listItem = $(selectBox.content()).find(`.${LIST_ITEM_CLASS}`).eq(1);
         listItem.trigger('dxclick');
 
-        assert.equal($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)).val(), 'Name 2', 'selectBox displays right value');
+        assert.equal($selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`).val(), 'Name 2', 'selectBox displays right value');
     });
 
     [
@@ -3339,17 +3335,17 @@ QUnit.module('search', moduleSetup, () => {
                 validationRules: [ { type: 'required' } ]
             });
             const selectBox = $selectBox.dxSelectBox('instance');
-            let $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+            let $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
             assert.strictEqual($input.attr(attribute), value, `initial render should have ${attribute} attribute set to ${value}`);
 
             keyboardMock($input)
                 .type('a');
 
-            const listItem = $(selectBox.content()).find(toSelector(LIST_ITEM_CLASS)).eq(1);
+            const listItem = $(selectBox.content()).find(`.${LIST_ITEM_CLASS}`).eq(1);
             listItem.trigger('dxclick');
 
-            $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+            $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
             assert.strictEqual($input.attr(attribute), value, `${attribute} should stay ${value} after search and selection`);
         });
     });
@@ -3387,26 +3383,26 @@ QUnit.module('search', moduleSetup, () => {
                 this.clock.tick(TIME_TO_WAIT);
 
                 const selectBox = $selectBox.dxSelectBox('instance');
-                let $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+                let $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
                 assert.strictEqual($input.attr('aria-invalid'), nonEmptyValue, `initial render should set aria-invalid to ${nonEmptyValue}`);
 
-                const listItem = $(selectBox.content()).find(toSelector(LIST_ITEM_CLASS)).eq(0);
+                const listItem = $(selectBox.content()).find(`.${LIST_ITEM_CLASS}`).eq(0);
                 listItem.trigger('dxclick');
 
                 this.clock.tick(TIME_TO_WAIT);
 
                 assert.equal($input.val(), '1', 'input value is not empty');
-                $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+                $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
                 assert.strictEqual($input.attr('aria-invalid'), nonEmptyValue, `non empty input value set aria-invalid to ${nonEmptyValue}`);
 
-                const $clearButton = $(toSelector(CLEAR_BUTTON_AREA));
+                const $clearButton = $(`.${CLEAR_BUTTON_AREA}`);
                 $($clearButton).trigger('dxclick');
 
                 this.clock.tick(TIME_TO_WAIT);
 
                 assert.equal($input.val(), '', 'input value is empty');
-                $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+                $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
                 assert.strictEqual($input.attr('aria-invalid'), emptyValue, `empty input value set aria-invalid to ${emptyValue}`);
             });
         });
@@ -3437,26 +3433,26 @@ QUnit.module('search', moduleSetup, () => {
             this.clock.tick(TIME_TO_WAIT);
 
             const selectBox = $selectBox.dxSelectBox('instance');
-            let $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+            let $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
             assert.strictEqual($input.attr('aria-invalid'), undefined, 'initial render should set aria-invalid to undefined');
 
-            const listItem = $(selectBox.content()).find(toSelector(LIST_ITEM_CLASS)).eq(0);
+            const listItem = $(selectBox.content()).find(`.${LIST_ITEM_CLASS}`).eq(0);
             listItem.trigger('dxclick');
 
             this.clock.tick(TIME_TO_WAIT);
 
             assert.equal($input.val(), '1', 'input value is not empty');
-            $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+            $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
             assert.strictEqual($input.attr('aria-invalid'), undefined, 'initial render should set aria-invalid to undefined');
 
-            const $clearButton = $(toSelector(CLEAR_BUTTON_AREA));
+            const $clearButton = $(`.${CLEAR_BUTTON_AREA}`);
             $($clearButton).trigger('dxclick');
 
             this.clock.tick(TIME_TO_WAIT);
 
             assert.equal($input.val(), '', 'input value is empty');
-            $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+            $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
             assert.strictEqual($input.attr('aria-invalid'), undefined, 'initial render should set aria-invalid to undefined');
         });
     });
@@ -3470,7 +3466,7 @@ QUnit.module('search', moduleSetup, () => {
             searchEnabled: true,
             searchTimeout: 0,
         });
-        let $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        let $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         assert.strictEqual($input.attr('role'), 'combobox', 'initial render should have role attribute set to combobox');
 
@@ -3479,10 +3475,10 @@ QUnit.module('search', moduleSetup, () => {
 
         keyboard.type('a');
 
-        const listItem = $(selectBox.content()).find(toSelector(LIST_ITEM_CLASS)).eq(1);
+        const listItem = $(selectBox.content()).find(`.${LIST_ITEM_CLASS}`).eq(1);
         listItem.trigger('dxclick');
 
-        $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         assert.strictEqual($input.attr('role'), 'combobox', 'role should stay to combobox after search and selection');
     });
@@ -3503,8 +3499,8 @@ QUnit.module('search', moduleSetup, () => {
                 searchTimeout: 0,
                 ...options
             });
-            let $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
-            const $label = $selectBox.find(toSelector(TEXTEDITOR_LABEL_CLASS));
+            let $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+            const $label = $selectBox.find(`.${TEXTEDITOR_LABEL_CLASS}`);
 
             const expectedAriaLabeledByValue = !options.inputAttr && options.label ? $label.attr('id') : undefined;
 
@@ -3515,10 +3511,10 @@ QUnit.module('search', moduleSetup, () => {
 
             keyboard.type('a');
 
-            const listItem = $(selectBox.content()).find(toSelector(LIST_ITEM_CLASS)).eq(1);
+            const listItem = $(selectBox.content()).find(`.${LIST_ITEM_CLASS}`).eq(1);
             listItem.trigger('dxclick');
 
-            $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+            $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
             assert.strictEqual($input.attr('aria-labelledby'), expectedAriaLabeledByValue, 'aria-labelledby attribute value after search and selection');
         });
@@ -3534,7 +3530,7 @@ QUnit.module('search', moduleSetup, () => {
                 searchTimeout: 0
             });
             const selectBox = $selectBox.dxSelectBox('instance');
-            const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+            const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
             const keyboard = keyboardMock($input);
 
             $input.focus();
@@ -3584,7 +3580,7 @@ QUnit.module('search', moduleSetup, () => {
             allowClearing: true,
             searchEnabled: true
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         $input.focus();
         $input.focusout();
@@ -3607,7 +3603,7 @@ QUnit.module('search', moduleSetup, () => {
             onValueChanged: valueChangedHandler
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         $input.focus();
@@ -3639,7 +3635,7 @@ QUnit.module('search', moduleSetup, () => {
         });
         const selectBox = $selectBox.dxSelectBox('instance');
 
-        keyboardMock($selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS)), true)
+        keyboardMock($selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`), true)
             .caret({
                 start: 0,
                 end: item.length
@@ -3658,12 +3654,12 @@ QUnit.module('search', moduleSetup, () => {
             value: item,
             searchTimeout: 0
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const selectBox = $selectBox.dxSelectBox('instance');
         const keyboard = keyboardMock($input);
 
         keyboard.focus();
-        $($selectBox.find(toSelector(DX_DROP_DOWN_BUTTON))).trigger('dxclick');
+        $($selectBox.find(`.${DX_DROP_DOWN_BUTTON}`)).trigger('dxclick');
 
         keyboard
             .press('tab')
@@ -3690,7 +3686,7 @@ QUnit.module('search', moduleSetup, () => {
             searchTimeout: 0
         });
         const instance = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         keyboardMock($input)
             .focus()
@@ -3702,7 +3698,7 @@ QUnit.module('search', moduleSetup, () => {
         $($input).trigger('dxclick');
 
         const $emptyMessage = $(`.${EMPTY_MESSAGE_CLASS}`);
-        const $items = $(toSelector(LIST_ITEM_CLASS));
+        const $items = $(`.${LIST_ITEM_CLASS}`);
 
         assert.equal(loadSpy.callCount, 0, 'the was no load');
         assert.ok(instance.option('opened'), 'selectBox is opened');
@@ -3717,7 +3713,7 @@ QUnit.module('search', moduleSetup, () => {
             minSearchLength: 2,
             searchTimeout: 0
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         keyboardMock($input)
             .focus()
@@ -3726,7 +3722,7 @@ QUnit.module('search', moduleSetup, () => {
         $input.trigger('dxclick');
         $input.trigger('dxclick');
 
-        const $items = $(toSelector(LIST_ITEM_CLASS));
+        const $items = $(`.${LIST_ITEM_CLASS}`);
         assert.strictEqual($items.length, 1, 'filtered item is shown');
     });
 
@@ -3742,8 +3738,8 @@ QUnit.module('search', moduleSetup, () => {
             searchEnabled: true
         });
         const instance = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
-        const $dropDownButton = $selectBox.find(toSelector(DX_DROP_DOWN_BUTTON));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const $dropDownButton = $selectBox.find(`.${DX_DROP_DOWN_BUTTON}`);
 
         keyboardMock($input)
             .focus()
@@ -3870,7 +3866,7 @@ QUnit.module('search substitution', {
 
         this.selectBox = this.$selectBox.dxSelectBox('instance');
         this._init = () => {
-            this.$input = this.$selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+            this.$input = this.$selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
             this.keyboard = keyboardMock(this.$input, true);
 
             const inputElement = this.$input.get(0);
@@ -3906,9 +3902,9 @@ QUnit.module('search substitution', {
                 searchTimeout: 100
             });
 
-            const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+            const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
             const kb = keyboardMock($input, true);
-            const $dropDownButton = $selectBox.find(toSelector(DX_DROP_DOWN_BUTTON));
+            const $dropDownButton = $selectBox.find(`.${DX_DROP_DOWN_BUTTON}`);
 
             kb.type('2');
             this.clock.tick(60);
@@ -4149,16 +4145,16 @@ QUnit.module('search substitution', {
             }
         });
 
-        const listItem = $('.dx-list').find(toSelector(LIST_ITEM_CLASS)).eq(1);
+        const listItem = $('.dx-list').find(`.${LIST_ITEM_CLASS}`).eq(1);
 
         listItem.trigger('dxpointerdown');
         this.clock.tick(10);
-        let $input = this.$selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        let $input = this.$selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         assert.equal($input.val(), '', 'input value should not be changed when selection is not complete');
 
         listItem.trigger('dxclick');
-        $input = this.$selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        $input = this.$selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         assert.equal($input.val(), '2', 'input value should be changed after selection complete');
         this.clock.tick(100000);
@@ -4179,14 +4175,14 @@ QUnit.module('search substitution', {
 
         const $list = $(this.selectBox._list.$element());
 
-        assert.ok($list.find(toSelector(LIST_ITEM_CLASS)).eq(2).hasClass(STATE_FOCUSED_CLASS), 'the focused element is correct after popup is opened');
+        assert.ok($list.find(`.${LIST_ITEM_CLASS}`).eq(2).hasClass(STATE_FOCUSED_CLASS), 'the focused element is correct after popup is opened');
 
         this.keyboard
             .focus()
             .press('end')
             .press('backspace');
 
-        assert.ok($list.find(toSelector(LIST_ITEM_CLASS)).eq(0).hasClass(STATE_FOCUSED_CLASS), 'the focused element is correct after the first searching');
+        assert.ok($list.find(`.${LIST_ITEM_CLASS}`).eq(0).hasClass(STATE_FOCUSED_CLASS), 'the focused element is correct after the first searching');
     });
 
     QUnit.test('There is no substitution if the "acceptCustomValue" option is true', function(assert) {
@@ -4212,7 +4208,7 @@ QUnit.module('search substitution', {
 
         const $list = $(this.selectBox._list.$element());
 
-        assert.equal($list.find(toSelector(STATE_FOCUSED_CLASS)).length, 0, 'no items are focused');
+        assert.equal($list.find(`.${STATE_FOCUSED_CLASS}`).length, 0, 'no items are focused');
     });
 });
 
@@ -4286,7 +4282,7 @@ QUnit.module('Async tests', {}, () => {
             searchTimeout: 0
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         $input.focus();
@@ -4373,7 +4369,7 @@ QUnit.module('Async tests', {}, () => {
 
         clock.tick(50);
 
-        const $selectedItems = $list.find(toSelector(LIST_ITEM_SELECTED_CLASS));
+        const $selectedItems = $list.find(`.${LIST_ITEM_SELECTED_CLASS}`);
 
         assert.strictEqual($selectedItems.length, 0, 'no items are selected');
         clock.restore();
@@ -4450,7 +4446,7 @@ QUnit.module('regressions', moduleSetup, () => {
         assert.expect(0);
 
         const $element = $('#selectBox').dxSelectBox({ items: [0, 1, 2], value: 0 });
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         $input.click();
         $($input).trigger('keyup', { key: KEY_DOWN });
@@ -4461,19 +4457,19 @@ QUnit.module('regressions', moduleSetup, () => {
 
         const $element = $('#selectBox').dxSelectBox({ dataSource: [0, 1, 2], value: 0 });
         const $list = $element.find('.dx-list');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         $input.click();
         this.clock.tick(TIME_TO_WAIT);
 
-        assert.equal($list.find(toSelector(LIST_ITEM_CLASS)).length, 3, 'all items rendered');
+        assert.equal($list.find(`.${LIST_ITEM_CLASS}`).length, 3, 'all items rendered');
     });
 
     QUnit.test('incorrect list items count after press key_down', function(assert) {
         assert.expect(1);
 
         const $element = $('#selectBox').dxSelectBox({ dataSource: [0, 1, 2], value: 0 });
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const $list = $element.find('.dx-list');
 
         $input.click();
@@ -4482,7 +4478,7 @@ QUnit.module('regressions', moduleSetup, () => {
         $($input).trigger('keyup', { key: KEY_DOWN });
         this.clock.tick(TIME_TO_WAIT);
 
-        assert.strictEqual($list.find(toSelector(LIST_ITEM_CLASS)).length, 3);
+        assert.strictEqual($list.find(`.${LIST_ITEM_CLASS}`).length, 3);
     });
 
     QUnit.test('B251138 disabled', function(assert) {
@@ -4515,11 +4511,11 @@ QUnit.module('regressions', moduleSetup, () => {
 
         $(instance._input()).trigger('dxclick');
         this.clock.tick(TIME_TO_WAIT);
-        $($element.find(toSelector(LIST_ITEM_CLASS)).eq(1)).trigger('dxclick');
+        $($element.find(`.${LIST_ITEM_CLASS}`).eq(1)).trigger('dxclick');
 
         $(instance._input()).click();
         this.clock.tick(TIME_TO_WAIT);
-        $($element.find(toSelector(LIST_ITEM_CLASS)).eq(0)).trigger('dxclick');
+        $($element.find(`.${LIST_ITEM_CLASS}`).eq(0)).trigger('dxclick');
 
         assert.equal(instance._input().val(), 'item1', 'item was found in items by reference');
     });
@@ -4568,7 +4564,7 @@ QUnit.module('regressions', moduleSetup, () => {
         this.clock.tick(10);
 
         const selectBox = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         selectBox.open();
         keyboardMock($input)
@@ -4597,7 +4593,7 @@ QUnit.module('regressions', moduleSetup, () => {
         this.clock.tick(10);
 
         const selectBox = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         selectBox.open();
         keyboardMock($input)
@@ -4627,7 +4623,7 @@ QUnit.module('regressions', moduleSetup, () => {
         this.clock.tick(10);
 
         const selectBox = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         selectBox.open();
         keyboardMock($input)
@@ -4657,7 +4653,7 @@ QUnit.module('regressions', moduleSetup, () => {
         this.clock.tick(10);
 
         const selectBox = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         selectBox.open();
         keyboardMock($input)
@@ -4712,7 +4708,7 @@ QUnit.module('regressions', moduleSetup, () => {
         const instance = $element.dxSelectBox('instance');
 
         $element
-            .find(toSelector(TEXTEDITOR_INPUT_CLASS))
+            .find(`.${TEXTEDITOR_INPUT_CLASS}`)
             .trigger('dxclick')
             .trigger('keyup');
 
@@ -4742,13 +4738,13 @@ QUnit.module('regressions', moduleSetup, () => {
         assert.equal(valueChanged, 1, 'when change value via option(optionName, value) - option value changed');
 
         $element
-            .find(toSelector(TEXTEDITOR_INPUT_CLASS))
+            .find(`.${TEXTEDITOR_INPUT_CLASS}`)
             .trigger('keyup');
 
         assert.equal(valueChanged, 1, 'after keypress "optionChanged" didn\'t changed');
 
         $element
-            .find(toSelector(TEXTEDITOR_INPUT_CLASS))
+            .find(`.${TEXTEDITOR_INPUT_CLASS}`)
             .trigger('change');
         assert.equal(valueChanged, 1, 'after change value didn\'t changed');
 
@@ -4774,7 +4770,7 @@ QUnit.module('hide on blur', moduleSetup, () => {
         });
         const selectBox = $selectBox.dxSelectBox('instance');
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         pointerMock($input).start().click();
         const $popupContent = $(selectBox.content());
         assert.equal($popupContent.is(':visible'), true, 'popup visible after click');
@@ -4815,7 +4811,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             deferRendering: true
         });
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         assert.strictEqual(instance.option('value'), 1);
@@ -4857,7 +4853,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             deferRendering: true
         });
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         instance.option('dataSource', [4, 5, 6]);
@@ -4881,7 +4877,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             opened: false,
             deferRendering: true
         });
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const instance = $element.dxSelectBox('instance');
         const keyboard = keyboardMock($input);
 
@@ -4903,7 +4899,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             opened: false
         });
 
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const instance = $element.dxSelectBox('instance');
         const keyboard = keyboardMock($input);
 
@@ -4912,9 +4908,9 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             keyboard.press('down');
         }
 
-        const $list = $(instance.content()).find(toSelector(LIST_CLASS));
+        const $list = $(instance.content()).find(`.${LIST_CLASS}`);
 
-        assert.equal($list.find(toSelector(LIST_ITEM_CLASS)).text(), '123', 'downArrow works correct');
+        assert.equal($list.find(`.${LIST_ITEM_CLASS}`).text(), '123', 'downArrow works correct');
     });
 
     [144, 145].forEach((testHeight) => {
@@ -4938,9 +4934,9 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
                     container: testContainer
                 }
             });
-            const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+            const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
             const instance = $element.dxSelectBox('instance');
-            const $dropDownButton = $element.find(toSelector(DX_DROP_DOWN_BUTTON));
+            const $dropDownButton = $element.find(`.${DX_DROP_DOWN_BUTTON}`);
             const keyboard = keyboardMock($input);
 
             $dropDownButton.trigger('dxclick');
@@ -4973,11 +4969,11 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             }
         });
 
-        let $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        let $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.press('down');
-        $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         assert.equal($input.val(), 'item 2', 'navigation is correct');
     });
 
@@ -4994,7 +4990,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             displayExpr: 'text'
         });
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.keyDown('down');
@@ -5015,7 +5011,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             acceptCustomValue: true
         });
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         let prevented = 0;
@@ -5042,7 +5038,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             focusStateEnabled: true,
             opened: false
         });
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         let prevented = 0;
@@ -5067,7 +5063,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             deferRendering: true,
             opened: false
         });
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.keyDown('esc');
@@ -5083,7 +5079,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             opened: false
         });
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.keyDown('up');
@@ -5101,7 +5097,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             showClearButton: true
         });
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.keyDown('backspace');
@@ -5127,7 +5123,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
         });
 
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.keyDown('backspace');
@@ -5147,7 +5143,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
         });
 
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.keyDown('backspace');
@@ -5194,7 +5190,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             displayExpr: 'value'
         });
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.keyDown('down');
@@ -5235,7 +5231,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             value: 0
         });
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         this.clock.tick(0);
@@ -5277,7 +5273,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             valueExpr: 'id'
         });
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.keyDown('down');
@@ -5304,7 +5300,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             focusStateEnabled: true
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         const altDownEvent = $.Event('keydown', { key: KEY_DOWN, altKey: true });
@@ -5331,7 +5327,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             focusStateEnabled: true
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         $input.val('');
@@ -5350,10 +5346,10 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
         });
 
         const scrollView = $('.dx-scrollview').dxScrollView('instance');
-        scrollView.scrollToElement($(toSelector(LIST_ITEM_CLASS)).last());
-        $(toSelector(LIST_ITEM_CLASS)).last().trigger('dxclick');
+        scrollView.scrollToElement($(`.${LIST_ITEM_CLASS}`).last());
+        $(`.${LIST_ITEM_CLASS}`).last().trigger('dxclick');
 
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         keyboardMock($input)
             .keyDown('down');
@@ -5370,7 +5366,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             value: '9'
         });
 
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         ds.beginLoading();
         keyboardMock($input)
             .keyDown('down');
@@ -5391,7 +5387,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             searchEnabled: true
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         keyboardMock($input)
             .focus()
@@ -5415,7 +5411,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             value: items[0]
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.focus();
@@ -5439,7 +5435,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             searchTimeout: 0
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         keyboardMock($input)
             .focus()
@@ -5463,7 +5459,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             opened: true,
             value: items[0]
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         $input.get(0).focus();
@@ -5485,8 +5481,8 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             opened: true,
             value: items[0]
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
-        const $dropDownButton = $selectBox.find(toSelector(DX_DROP_DOWN_BUTTON));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
+        const $dropDownButton = $selectBox.find(`.${DX_DROP_DOWN_BUTTON}`);
         const keyboard = keyboardMock($input);
 
         keyboard.keyDown(KEY_DOWN);
@@ -5506,7 +5502,7 @@ QUnit.module('keyboard navigation', moduleSetup, () => {
             deferRendering: true,
             onKeyboardHandled: handler
         });
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.keyDown('esc');
@@ -5523,7 +5519,7 @@ QUnit.module('keyboard navigation "TAB" button', moduleSetup, () => {
             items: items,
             value: value
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const instance = $selectBox.dxSelectBox('instance');
         const keyboard = keyboardMock($input);
 
@@ -5542,7 +5538,7 @@ QUnit.module('keyboard navigation "TAB" button', moduleSetup, () => {
             dataSource: ['1', '2', '3']
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.keyDown('tab');
@@ -5558,7 +5554,7 @@ QUnit.module('keyboard navigation "TAB" button', moduleSetup, () => {
             value: null
         });
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         $input.focus();
         instance.option('opened', true);
@@ -5580,7 +5576,7 @@ QUnit.module('keyboard navigation "TAB" button', moduleSetup, () => {
         });
 
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         $input.focus();
 
@@ -5606,7 +5602,7 @@ QUnit.module('keyboard navigation "TAB" button', moduleSetup, () => {
         });
 
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         $input.focus();
 
@@ -5628,7 +5624,7 @@ QUnit.module('keyboard navigation "TAB" button', moduleSetup, () => {
         });
 
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         keyboardMock($input)
             .keyDown('tab');
@@ -5646,7 +5642,7 @@ QUnit.module('keyboard navigation "TAB" button', moduleSetup, () => {
         });
 
         const instance = $element.dxSelectBox('instance');
-        const $input = $element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         $input.focus();
 
@@ -5667,7 +5663,7 @@ QUnit.module('keyboard navigation "TAB" button', moduleSetup, () => {
             searchTimeout: 0
         });
 
-        const keyboard = keyboardMock($element.find(toSelector(TEXTEDITOR_INPUT_CLASS)), true)
+        const keyboard = keyboardMock($element.find(`.${TEXTEDITOR_INPUT_CLASS}`), true)
             .focus()
             .type(items[0][0])
             .press('tab');
@@ -5690,7 +5686,7 @@ QUnit.module('keyboard navigation "TAB" button', moduleSetup, () => {
         const instance = $element.dxSelectBox('instance');
         const $applyButton = instance._popup.$wrapper().find('.dx-popup-done.dx-button');
 
-        keyboardMock($element.find(toSelector(TEXTEDITOR_INPUT_CLASS)), true)
+        keyboardMock($element.find(`.${TEXTEDITOR_INPUT_CLASS}`), true)
             .focus()
             .keyDown('tab');
 
@@ -5733,7 +5729,7 @@ QUnit.module('acceptCustomValue mode', moduleSetup, () => {
         const $selectBox = $('#selectBox').dxSelectBox({
             acceptCustomValue: true
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         keyboardMock($input).type('test');
         assert.equal($input.val(), 'test', 'value typed in input');
@@ -5743,7 +5739,7 @@ QUnit.module('acceptCustomValue mode', moduleSetup, () => {
         const $selectBox = $('#selectBox').dxSelectBox({
             acceptCustomValue: true
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         keyboardMock($input).type('test').change();
         assert.equal($selectBox.dxSelectBox('option', 'value'), 'test', 'value typed in input');
@@ -5757,7 +5753,7 @@ QUnit.module('acceptCustomValue mode', moduleSetup, () => {
             dataSource: ['a', 'b', 'c', 'ab', 'bb', 'ac'],
             displayExpr: 'this'
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         keyboardMock($input).type('a');
 
@@ -5772,7 +5768,7 @@ QUnit.module('acceptCustomValue mode', moduleSetup, () => {
             acceptCustomValue: true,
             dataSource: ['1', '2', '3']
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard
@@ -5788,7 +5784,7 @@ QUnit.module('acceptCustomValue mode', moduleSetup, () => {
             searchEnabled: true,
             acceptCustomValue: true,
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
         const instance = $selectBox.dxSelectBox('instance');
 
@@ -5807,7 +5803,7 @@ QUnit.module('acceptCustomValue mode', moduleSetup, () => {
             opened: true,
             onCustomItemCreating: onCustomItemCreating
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard
@@ -5824,7 +5820,7 @@ QUnit.module('acceptCustomValue mode', moduleSetup, () => {
             value: initialCustomValue
         });
         const selectBox = $selectBox.dxSelectBox('instance');
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
         $input
             .focus()
@@ -5851,7 +5847,7 @@ QUnit.module('acceptCustomValue mode', moduleSetup, () => {
             },
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard
@@ -5871,7 +5867,7 @@ QUnit.module('acceptCustomValue mode', moduleSetup, () => {
             opened: false,
             onCustomItemCreating: onCustomItemCreating
         });
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard
@@ -5888,7 +5884,7 @@ QUnit.module('acceptCustomValue mode', moduleSetup, () => {
             searchTimeout: 0
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         keyboardMock($input).type('a');
 
         $($input).trigger('dxclick');
@@ -5905,9 +5901,9 @@ QUnit.module('acceptCustomValue mode', moduleSetup, () => {
             opened: true
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
 
-        let $item = $(toSelector(LIST_ITEM_CLASS)).eq(1);
+        let $item = $(`.${LIST_ITEM_CLASS}`).eq(1);
         $($item).trigger('dxclick');
         assert.equal($input.val(), 'b', 'item was chosen');
 
@@ -5917,7 +5913,7 @@ QUnit.module('acceptCustomValue mode', moduleSetup, () => {
 
         assert.equal($input.val(), '', 'input value is clear');
 
-        $item = $(toSelector(LIST_ITEM_CLASS)).eq(1);
+        $item = $(`.${LIST_ITEM_CLASS}`).eq(1);
         $($item).trigger('dxclick');
         assert.equal($input.val(), 'b', 'item should be choose after click on list item');
     });
@@ -5932,7 +5928,7 @@ QUnit.module('acceptCustomValue mode', moduleSetup, () => {
                 e.customItem = '';
             }
         }).dxSelectBox('instance');
-        const $input = instance.$element().find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = instance.$element().find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
         const filterDataSourceStub = sinon.stub(instance, '_filterDataSource');
 
@@ -6003,7 +5999,7 @@ QUnit.module('focus policy', {
             items: [1, 2, 3]
         });
         this.instance = this.$element.dxSelectBox('instance');
-        this.$input = this.$element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        this.$input = this.$element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         this.keyboard = keyboardMock(this.$input);
     },
     afterEach: function() {
@@ -6018,23 +6014,23 @@ QUnit.module('focus policy', {
             items: ['a', 'b', 'c']
         });
 
-        const $input = this.$element.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = this.$element.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const kb = keyboardMock($input);
 
         kb.type('a').press('esc');
         $($input).trigger($.Event('keydown', { key: KEY_DOWN, altKey: true }));
         this.clock.tick(TIME_TO_WAIT);
-        assert.equal($(toSelector(LIST_ITEM_CLASS)).text().trim(), 'a', 'filter should not be cleared before focusout');
+        assert.equal($(`.${LIST_ITEM_CLASS}`).text().trim(), 'a', 'filter should not be cleared before focusout');
 
         this.instance.blur();
         this.instance.option('opened', false);
         $($input).trigger($.Event('keydown', { key: KEY_DOWN, altKey: true }));
         this.clock.tick(TIME_TO_WAIT);
-        assert.equal($(toSelector(LIST_ITEM_CLASS)).text().trim(), 'abc', 'no filtering');
+        assert.equal($(`.${LIST_ITEM_CLASS}`).text().trim(), 'abc', 'no filtering');
     });
 
     QUnit.test('input keep focus when popup is opened by click on button', function(assert) {
-        const $arrow = this.$element.find(toSelector(TEXTEDITOR_BUTTONS_CONTAINER_CLASS));
+        const $arrow = this.$element.find(`.${TEXTEDITOR_BUTTONS_CONTAINER_CLASS}`);
 
         this.instance.focus();
         assert.ok(this.$element.hasClass(STATE_FOCUSED_CLASS), 'element is focused');
@@ -6079,7 +6075,7 @@ QUnit.module('focus policy', {
         keyboardMock($input).type('b');
 
         this.clock.tick(TIME_TO_WAIT);
-        const $item = $(toSelector(LIST_ITEM_CLASS)).eq(1);
+        const $item = $(`.${LIST_ITEM_CLASS}`).eq(1);
 
         // assert
         assert.ok($item.hasClass(STATE_FOCUSED_CLASS), 'first non disabled item is focused');
@@ -6173,7 +6169,7 @@ QUnit.module('focus policy', {
             }
         });
 
-        const $input = $selectBox.find(toSelector(TEXTEDITOR_INPUT_CLASS));
+        const $input = $selectBox.find(`.${TEXTEDITOR_INPUT_CLASS}`);
         const keyboard = keyboardMock($input);
 
         keyboard.type(customValue);

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/trackBar.markup.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/trackBar.markup.tests.js
@@ -9,10 +9,6 @@ QUnit.testStart(function() {
     $('#qunit-fixture').html(markup);
 });
 
-function toSelector(text) {
-    return '.' + text;
-}
-
 const TRACKBAR_CLASS = 'dx-trackbar';
 const TRACKBAR_CONTAINER_CLASS = 'dx-trackbar-container';
 const TRACKBAR_RANGE_CLASS = 'dx-trackbar-range';
@@ -29,9 +25,9 @@ QUnit.module('TrackBar markup', {
         const $trackBar = this.$element.dxTrackBar();
 
         assert.ok($trackBar.hasClass(TRACKBAR_CLASS), 'dxTrackBar initialized');
-        assert.equal($trackBar.find(toSelector(TRACKBAR_CONTAINER_CLASS)).length, 1, 'Container has been created');
-        assert.equal($trackBar.find(toSelector(TRACKBAR_RANGE_CLASS)).length, 1, 'Range has been created');
-        assert.equal($trackBar.find(toSelector(TRACKBAR_WRAPPER_CLASS)).length, 1, 'Wrapper div has been created');
+        assert.equal($trackBar.find(`.${TRACKBAR_CONTAINER_CLASS}`).length, 1, 'Container has been created');
+        assert.equal($trackBar.find(`.${TRACKBAR_RANGE_CLASS}`).length, 1, 'Range has been created');
+        assert.equal($trackBar.find(`.${TRACKBAR_WRAPPER_CLASS}`).length, 1, 'Wrapper div has been created');
     });
 });
 

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/trackBar.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/trackBar.tests.js
@@ -14,10 +14,6 @@ QUnit.testStart(function() {
     $('#qunit-fixture').html(markup);
 });
 
-function toSelector(text) {
-    return '.' + text;
-}
-
 const TRACKBAR_RANGE_CLASS = 'dx-trackbar-range';
 
 QUnit.module('options', {
@@ -93,7 +89,7 @@ QUnit.module('options', {
             max: 100
         }).css('width', 100);
         const trackBar = $trackBar.dxTrackBar('instance');
-        const $range = $trackBar.find(toSelector(TRACKBAR_RANGE_CLASS));
+        const $range = $trackBar.find(`.${TRACKBAR_RANGE_CLASS}`);
 
         assert.equal($range.width(), trackBar.option('value'), 'range width is right');
 
@@ -110,7 +106,7 @@ QUnit.module('options', {
             max: 100
         }).css('width', 100);
         const trackBar = $trackBar.dxTrackBar('instance');
-        const $range = $trackBar.find(toSelector(TRACKBAR_RANGE_CLASS));
+        const $range = $trackBar.find(`.${TRACKBAR_RANGE_CLASS}`);
 
         assert.equal($range.width(), 25, 'range width is right');
 

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets/overlay.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets/overlay.tests.js
@@ -130,9 +130,7 @@ const IS_SAFARI = !!browser.safari;
 const VIEWPORT_CLASS = 'dx-viewport';
 const PREVENT_SAFARI_SCROLLING_CLASS = 'dx-prevent-safari-scrolling';
 
-const viewport = function() { return $(toSelector(VIEWPORT_CLASS)); };
-
-const toSelector = (cssClass) => `.${cssClass}`;
+const viewport = function() { return $(`.${VIEWPORT_CLASS}`); };
 
 const moduleConfig = {
     beforeEach: function() {
@@ -169,10 +167,10 @@ testModule('render', moduleConfig, () => {
         const $element = $('#overlay').dxOverlay();
         const instance = $element.dxOverlay('instance');
 
-        assert.ok($(toSelector(OVERLAY_CONTENT_CLASS)).length);
+        assert.ok($(`.${OVERLAY_CONTENT_CLASS}`).length);
 
         instance.dispose();
-        assert.ok(!$(toSelector(OVERLAY_CONTENT_CLASS)).length);
+        assert.ok(!$(`.${OVERLAY_CONTENT_CLASS}`).length);
     });
 
     test('overlay should use default template when element with data-options has not dxTemplate params (B253554)', function(assert) {
@@ -198,7 +196,7 @@ testModule('render', moduleConfig, () => {
 
                 onContentReady: function() {
                     resizeCallbacks.fire();
-                    getWidth($(toSelector(OVERLAY_CONTENT_CLASS)));
+                    getWidth($(`.${OVERLAY_CONTENT_CLASS}`));
                     resizeCallbacks.fire();
                 }
             }).remove();
@@ -271,7 +269,7 @@ testModule('render', moduleConfig, () => {
         const $content = instance.$content();
 
         assert.ok(!$content.is(':visible'));
-        assert.ok(!viewport().children(toSelector(OVERLAY_SHADER_CLASS)).is(':visible'));
+        assert.ok(!viewport().children(`.${OVERLAY_SHADER_CLASS}`).is(':visible'));
         assert.ok(getWidth($content) < getWidth($(window)));
         assert.ok(getHeight($content) < getHeight($(window)));
     });
@@ -1121,7 +1119,7 @@ testModule('position', moduleConfig, () => {
             position: { my: 'left top', at: 'center', of: viewport() }
         });
 
-        const position = viewport().find(toSelector(OVERLAY_CONTENT_CLASS)).position();
+        const position = viewport().find(`.${OVERLAY_CONTENT_CLASS}`).position();
 
         assert.notEqual(position.left, 0);
         assert.notEqual(position.top, 0);
@@ -1133,7 +1131,7 @@ testModule('position', moduleConfig, () => {
             visualContainer: viewPort()
         });
 
-        const $overlayWrapper = viewport().find(toSelector(OVERLAY_WRAPPER_CLASS));
+        const $overlayWrapper = viewport().find(`.${OVERLAY_WRAPPER_CLASS}`);
         assert.strictEqual($overlayWrapper.css('position'), 'absolute');
     });
 
@@ -1143,7 +1141,7 @@ testModule('position', moduleConfig, () => {
             shading: false
         });
 
-        const $overlayWrapper = viewport().find(toSelector(OVERLAY_WRAPPER_CLASS));
+        const $overlayWrapper = viewport().find(`.${OVERLAY_WRAPPER_CLASS}`);
         const wrapperStyle = getComputedStyle($overlayWrapper.get(0));
 
         assert.strictEqual(parseInt(wrapperStyle.width), getWidth($(window)), 'width is 100%');
@@ -2145,7 +2143,7 @@ testModule('hide on outside click', moduleConfig, () => {
 
         overlay1.show();
         overlay2.option('hideOnOutsideClick', function(e) {
-            return !e.target.closest(toSelector(OVERLAY_CONTENT_CLASS));
+            return !e.target.closest(`.${OVERLAY_CONTENT_CLASS}`);
         });
         $(overlay1.$content()).trigger('dxpointerdown');
 
@@ -2610,7 +2608,7 @@ testModule('container', moduleConfig, () => {
         beforeEach: function() {
             this.$container = $('#customTargetContainer');
             this.isContentInContainer = () => {
-                return this.$container.children(toSelector(OVERLAY_WRAPPER_CLASS)).length === 1;
+                return this.$container.children(`.${OVERLAY_WRAPPER_CLASS}`).length === 1;
             };
         }
     }, () => {
@@ -2654,8 +2652,8 @@ testModule('container', moduleConfig, () => {
         const overlay = $('#overlay').dxOverlay().dxOverlay('instance');
         overlay.show();
 
-        assert.strictEqual($(toSelector(VIEWPORT_CLASS)).children(toSelector(OVERLAY_WRAPPER_CLASS)).length, 1);
-        assert.strictEqual($('#parentContainer').children(toSelector(OVERLAY_WRAPPER_CLASS)).length, 0);
+        assert.strictEqual($(`.${VIEWPORT_CLASS}`).children(`.${OVERLAY_WRAPPER_CLASS}`).length, 1);
+        assert.strictEqual($('#parentContainer').children(`.${OVERLAY_WRAPPER_CLASS}`).length, 0);
     });
 
     test('content should be moved back to overlay element on hide (B253278)', function(assert) {
@@ -2703,7 +2701,7 @@ testModule('container', moduleConfig, () => {
 
         $overlay.dxOverlay('show');
 
-        const $shader = $container.find(toSelector(OVERLAY_SHADER_CLASS));
+        const $shader = $container.find(`.${OVERLAY_SHADER_CLASS}`);
 
         assert.ok(Math.abs(Math.round($shader.offset().top) - Math.round($container.offset().top)) <= 1, 'shader top position is correct');
         assert.strictEqual(getWidth($shader), getWidth($container), 'shader width is correct');
@@ -2729,7 +2727,7 @@ testModule('container', moduleConfig, () => {
                 },
             });
 
-            const $overlayWrapper = viewport().find(toSelector(OVERLAY_WRAPPER_CLASS));
+            const $overlayWrapper = viewport().find(`.${OVERLAY_WRAPPER_CLASS}`);
             const wrapperRect = $overlayWrapper.get(0).getBoundingClientRect();
             const targetRect = $targetContainer.get(0).getBoundingClientRect();
 
@@ -2761,7 +2759,7 @@ testModule('container', moduleConfig, () => {
 
         $overlay.dxOverlay('show');
 
-        const $content = $container.find(toSelector(OVERLAY_CONTENT_CLASS));
+        const $content = $container.find(`.${OVERLAY_CONTENT_CLASS}`);
         assert.strictEqual(getHeight($content), getHeight($container) * 0.5, 'overlay height is correct');
         assert.strictEqual(getWidth($content), getWidth($container) * 0.5, 'overlay width is correct');
     });
@@ -2777,7 +2775,7 @@ testModule('container', moduleConfig, () => {
 
             const $viewport = $('<div>');
             viewPort($viewport);
-            assert.strictEqual($viewport.children(toSelector(OVERLAY_WRAPPER_CLASS)).length, 1, 'overlay moved to new viewport');
+            assert.strictEqual($viewport.children(`.${OVERLAY_WRAPPER_CLASS}`).length, 1, 'overlay moved to new viewport');
         } finally {
             viewPort(origViewport);
         }
@@ -2796,7 +2794,7 @@ testModule('container', moduleConfig, () => {
             overlay.$element().parent().hide();
 
             viewPort($origViewport); // Need to trigger viewport change callback but not change viewport value
-            assert.strictEqual($origViewport.children(toSelector(OVERLAY_WRAPPER_CLASS)).length, 0, 'overlay not rendered because parent is hidden');
+            assert.strictEqual($origViewport.children(`.${OVERLAY_WRAPPER_CLASS}`).length, 0, 'overlay not rendered because parent is hidden');
         } finally {
             viewPort($origViewport);
         }
@@ -2813,7 +2811,7 @@ testModule('container', moduleConfig, () => {
 
             const $viewport = $('<div>');
             viewPort($viewport);
-            assert.strictEqual($viewport.children(toSelector(OVERLAY_WRAPPER_CLASS)).length, 0, 'overlay not moved to new viewport');
+            assert.strictEqual($viewport.children(`.${OVERLAY_WRAPPER_CLASS}`).length, 0, 'overlay not moved to new viewport');
         } finally {
             viewPort(origViewport);
         }
@@ -2830,7 +2828,7 @@ testModule('container', moduleConfig, () => {
 
         const overlay = new TestOverlay($('#overlay'));
         overlay.show();
-        assert.strictEqual($('#customTargetContainer').children(toSelector(OVERLAY_WRAPPER_CLASS)).length, 1);
+        assert.strictEqual($('#customTargetContainer').children(`.${OVERLAY_WRAPPER_CLASS}`).length, 1);
     });
 });
 
@@ -3372,7 +3370,7 @@ testModule('focus policy', {
             contentTemplate: $('#focusableTemplate')
         });
         const $content = overlay.$content();
-        const $wrapper = $content.closest(toSelector(OVERLAY_WRAPPER_CLASS));
+        const $wrapper = $content.closest(`.${OVERLAY_WRAPPER_CLASS}`);
 
         const contentFocusHandler = sinon.spy();
         const $tabbableDiv = $('<div>')
@@ -3622,7 +3620,7 @@ testModule('scrollable interaction', {
         $overlay.dxOverlay('option', 'visible', true);
 
         const $content = $overlay.dxOverlay('$content');
-        const $shader = $content.closest(toSelector(OVERLAY_SHADER_CLASS));
+        const $shader = $content.closest(`.${OVERLAY_SHADER_CLASS}`);
 
         $($shader.parent()).on('dxdrag.TEST', {
             getDirection: function() { return 'both'; },
@@ -3643,7 +3641,7 @@ testModule('scrollable interaction', {
         });
 
         const $content = $overlay.dxOverlay('$content');
-        const $shader = $content.closest(toSelector(OVERLAY_SHADER_CLASS));
+        const $shader = $content.closest(`.${OVERLAY_SHADER_CLASS}`);
 
         $($shader).on('dxdrag', {
             getDirection: function() { return 'both'; },
@@ -3716,7 +3714,7 @@ testModule('scrollable interaction', {
             inertiaEnabled: false
         });
 
-        const $overlayWrapper = $content.closest(toSelector(OVERLAY_WRAPPER_CLASS));
+        const $overlayWrapper = $content.closest(`.${OVERLAY_WRAPPER_CLASS}`);
 
         $($overlayWrapper).on('dxdrag.TEST', {
             getDirection: function() { return 'both'; },
@@ -3759,7 +3757,7 @@ testModule('scrollable interaction', {
             inertiaEnabled: false
         });
 
-        const $overlayWrapper = $content.closest(toSelector(OVERLAY_WRAPPER_CLASS));
+        const $overlayWrapper = $content.closest(`.${OVERLAY_WRAPPER_CLASS}`);
 
         $($overlayWrapper).on('dxdrag', {
             getDirection: () => 'both',
@@ -3795,7 +3793,7 @@ testModule('scrollable interaction', {
         });
 
         const $content = $overlay.dxOverlay('$content');
-        const $shader = $content.closest(toSelector(OVERLAY_SHADER_CLASS));
+        const $shader = $content.closest(`.${OVERLAY_SHADER_CLASS}`);
 
         $($shader).on({
             'dxdragstart': function() {
@@ -3820,7 +3818,7 @@ testModule('scrollable interaction', {
         });
 
         const $content = $overlay.dxOverlay('$content');
-        const $shader = $content.closest(toSelector(OVERLAY_SHADER_CLASS));
+        const $shader = $content.closest(`.${OVERLAY_SHADER_CLASS}`);
 
         const e = pointerMock($shader)
             .start()
@@ -3846,7 +3844,7 @@ testModule('scrollable interaction', {
             $('#qunit-fixture').on('wheel', handler);
 
             const $content = $overlay.dxOverlay('$content');
-            const $shader = $content.closest(toSelector(OVERLAY_SHADER_CLASS));
+            const $shader = $content.closest(`.${OVERLAY_SHADER_CLASS}`);
 
             nativePointerMock($shader)
                 .start()

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets/popover.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets/popover.tests.js
@@ -28,12 +28,8 @@ const positionAtWindowCenter = function(element) {
     });
 };
 
-const toSelector = function(cssClass) {
-    return '.' + cssClass;
-};
-
 const wrapper = function() {
-    return $('body').find(toSelector(POPOVER_WRAPPER_CLASS));
+    return $('body').find(`.${POPOVER_WRAPPER_CLASS}`);
 };
 
 const getArrow = function() {
@@ -546,7 +542,7 @@ QUnit.module('arrow positioning', () => {
                 height: 50,
                 visible: true
             });
-            const $arrow = $(toSelector(POPOVER_ARROW_CLASS));
+            const $arrow = $(`.${POPOVER_ARROW_CLASS}`);
             const $content = $(`.${POPUP_CONTENT_CLASS}`);
 
             const positions = [

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets/popup.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets/popup.tests.js
@@ -141,10 +141,7 @@ const POPUP_DRAGGABLE_CLASS = 'dx-popup-draggable';
 
 const VIEWPORT_CLASS = 'dx-viewport';
 
-const viewport = function() { return $(toSelector(VIEWPORT_CLASS)); };
-
-const toSelector = (cssClass) => `.${cssClass}`;
-
+const viewport = function() { return $(`.${VIEWPORT_CLASS}`); };
 
 QUnit.module('basic', () => {
     QUnit.test('markup init', function(assert) {
@@ -2228,7 +2225,7 @@ QUnit.module('drag', {
             assert.strictEqual(position.top + startEvent.maxBottomOffset, viewHeight - getOuterHeight(this.$overlayContent), 'popup should not be dragged below than target');
         } finally {
             viewPort().removeAttr('style');
-            viewPort(toSelector(VIEWPORT_CLASS));
+            viewPort(`.${VIEWPORT_CLASS}`);
         }
     });
 
@@ -2350,7 +2347,7 @@ QUnit.module('resize', {
                 .dxPopup($.extend({}, initialOptions, options))
                 .dxPopup('instance');
             this.$overlayContent = this.popup.$content().parent();
-            this.$handle = this.$overlayContent.find(toSelector(POPUP_BOTTOM_RIGHT_RESIZE_HANDLE_CLASS));
+            this.$handle = this.$overlayContent.find(`.${POPUP_BOTTOM_RIGHT_RESIZE_HANDLE_CLASS}`);
         };
         this.reinit = (options) => {
             this.popup && this.popup.dispose();
@@ -2480,7 +2477,7 @@ QUnit.module('resize', {
 
             assert.ok(isWindow(resizable.option('area').get(0)), 'window is the area of the resizable');
         } finally {
-            viewPort(toSelector(VIEWPORT_CLASS));
+            viewPort(`.${VIEWPORT_CLASS}`);
         }
     });
 

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets/progressBar.markup.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets/progressBar.markup.tests.js
@@ -11,10 +11,6 @@ QUnit.testStart(function() {
     $('#qunit-fixture').html(markup);
 });
 
-function toSelector(text) {
-    return '.' + text;
-}
-
 const PROGRESSBAR_CLASS = 'dx-progressbar';
 const PROGRESSBAR_CONTAINER_CLASS = 'dx-progressbar-container';
 const PROGRESSBAR_RANGE_CLASS = 'dx-progressbar-range';
@@ -34,10 +30,10 @@ QUnit.module('ProgressBar markup', {
         const $progressBar = this.$element.dxProgressBar();
 
         assert.ok($progressBar.hasClass(PROGRESSBAR_CLASS), 'ProgressBar initialized');
-        assert.equal($progressBar.find(toSelector(PROGRESSBAR_CONTAINER_CLASS)).length, 1, 'Container has been created');
-        assert.equal($progressBar.find(toSelector(PROGRESSBAR_RANGE_CLASS)).length, 1, 'Range has been created');
-        assert.equal($progressBar.find(toSelector(PROGRESSBAR_WRAPPER_CLASS)).length, 1, 'Wrapper div has been created');
-        assert.equal($progressBar.find(toSelector(PROGRESSBAR_STATUS_CLASS)).length, 1, 'Status div has been created');
+        assert.equal($progressBar.find(`.${PROGRESSBAR_CONTAINER_CLASS}`).length, 1, 'Container has been created');
+        assert.equal($progressBar.find(`.${PROGRESSBAR_RANGE_CLASS}`).length, 1, 'Range has been created');
+        assert.equal($progressBar.find(`.${PROGRESSBAR_WRAPPER_CLASS}`).length, 1, 'Wrapper div has been created');
+        assert.equal($progressBar.find(`.${PROGRESSBAR_STATUS_CLASS}`).length, 1, 'Status div has been created');
     });
 
     QUnit.test('showStatus test', function(assert) {
@@ -48,10 +44,10 @@ QUnit.module('ProgressBar markup', {
         });
         const progressBar = $progressBar.dxProgressBar('instance');
 
-        assert.equal($progressBar.find(toSelector(PROGRESSBAR_STATUS_CLASS)).length, 0, 'Status div hasn\'t been created');
+        assert.equal($progressBar.find(`.${PROGRESSBAR_STATUS_CLASS}`).length, 0, 'Status div hasn\'t been created');
 
         progressBar.option('showStatus', true);
-        assert.equal($progressBar.find(toSelector(PROGRESSBAR_STATUS_CLASS)).length, 1, 'Status div has been added');
+        assert.equal($progressBar.find(`.${PROGRESSBAR_STATUS_CLASS}`).length, 1, 'Status div has been added');
     });
 
     QUnit.test('value display in status', function(assert) {
@@ -59,7 +55,7 @@ QUnit.module('ProgressBar markup', {
             value: 10
         });
         const progressBar = $progressBar.dxProgressBar('instance');
-        const $status = $progressBar.find(toSelector(PROGRESSBAR_STATUS_CLASS));
+        const $status = $progressBar.find(`.${PROGRESSBAR_STATUS_CLASS}`);
 
         assert.equal($status.text(), 'Progress: ' + progressBar.option('value') + '%', 'status text is right');
     });
@@ -72,7 +68,7 @@ QUnit.module('ProgressBar markup', {
             }
         });
         const progressBar = $progressBar.dxProgressBar('instance');
-        const $status = $progressBar.find(toSelector(PROGRESSBAR_STATUS_CLASS));
+        const $status = $progressBar.find(`.${PROGRESSBAR_STATUS_CLASS}`);
         assert.equal($status.text(), 'Customised value: ' + progressBar.option('value'), 'status text is right');
     });
 
@@ -105,10 +101,10 @@ QUnit.module('ProgressBar markup', {
         });
         const progressBar = $progressBar.dxProgressBar('instance');
 
-        const renderedIndeterminateSegmentsCount = $progressBar.find(toSelector(PROGRESSBAR_INDETERMINATE_SEGMENT)).length;
+        const renderedIndeterminateSegmentsCount = $progressBar.find(`.${PROGRESSBAR_INDETERMINATE_SEGMENT}`).length;
         const defaultSegmentCount = progressBar.option('_animatingSegmentCount');
 
-        assert.equal($progressBar.find(toSelector(PROGRESSBAR_INDETERMINATE_SEGMENT_CONTAINER)).length, 1, 'Segment wrapper has been created');
+        assert.equal($progressBar.find(`.${PROGRESSBAR_INDETERMINATE_SEGMENT_CONTAINER}`).length, 1, 'Segment wrapper has been created');
         assert.equal(renderedIndeterminateSegmentsCount, defaultSegmentCount, 'Segments have been created');
     });
 
@@ -119,7 +115,7 @@ QUnit.module('ProgressBar markup', {
         });
         const progressBar = $progressBar.dxProgressBar('instance');
 
-        const renderedIndeterminateSegmentsCount = $progressBar.find(toSelector(PROGRESSBAR_INDETERMINATE_SEGMENT)).length;
+        const renderedIndeterminateSegmentsCount = $progressBar.find(`.${PROGRESSBAR_INDETERMINATE_SEGMENT}`).length;
         const defaultSegmentCount = progressBar.option('_animatingSegmentCount');
 
         assert.equal(renderedIndeterminateSegmentsCount, defaultSegmentCount, 'dxProgressBar have been created with correct segment count');

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets/progressBar.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets/progressBar.tests.js
@@ -18,10 +18,6 @@ QUnit.testStart(function() {
     $('#qunit-fixture').html(markup);
 });
 
-function toSelector(text) {
-    return '.' + text;
-}
-
 const PROGRESSBAR_CLASS = 'dx-progressbar';
 const PROGRESSBAR_CONTAINER_CLASS = 'dx-progressbar-container';
 const PROGRESSBAR_STATUS_CLASS = 'dx-progressbar-status';
@@ -58,7 +54,7 @@ QUnit.module('options', {
             value: 10
         });
         const progressBar = $progressBar.dxProgressBar('instance');
-        const $status = $progressBar.find(toSelector(PROGRESSBAR_STATUS_CLASS));
+        const $status = $progressBar.find(`.${PROGRESSBAR_STATUS_CLASS}`);
 
         progressBar.option('value', 30);
         assert.equal($status.text(), 'Progress: ' + progressBar.option('value') + '%', 'status text has been change right');
@@ -74,7 +70,7 @@ QUnit.module('options', {
             }
         });
         const progressBar = $progressBar.dxProgressBar('instance');
-        const $status = $progressBar.find(toSelector(PROGRESSBAR_STATUS_CLASS));
+        const $status = $progressBar.find(`.${PROGRESSBAR_STATUS_CLASS}`);
         assert.equal($status.text(), 'Customised value: ' + progressBar.option('value'), 'status text is right');
 
         progressBar.option('value', 50);
@@ -182,8 +178,8 @@ QUnit.module('states', {
         });
         const progressBar = $progressBar.dxProgressBar('instance');
 
-        const renderedIndeterminateSegmentContainersCount = $progressBar.find(toSelector(PROGRESSBAR_INDETERMINATE_SEGMENT_CONTAINER)).length;
-        let renderedIndeterminateSegmentsCount = $progressBar.find(toSelector(PROGRESSBAR_INDETERMINATE_SEGMENT)).length;
+        const renderedIndeterminateSegmentContainersCount = $progressBar.find(`.${PROGRESSBAR_INDETERMINATE_SEGMENT_CONTAINER}`).length;
+        let renderedIndeterminateSegmentsCount = $progressBar.find(`.${PROGRESSBAR_INDETERMINATE_SEGMENT}`).length;
         const defaultSegmentCount = progressBar.option('_animatingSegmentCount');
 
         assert.equal(renderedIndeterminateSegmentContainersCount, 0, 'Segment wrapper has not been created');
@@ -191,12 +187,12 @@ QUnit.module('states', {
 
         progressBar.option('value', null);
 
-        assert.equal($progressBar.find(toSelector(PROGRESSBAR_INDETERMINATE_SEGMENT_CONTAINER)).length, 1, 'Segment wrapper has been created');
+        assert.equal($progressBar.find(`.${PROGRESSBAR_INDETERMINATE_SEGMENT_CONTAINER}`).length, 1, 'Segment wrapper has been created');
 
-        renderedIndeterminateSegmentsCount = $progressBar.find(toSelector(PROGRESSBAR_INDETERMINATE_SEGMENT)).length;
+        renderedIndeterminateSegmentsCount = $progressBar.find(`.${PROGRESSBAR_INDETERMINATE_SEGMENT}`).length;
         assert.equal(renderedIndeterminateSegmentsCount, defaultSegmentCount, 'Segments have been created');
 
-        assert.equal($progressBar.find(toSelector(PROGRESSBAR_CONTAINER_CLASS)).is(':visible'), false, 'progressbar container does not attached');
+        assert.equal($progressBar.find(`.${PROGRESSBAR_CONTAINER_CLASS}`).is(':visible'), false, 'progressbar container does not attached');
     });
 });
 


### PR DESCRIPTION
`toSelector` utility is outdated now while using of ES6 template literals is more clear and short for a modern developer