### PR TITLE
Navigation: get rid of outdated toSelector utility in tests

### DIFF
--- a/packages/devextreme/testing/tests/DevExpress.knockout/list.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.knockout/list.tests.js
@@ -36,10 +36,6 @@ const LIST_CLASS = 'dx-list';
 const LIST_ITEM_CLASS = 'dx-list-item';
 const LIST_ITEM_SELECTED_CLASS = 'dx-list-item-selected';
 
-const toSelector = function(cssClass) {
-    return '.' + cssClass;
-};
-
 const moduleSetup = {
     beforeEach: function() {
         executeAsyncMock.setup();
@@ -70,7 +66,7 @@ QUnit.test('default with ko approach', function(assert) {
 
     assert.ok($element.hasClass(LIST_CLASS));
 
-    const items = $element.find(toSelector(LIST_ITEM_CLASS));
+    const items = $element.find(`.${LIST_ITEM_CLASS}`);
     assert.equal(items.length, 2);
     assert.ok(items.eq(0).hasClass(LIST_ITEM_CLASS));
     assert.ok(items.eq(1).hasClass(LIST_ITEM_CLASS));
@@ -121,11 +117,11 @@ QUnit.test('observableArray.push must refresh', function(assert) {
     this.element.attr('data-bind', 'dxList: { dataSource: data }');
     ko.applyBindings(vm, this.element[0]);
 
-    assert.equal(this.element.find(toSelector(LIST_ITEM_CLASS)).length, 1);
+    assert.equal(this.element.find(`.${LIST_ITEM_CLASS}`).length, 1);
     assert.equal(this.element.dxList('instance').option('items').length, 1);
 
     vm.data.push(2);
-    assert.equal(this.element.find(toSelector(LIST_ITEM_CLASS)).length, 2);
+    assert.equal(this.element.find(`.${LIST_ITEM_CLASS}`).length, 2);
     assert.equal(this.element.dxList('instance').option('items').length, 2);
 });
 
@@ -211,7 +207,7 @@ QUnit.test('grouped list should respond on outside selectedItems changes', funct
         unselectActionFired += args.removedItems.length;
     });
 
-    const $items = $list.find(toSelector(LIST_ITEM_CLASS));
+    const $items = $list.find(`.${LIST_ITEM_CLASS}`);
 
     vm.selectedItems([
         {

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets/list.markup.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets/list.markup.tests.js
@@ -27,10 +27,6 @@ const LIST_GROUP_HEADER_CLASS = 'dx-list-group-header';
 const LIST_GROUP_BODY_CLASS = 'dx-list-group-body';
 const LIST_ITEM_BEFORE_BAG_CLASS = 'dx-list-item-before-bag';
 
-const toSelector = cssClass => {
-    return '.' + cssClass;
-};
-
 QUnit.module('List markup', {}, () => {
     QUnit.test('rendering empty message for empty list', function(assert) {
         const element = $('#list').dxList();
@@ -41,7 +37,7 @@ QUnit.module('List markup', {}, () => {
         const element = $('#list').dxList({ items: ['0', '1'] });
         assert.ok(element.hasClass(LIST_CLASS));
 
-        const items = element.find(toSelector(LIST_ITEM_CLASS));
+        const items = element.find(`.${LIST_ITEM_CLASS}`);
         assert.equal(items.length, 2);
         assert.ok(items.eq(0).hasClass(LIST_ITEM_CLASS));
         assert.ok(items.eq(1).hasClass(LIST_ITEM_CLASS));
@@ -56,7 +52,7 @@ QUnit.module('List markup', {}, () => {
             }
         });
 
-        const item = element.find(toSelector(LIST_ITEM_CLASS));
+        const item = element.find(`.${LIST_ITEM_CLASS}`);
 
         assert.equal(item.eq(0).text(), '0: a');
         assert.equal(item.eq(1).text(), '1: b');
@@ -70,7 +66,7 @@ QUnit.module('List markup', {}, () => {
             }
         });
 
-        const item = element.find(toSelector(LIST_ITEM_CLASS));
+        const item = element.find(`.${LIST_ITEM_CLASS}`);
 
         assert.equal(item.eq(0).text(), '0: a');
         assert.equal(item.eq(1).text(), '1: b');
@@ -110,16 +106,16 @@ QUnit.module('List markup', {}, () => {
             grouped: true
         });
 
-        const groups = element.find(toSelector(LIST_GROUP_CLASS));
+        const groups = element.find(`.${LIST_GROUP_CLASS}`);
         assert.equal(groups.length, 2);
 
-        const groupHeaders = element.find(toSelector(LIST_GROUP_HEADER_CLASS));
+        const groupHeaders = element.find(`.${LIST_GROUP_HEADER_CLASS}`);
         assert.equal(groupHeaders.length, 2);
 
         assert.equal(groupHeaders.eq(0).text(), 'group1');
         assert.equal(groupHeaders.eq(1).text(), 'group2');
 
-        const items = element.find(toSelector(LIST_ITEM_CLASS));
+        const items = element.find(`.${LIST_ITEM_CLASS}`);
         assert.equal(items.length, 3);
     });
 
@@ -144,7 +140,7 @@ QUnit.module('List markup', {}, () => {
             }
         });
 
-        const groupHeaders = element.find(toSelector(LIST_GROUP_HEADER_CLASS));
+        const groupHeaders = element.find(`.${LIST_GROUP_HEADER_CLASS}`);
         assert.equal(groupHeaders.eq(0).text(), '0: a');
         assert.equal(groupHeaders.eq(1).text(), '1: b');
     });
@@ -166,7 +162,7 @@ QUnit.module('List markup', {}, () => {
             }
         });
 
-        const groupHeaders = element.find(toSelector(LIST_GROUP_HEADER_CLASS));
+        const groupHeaders = element.find(`.${LIST_GROUP_HEADER_CLASS}`);
         assert.ok(groupHeaders.find('span').length);
     });
 
@@ -451,14 +447,14 @@ QUnit.module('decorators markup', {}, () => {
             itemDeleteMode: 'static'
         }));
 
-        const $items = $list.find(toSelector(LIST_ITEM_CLASS));
+        const $items = $list.find(`.${LIST_ITEM_CLASS}`);
         const $item = $items.eq(0);
 
-        const $button = $item.find(toSelector(STATIC_DELETE_BUTTON_CLASS));
+        const $button = $item.find(`.${STATIC_DELETE_BUTTON_CLASS}`);
 
         assert.equal($button.length, 1, 'delete button was rendered');
         assert.ok($button.parent().hasClass(STATIC_DELETE_BUTTON_CONTAINER_CLASS), 'delete button was rendered in correct container');
-        assert.equal($list.find(toSelector(STATIC_DELETE_BUTTON_CLASS)).length, 3, 'delete button was rendered for all items');
+        assert.equal($list.find(`.${STATIC_DELETE_BUTTON_CLASS}`).length, 3, 'delete button was rendered for all items');
     });
 
     QUnit.test('list item markup, toggle delete decorator', function(assert) {
@@ -468,12 +464,12 @@ QUnit.module('decorators markup', {}, () => {
             itemDeleteMode: 'toggle'
         }));
 
-        const $items = $list.find(toSelector(LIST_ITEM_CLASS));
+        const $items = $list.find(`.${LIST_ITEM_CLASS}`);
         const $item = $items.eq(0);
 
-        const $deleteToggle = $item.children(toSelector(LIST_ITEM_BEFORE_BAG_CLASS)).children(toSelector(TOGGLE_DELETE_SWITCH_CLASS));
+        const $deleteToggle = $item.children(`.${LIST_ITEM_BEFORE_BAG_CLASS}`).children(`.${TOGGLE_DELETE_SWITCH_CLASS}`);
         assert.ok($deleteToggle.length, 'toggle generated');
-        assert.ok($deleteToggle.find(toSelector(TOGGLE_DELETE_SWITCH_ICON_CLASS)).length, 'toggle icon generated');
+        assert.ok($deleteToggle.find(`.${TOGGLE_DELETE_SWITCH_ICON_CLASS}`).length, 'toggle icon generated');
     });
 
     QUnit.test('list item delete icon is visible when showSelectionControls=true (T966717)', function(assert) {
@@ -579,10 +575,10 @@ QUnit.module('decorators markup', {}, () => {
             selectionMode: 'multiple'
         }));
 
-        const $items = $list.find(toSelector(LIST_ITEM_CLASS));
+        const $items = $list.find(`.${LIST_ITEM_CLASS}`);
         const $item = $items.eq(0);
-        const $checkboxContainer = $item.children(toSelector(LIST_ITEM_BEFORE_BAG_CLASS));
-        const $checkbox = $checkboxContainer.children(toSelector(SELECT_CHECKBOX_CLASS));
+        const $checkboxContainer = $item.children(`.${LIST_ITEM_BEFORE_BAG_CLASS}`);
+        const $checkbox = $checkboxContainer.children(`.${SELECT_CHECKBOX_CLASS}`);
 
         assert.ok($checkboxContainer.hasClass(SELECT_CHECKBOX_CONTAINER_CLASS), 'container has proper class');
         assert.ok($checkbox.hasClass('dx-checkbox'), 'select generated');
@@ -595,10 +591,10 @@ QUnit.module('decorators markup', {}, () => {
             selectionMode: 'single'
         }));
 
-        const $items = $list.find(toSelector(LIST_ITEM_CLASS));
+        const $items = $list.find(`.${LIST_ITEM_CLASS}`);
         const $item = $items.eq(0);
-        const $radioButtonContainer = $item.children(toSelector(SELECT_RADIO_BUTTON_CONTAINER_CLASS));
-        const $radioButton = $radioButtonContainer.children(toSelector(SELECT_RADIO_BUTTON_CLASS));
+        const $radioButtonContainer = $item.children(`.${SELECT_RADIO_BUTTON_CONTAINER_CLASS}`);
+        const $radioButton = $radioButtonContainer.children(`.${SELECT_RADIO_BUTTON_CLASS}`);
 
         assert.ok($radioButton.hasClass('dx-radiobutton'), 'radio button generated');
     });
@@ -611,7 +607,7 @@ QUnit.module('decorators markup', {}, () => {
             selectAllText: 'Test'
         }));
 
-        const $multipleContainer = $list.find(toSelector(SELECT_ALL_CLASS));
+        const $multipleContainer = $list.find(`.${SELECT_ALL_CLASS}`);
         assert.equal($multipleContainer.length, 1, 'container for SelectAll rendered');
         assert.equal($multipleContainer.text(), 'Test', 'select all rendered');
         const $checkbox = $multipleContainer.find('.dx-checkbox');
@@ -632,8 +628,8 @@ QUnit.module('decorators markup', {}, () => {
             selectionMode: 'all',
         }));
 
-        const $selectAllCheckBox = $list.find(toSelector(SELECT_ALL_CHECKBOX_CLASS));
-        const $multipleContainer = $list.find(toSelector(SELECT_ALL_CLASS));
+        const $selectAllCheckBox = $list.find(`.${SELECT_ALL_CHECKBOX_CLASS}`);
+        const $multipleContainer = $list.find(`.${SELECT_ALL_CLASS}`);
 
         assert.strictEqual($selectAllCheckBox.attr('aria-label'), localizedSelectAllText, 'selectAll checkbox aria-label should be equal to localized text');
 
@@ -667,10 +663,10 @@ QUnit.module('decorators markup', {}, () => {
             }
         }));
 
-        const $items = $list.find(toSelector(LIST_ITEM_CLASS));
+        const $items = $list.find(`.${LIST_ITEM_CLASS}`);
         const $item = $items.eq(0);
-        const $handleContainer = $item.children(toSelector(REORDER_HANDLE_CONTAINER_CLASS));
-        const $handle = $handleContainer.children(toSelector(REORDER_HANDLE_CLASS));
+        const $handleContainer = $item.children(`.${REORDER_HANDLE_CONTAINER_CLASS}`);
+        const $handle = $handleContainer.children(`.${REORDER_HANDLE_CLASS}`);
 
         assert.equal($handleContainer.length, 1, 'container generated');
         assert.equal($handle.length, 1, 'handle generated');
@@ -682,7 +678,7 @@ QUnit.module('decorators markup', {}, () => {
             displayExpr: 'name'
         });
 
-        const $items = $list.find(toSelector(LIST_ITEM_CLASS));
+        const $items = $list.find(`.${LIST_ITEM_CLASS}`);
 
         assert.strictEqual($items.text(), 'Item 1', 'displayExpr works');
     });

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets/menu.markup.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets/menu.markup.tests.js
@@ -30,8 +30,6 @@ const createMenu = (options) => {
     return { instance: menuInstance, element: $menu };
 };
 
-const toSelector = cssClass => '.' + cssClass;
-
 QUnit.module('Menu rendering', {
     beforeEach: function() {
         fx.off = true;
@@ -55,10 +53,10 @@ QUnit.module('Menu rendering', {
             itemsExpr: 'child',
             showFirstSubmenuMode: 'onClick'
         });
-        const $item1 = $(menu.element).find(toSelector(DX_MENU_ITEM_CLASS)).eq(0);
+        const $item1 = $(menu.element).find(`.${DX_MENU_ITEM_CLASS}`).eq(0);
 
         assert.equal($item1.text(), 'item 1', 'root item rendered correct');
-        assert.ok($item1.find(toSelector(DX_MENU_ITEM_POPOUT_CLASS)).length, 'popout was rendered');
+        assert.ok($item1.find(`.${DX_MENU_ITEM_POPOUT_CLASS}`).length, 'popout was rendered');
     });
 
     QUnit.test('Check default css class', function(assert) {
@@ -69,7 +67,7 @@ QUnit.module('Menu rendering', {
 
     QUnit.test('Do not render menu with empty items', function(assert) {
         const menu = createMenu({ items: [] });
-        const root = $(menu.element).find(toSelector(DX_MENU_HORIZONTAL));
+        const root = $(menu.element).find(`.${DX_MENU_HORIZONTAL}`);
 
         assert.ok(menu);
         assert.equal(root.length, 0, 'no root');
@@ -101,7 +99,7 @@ QUnit.module('Menu - selection', {
             items: [{ text: 'root', selected: true }],
             selectionMode: 'single'
         });
-        const item1 = $(menu.element).find(toSelector(DX_MENU_ITEM_CLASS)).eq(0);
+        const item1 = $(menu.element).find(`.${DX_MENU_ITEM_CLASS}`).eq(0);
         assert.ok(item1.hasClass(DX_MENU_ITEM_SELECTED_CLASS));
     });
 });
@@ -131,7 +129,7 @@ QUnit.module('Menu with templates', {
             itemTemplate: $template
         };
         const menu = createMenu(options);
-        const $item = $(menu.element).find(toSelector(DX_MENU_ITEM_CLASS)).eq(1);
+        const $item = $(menu.element).find(`.${DX_MENU_ITEM_CLASS}`).eq(1);
 
         $($item).trigger('dxclick');
 

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets/multiView.markup.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets/multiView.markup.tests.js
@@ -25,10 +25,6 @@ const MULTIVIEW_ITEM_CLASS = 'dx-multiview-item';
 const MULTIVIEW_ITEM_CONTENT_CLASS = 'dx-multiview-item-content';
 const MULTIVIEW_ITEM_HIDDEN_CLASS = 'dx-multiview-item-hidden';
 
-const toSelector = function(cssClass) {
-    return '.' + cssClass;
-};
-
 QUnit.module('markup', () => {
     QUnit.test('widget should be rendered', function(assert) {
         const $multiView = $('#multiView').dxMultiView();
@@ -38,15 +34,15 @@ QUnit.module('markup', () => {
 
     QUnit.test('wrapper should be rendered', function(assert) {
         const $multiView = $('#multiView').dxMultiView();
-        const $wrapper = $multiView.children(toSelector(MULTIVIEW_WRAPPER_CLASS));
+        const $wrapper = $multiView.children(`.${MULTIVIEW_WRAPPER_CLASS}`);
 
         assert.equal($wrapper.length, 1, 'wrapper was rendered');
     });
 
     QUnit.test('item container should be rendered', function(assert) {
         const $multiView = $('#multiView').dxMultiView();
-        const $wrapper = $multiView.children(toSelector(MULTIVIEW_WRAPPER_CLASS));
-        const $itemContainer = $wrapper.children(toSelector(MULTIVIEW_ITEM_CONTAINER_CLASS));
+        const $wrapper = $multiView.children(`.${MULTIVIEW_WRAPPER_CLASS}`);
+        const $itemContainer = $wrapper.children(`.${MULTIVIEW_ITEM_CONTAINER_CLASS}`);
 
         assert.equal($itemContainer.length, 1, 'item container was rendered');
     });
@@ -56,12 +52,12 @@ QUnit.module('markup', () => {
             items: [1, 2],
             selectedIndex: 0
         });
-        const $itemContainer = $multiView.find(toSelector(MULTIVIEW_ITEM_CONTAINER_CLASS));
-        const $items = $itemContainer.children(toSelector(MULTIVIEW_ITEM_CLASS));
+        const $itemContainer = $multiView.find(`.${MULTIVIEW_ITEM_CONTAINER_CLASS}`);
+        const $items = $itemContainer.children(`.${MULTIVIEW_ITEM_CLASS}`);
 
         assert.equal($items.length, 2, 'items was rendered');
-        assert.equal($items.eq(0).find(toSelector(MULTIVIEW_ITEM_CONTENT_CLASS)).length, 1, 'rendered item has item content inside');
-        assert.equal($items.eq(1).find(toSelector(MULTIVIEW_ITEM_CONTENT_CLASS)).length, 0, 'second item has no item content because deferRendering is true');
+        assert.equal($items.eq(0).find(`.${MULTIVIEW_ITEM_CONTENT_CLASS}`).length, 1, 'rendered item has item content inside');
+        assert.equal($items.eq(1).find(`.${MULTIVIEW_ITEM_CONTENT_CLASS}`).length, 0, 'second item has no item content because deferRendering is true');
     });
 
     QUnit.test('item templates should be applied', function(assert) {
@@ -70,8 +66,8 @@ QUnit.module('markup', () => {
             selectedIndex: 1,
             deferRendering: false
         });
-        const $itemContainer = $multiView.find(toSelector(MULTIVIEW_ITEM_CONTAINER_CLASS));
-        const $items = $itemContainer.children(toSelector(MULTIVIEW_ITEM_CLASS));
+        const $itemContainer = $multiView.find(`.${MULTIVIEW_ITEM_CONTAINER_CLASS}`);
+        const $items = $itemContainer.children(`.${MULTIVIEW_ITEM_CLASS}`);
 
         assert.equal($items.eq(0).text(), 'Test1', 'element has correct content');
         assert.equal($items.eq(1).text(), 'Test2', 'element has correct content');
@@ -87,9 +83,9 @@ QUnit.module('markup', () => {
                 });
             }
         });
-        const $itemContainer = $multiView.find(toSelector(MULTIVIEW_ITEM_CONTAINER_CLASS));
+        const $itemContainer = $multiView.find(`.${MULTIVIEW_ITEM_CONTAINER_CLASS}`);
 
-        const $items = $itemContainer.children(toSelector(MULTIVIEW_ITEM_CLASS));
+        const $items = $itemContainer.children(`.${MULTIVIEW_ITEM_CLASS}`);
         assert.ok(!$items.eq(3).hasClass(MULTIVIEW_ITEM_HIDDEN_CLASS), 'correct item selected');
     });
 
@@ -98,7 +94,7 @@ QUnit.module('markup', () => {
             items: [1, 2, 3],
             selectedIndex: 0
         });
-        const $items = $multiView.find(toSelector(MULTIVIEW_ITEM_CLASS));
+        const $items = $multiView.find(`.${MULTIVIEW_ITEM_CLASS}`);
 
         assert.ok(!$items.eq(0).hasClass(MULTIVIEW_ITEM_HIDDEN_CLASS));
         assert.ok($items.eq(1).hasClass(MULTIVIEW_ITEM_HIDDEN_CLASS));

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets/multiView.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets/multiView.tests.js
@@ -56,7 +56,6 @@ const MULTIVIEW_ITEM_CLASS = 'dx-multiview-item';
 const MULTIVIEW_ITEM_CONTENT_CLASS = 'dx-multiview-item-content';
 const MULTIVIEW_ITEM_HIDDEN_CLASS = 'dx-multiview-item-hidden';
 
-const toSelector = cssClass => `.${cssClass}`;
 const position = $element => translator.locate($element).left;
 
 const mockFxAnimate = (animations, type, output, startAction) => {
@@ -117,7 +116,7 @@ QUnit.module('rendering', () => {
             $container.appendTo('#qunit-fixture');
             triggerShownEvent($container);
 
-            const $items = $multiView.find(toSelector(MULTIVIEW_ITEM_CLASS));
+            const $items = $multiView.find(`.${MULTIVIEW_ITEM_CLASS}`);
             assert.equal($items.eq(0).outerHeight(), $multiView.outerHeight(), 'element has correct height');
         } finally {
             $container.remove();
@@ -130,7 +129,7 @@ QUnit.module('rendering', () => {
                 { text: '1' }
             ]
         });
-        const $items = $multiView.find(toSelector(MULTIVIEW_ITEM_CLASS));
+        const $items = $multiView.find(`.${MULTIVIEW_ITEM_CLASS}`);
 
         assert.notOk($items.eq(0).hasClass(MULTIVIEW_ITEM_HIDDEN_CLASS), 'first item is visible');
     });
@@ -142,7 +141,7 @@ QUnit.module('rendering', () => {
                 { text: '2', visible: false }
             ]
         });
-        const $items = $multiView.find(toSelector(MULTIVIEW_ITEM_CLASS));
+        const $items = $multiView.find(`.${MULTIVIEW_ITEM_CLASS}`);
 
         assert.notOk($items.eq(0).hasClass(MULTIVIEW_ITEM_HIDDEN_CLASS), 'first item is visible');
         assert.ok($items.eq(1).hasClass(MULTIVIEW_ITEM_HIDDEN_CLASS), 'second item is hidden');
@@ -174,7 +173,7 @@ QUnit.module('rendering', () => {
         multiView.option('items[1].template', $('#template2'));
         multiView.option('selectedIndex', 1);
 
-        const $items = $multiView.find(toSelector(MULTIVIEW_ITEM_CLASS));
+        const $items = $multiView.find(`.${MULTIVIEW_ITEM_CLASS}`);
 
         assert.equal($items.eq(1).text(), 'Test2', 'element has correct content');
     });
@@ -188,7 +187,7 @@ QUnit.module('rendering', () => {
 
         multiView.option('items[1].template', $('#template2'));
 
-        const $items = $multiView.find(toSelector(MULTIVIEW_ITEM_CLASS));
+        const $items = $multiView.find(`.${MULTIVIEW_ITEM_CLASS}`);
 
         assert.notOk($items.eq(0).hasClass(MULTIVIEW_ITEM_HIDDEN_CLASS), 'first item is visible');
         assert.ok($items.eq(1).hasClass(MULTIVIEW_ITEM_HIDDEN_CLASS), 'second item is still hidden');
@@ -205,11 +204,11 @@ QUnit.module('nested multiview', () => {
                 });
             }
         });
-        const $itemContainer = $multiView.find(toSelector(MULTIVIEW_ITEM_CONTAINER_CLASS));
+        const $itemContainer = $multiView.find(`.${MULTIVIEW_ITEM_CONTAINER_CLASS}`);
 
         $multiView.dxMultiView('option', 'selectedIndex', 3);
 
-        const $items = $itemContainer.children(toSelector(MULTIVIEW_ITEM_CLASS));
+        const $items = $itemContainer.children(`.${MULTIVIEW_ITEM_CLASS}`);
         assert.ok(!$items.eq(3).hasClass(MULTIVIEW_ITEM_HIDDEN_CLASS), 'correct item selected');
     });
 
@@ -251,7 +250,7 @@ QUnit.module('items positioning', {
             items: [1, 2, 3],
             selectedIndex: 0
         });
-        const $items = $multiView.find(toSelector(MULTIVIEW_ITEM_CLASS));
+        const $items = $multiView.find(`.${MULTIVIEW_ITEM_CLASS}`);
 
         assert.equal(position($items.eq(0)), 0, 'first item has correct position');
 
@@ -264,7 +263,7 @@ QUnit.module('items positioning', {
             items: [1, 2, 3],
             selectedIndex: 0
         });
-        const $items = $multiView.find(toSelector(MULTIVIEW_ITEM_CLASS));
+        const $items = $multiView.find(`.${MULTIVIEW_ITEM_CLASS}`);
 
         assert.ok(!$items.eq(0).hasClass(MULTIVIEW_ITEM_HIDDEN_CLASS));
         assert.ok($items.eq(1).hasClass(MULTIVIEW_ITEM_HIDDEN_CLASS));
@@ -342,7 +341,7 @@ QUnit.module('selected index change animation', {
             selectedIndex: 0
         });
         const multiView = $('#multiView').dxMultiView('instance');
-        const $itemContainer = $multiView.find(toSelector(MULTIVIEW_ITEM_CONTAINER_CLASS));
+        const $itemContainer = $multiView.find(`.${MULTIVIEW_ITEM_CONTAINER_CLASS}`);
 
         multiView.option('selectedIndex', 1);
 
@@ -359,7 +358,7 @@ QUnit.module('selected index change animation', {
             selectedIndex: 2
         });
         const multiView = $('#multiView').dxMultiView('instance');
-        const $itemContainer = $multiView.find(toSelector(MULTIVIEW_ITEM_CONTAINER_CLASS));
+        const $itemContainer = $multiView.find(`.${MULTIVIEW_ITEM_CONTAINER_CLASS}`);
 
         multiView.option('selectedIndex', 1);
 
@@ -376,7 +375,7 @@ QUnit.module('selected index change animation', {
             selectedIndex: 0
         });
         const multiView = $('#multiView').dxMultiView('instance');
-        const $items = $multiView.find(toSelector(MULTIVIEW_ITEM_CLASS));
+        const $items = $multiView.find(`.${MULTIVIEW_ITEM_CLASS}`);
 
         this.animationStartAction = function() {
             assert.equal(position($items.eq(0)), 0, 'first item has correct position');
@@ -395,7 +394,7 @@ QUnit.module('selected index change animation', {
             selectedIndex: 2
         });
         const multiView = $('#multiView').dxMultiView('instance');
-        const $items = $multiView.find(toSelector(MULTIVIEW_ITEM_CLASS));
+        const $items = $multiView.find(`.${MULTIVIEW_ITEM_CLASS}`);
 
         this.animationStartAction = function() {
             assert.equal(position($items.eq(0)), -800, 'first item has correct position');
@@ -543,7 +542,7 @@ QUnit.module('interaction via swipe', {
             ]
         });
         const instance = $multiView.dxMultiView('instance');
-        const $itemContainer = $multiView.find(toSelector(MULTIVIEW_ITEM_CONTAINER_CLASS));
+        const $itemContainer = $multiView.find(`.${MULTIVIEW_ITEM_CONTAINER_CLASS}`);
         const pointer = pointerMock($multiView);
 
         pointer.start().swipeStart().swipe(0.1).swipeEnd(1);
@@ -560,7 +559,7 @@ QUnit.module('interaction via swipe', {
             ]
         });
         const instance = $multiView.dxMultiView('instance');
-        const $itemContainer = $multiView.find(toSelector(MULTIVIEW_ITEM_CONTAINER_CLASS));
+        const $itemContainer = $multiView.find(`.${MULTIVIEW_ITEM_CONTAINER_CLASS}`);
         const $thirdItem = $multiView.find(`.${MULTIVIEW_ITEM_CLASS}`).eq(2);
         const pointer = pointerMock($multiView);
 
@@ -632,7 +631,7 @@ QUnit.module('interaction via swipe', {
         const $multiView = $('#multiView').dxMultiView({
             items: [1, 2, 3]
         });
-        const $itemContainer = $multiView.find(toSelector(MULTIVIEW_ITEM_CONTAINER_CLASS));
+        const $itemContainer = $multiView.find(`.${MULTIVIEW_ITEM_CONTAINER_CLASS}`);
         const pointer = pointerMock($multiView);
 
         pointer.start().swipeStart().swipe(-0.1);
@@ -775,7 +774,7 @@ QUnit.module('interaction via swipe', {
             items: [1, 2, 3],
             selectedIndex: 2
         });
-        const $itemContainer = $multiView.find(toSelector(MULTIVIEW_ITEM_CONTAINER_CLASS));
+        const $itemContainer = $multiView.find(`.${MULTIVIEW_ITEM_CONTAINER_CLASS}`);
         const pointer = pointerMock($multiView);
 
         pointer.start().swipeStart().swipe(-0.2);
@@ -789,7 +788,7 @@ QUnit.module('interaction via swipe', {
             items: [1, 2, 3],
             swipeEnabled: false
         });
-        const $itemContainer = $multiView.find(toSelector(MULTIVIEW_ITEM_CONTAINER_CLASS));
+        const $itemContainer = $multiView.find(`.${MULTIVIEW_ITEM_CONTAINER_CLASS}`);
         const pointer = pointerMock($multiView);
 
         pointer.start().swipeStart().swipe(-0.1);
@@ -909,7 +908,7 @@ QUnit.module('loop', {
             loop: true
         });
         const instance = $multiView.dxMultiView('instance');
-        const $itemContainer = $multiView.find(toSelector(MULTIVIEW_ITEM_CONTAINER_CLASS));
+        const $itemContainer = $multiView.find(`.${MULTIVIEW_ITEM_CONTAINER_CLASS}`);
         const pointer = pointerMock($multiView);
 
         pointer.start().swipeStart().swipe(-0.1).swipeEnd(-1);
@@ -958,7 +957,7 @@ QUnit.module('loop', {
             selectedIndex: 0,
             loop: true
         });
-        const $itemContainer = $multiView.find(toSelector(MULTIVIEW_ITEM_CONTAINER_CLASS));
+        const $itemContainer = $multiView.find(`.${MULTIVIEW_ITEM_CONTAINER_CLASS}`);
         const pointer = pointerMock($multiView);
 
         pointer.start().swipeStart().swipe(0.1);
@@ -972,7 +971,7 @@ QUnit.module('loop', {
             selectedIndex: 2,
             loop: true
         });
-        const $itemContainer = $multiView.find(toSelector(MULTIVIEW_ITEM_CONTAINER_CLASS));
+        const $itemContainer = $multiView.find(`.${MULTIVIEW_ITEM_CONTAINER_CLASS}`);
         const pointer = pointerMock($multiView);
 
         pointer.start().swipeStart().swipe(-0.1);
@@ -1146,7 +1145,7 @@ QUnit.module('loop', {
             selectedIndex: 0,
             loop: true
         });
-        const $items = $multiView.find(toSelector(MULTIVIEW_ITEM_CLASS));
+        const $items = $multiView.find(`.${MULTIVIEW_ITEM_CLASS}`);
         const pointer = pointerMock($multiView);
 
         this.animationStartAction = function() {
@@ -1163,7 +1162,7 @@ QUnit.module('loop', {
             selectedIndex: 2,
             loop: true
         });
-        const $items = $multiView.find(toSelector(MULTIVIEW_ITEM_CLASS));
+        const $items = $multiView.find(`.${MULTIVIEW_ITEM_CLASS}`);
         const pointer = pointerMock($multiView);
 
         this.animationStartAction = function() {
@@ -1180,7 +1179,7 @@ QUnit.module('loop', {
             selectedIndex: 0,
             loop: true
         });
-        const $item1 = $multiView.find(toSelector(MULTIVIEW_ITEM_CLASS)).eq(1);
+        const $item1 = $multiView.find(`.${MULTIVIEW_ITEM_CLASS}`).eq(1);
         const pointer = pointerMock($multiView);
 
         pointer.start().swipeStart().swipe(-0.01);
@@ -1357,7 +1356,7 @@ QUnit.module('keyboard navigation', {
                 focusStateEnabled: true
             });
             const instance = $multiView.dxMultiView('instance');
-            const $itemContainer = $multiView.find(toSelector(MULTIVIEW_ITEM_CONTAINER_CLASS));
+            const $itemContainer = $multiView.find(`.${MULTIVIEW_ITEM_CONTAINER_CLASS}`);
             const keyboard = keyboardMock($multiView);
 
             $multiView.focusin();

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets/tabPanel.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets/tabPanel.tests.js
@@ -62,8 +62,6 @@ const TABS_INDICATOR_POSITION_CLASS_BY_TABS_POSITION = {
     left: TABS_INDICATOR_POSITION_CLASS.right,
 };
 
-const toSelector = cssClass => '.' + cssClass;
-
 QUnit.module('rendering', {
     beforeEach() {
         this.$tabPanel = $('#tabPanel').dxTabPanel();
@@ -182,7 +180,7 @@ QUnit.module('options', {
         });
 
         this.tabPanelInstance = this.$tabPanel.dxTabPanel('instance');
-        this.tabWidgetInstance = this.$tabPanel.find(toSelector(TABS_CLASS)).dxTabs('instance');
+        this.tabWidgetInstance = this.$tabPanel.find(`.${TABS_CLASS}`).dxTabs('instance');
     },
     afterEach() {
         fx.off = false;
@@ -319,7 +317,7 @@ QUnit.module('onSelectionChanging', {
             this.tabPanel = this.$tabPanel
                 .dxTabPanel($.extend({}, initialOptions, options))
                 .dxTabPanel('instance');
-            this.$tabs = this.$tabPanel.find(toSelector(TABS_CLASS));
+            this.$tabs = this.$tabPanel.find(`.${TABS_CLASS}`);
             this.tabs = this.$tabs.dxTabs('instance');
         };
         this.reinit = (options) => {
@@ -761,10 +759,10 @@ QUnit.module('action handlers', {
         });
 
         this.tabPanelInstance = this.$tabPanel.dxTabPanel('instance');
-        this.tabWidgetInstance = this.$tabPanel.find(toSelector(TABS_CLASS)).dxTabs('instance');
+        this.tabWidgetInstance = this.$tabPanel.find(`.${TABS_CLASS}`).dxTabs('instance');
 
-        this.multiViewMouse = pointerMock(this.$tabPanel.find(toSelector(MULTIVIEW_ITEM_CLASS))[0]).start();
-        this.tabWidgetMouse = pointerMock(this.$tabPanel.find(toSelector(TABS_ITEM_CLASS))[0]).start();
+        this.multiViewMouse = pointerMock(this.$tabPanel.find(`.${MULTIVIEW_ITEM_CLASS}`)[0]).start();
+        this.tabWidgetMouse = pointerMock(this.$tabPanel.find(`.${TABS_ITEM_CLASS}`)[0]).start();
     },
     afterEach() {
         this.clock.restore();
@@ -832,15 +830,15 @@ QUnit.module('action handlers', {
         });
 
         try {
-            assert.equal($element.find(toSelector(MULTIVIEW_ITEM_CLASS + '-content')).length, 1, 'only one multiView item is rendered on init');
+            assert.equal($element.find(`.${MULTIVIEW_ITEM_CLASS}-content`).length, 1, 'only one multiView item is rendered on init');
 
             const index = 2;
-            const pointer = pointerMock($element.find(toSelector(TABS_ITEM_CLASS)).eq(index));
+            const pointer = pointerMock($element.find(`.${TABS_ITEM_CLASS}`).eq(index));
 
             pointer.start().click();
 
-            assert.equal($element.find(toSelector(MULTIVIEW_ITEM_CLASS + '-content')).length, 2, 'one multiView item is rendered after click on tab');
-            assert.equal($element.find(toSelector(SELECTED_ITEM_CLASS)).text(), items[index].text, 'selected multiView item has correct data');
+            assert.equal($element.find(`.${MULTIVIEW_ITEM_CLASS}-content`).length, 2, 'one multiView item is rendered after click on tab');
+            assert.equal($element.find(`.${SELECTED_ITEM_CLASS}`).text(), items[index].text, 'selected multiView item has correct data');
         } finally {
             $element.remove();
         }
@@ -879,7 +877,7 @@ QUnit.module('events handlers', {
 
             that.tabPanelInstance = that.$tabPanel.dxTabPanel('instance');
 
-            that.tabWidgetMouse = pointerMock(that.$tabPanel.find(toSelector(TABS_ITEM_CLASS))[0]).start();
+            that.tabWidgetMouse = pointerMock(that.$tabPanel.find(`.${TABS_ITEM_CLASS}`)[0]).start();
         };
     },
     afterEach() {
@@ -1026,8 +1024,8 @@ QUnit.module('focus policy', {
             focusStateEnabled: true,
         });
 
-        const $tabs = $tabPanel.find(toSelector(TABPANEL_TABS_ITEM_CLASS));
-        const tabsInstance = $tabPanel.find(toSelector(TABS_CLASS)).dxTabs('instance');
+        const $tabs = $tabPanel.find(`.${TABPANEL_TABS_ITEM_CLASS}`);
+        const tabsInstance = $tabPanel.find(`.${TABS_CLASS}`).dxTabs('instance');
         const $firstTab = $tabs.first();
 
         assert.strictEqual($tabs.filter(`.${FOCUS_STATE_CLASS}`).length, 1, 'only one tab is focused');
@@ -1049,7 +1047,7 @@ QUnit.module('keyboard navigation', {
             items
         });
         this.instance = this.$element.dxTabPanel('instance');
-        this.$tabs = this.$element.find(toSelector(TABS_CLASS));
+        this.$tabs = this.$element.find(`.${TABS_CLASS}`);
         this.tabs = this.$tabs.dxTabs('instance');
         this.clock = sinon.useFakeTimers();
     },
@@ -1072,7 +1070,7 @@ QUnit.module('keyboard navigation', {
         assert.expect(4);
 
         this.instance.focus();
-        $(toSelector(MULTIVIEW_ITEM_CLASS)).eq(1).trigger('dxpointerdown');
+        $(`.${MULTIVIEW_ITEM_CLASS}`).eq(1).trigger('dxpointerdown');
         this.clock.tick(10);
 
         const multiViewFocusedIndex = $(this.instance.option('focusedElement')).index();
@@ -1090,7 +1088,7 @@ QUnit.module('keyboard navigation', {
         const keyboard = keyboardMock(this.$tabs);
         keyboard.press('right');
 
-        const $thirdTab = this.$tabs.find(toSelector(TABPANEL_TABS_ITEM_CLASS)).get(2);
+        const $thirdTab = this.$tabs.find(`.${TABPANEL_TABS_ITEM_CLASS}`).get(2);
         pointerMock($thirdTab).start().click();
 
         this.clock.tick(10);
@@ -1098,7 +1096,7 @@ QUnit.module('keyboard navigation', {
         assert.strictEqual($($thirdTab).hasClass(FOCUS_STATE_CLASS), true);
         assert.strictEqual($($thirdTab).hasClass(TABS_ITEM_SELECTED_CLASS), true);
 
-        const $firstTab = this.$tabs.find(toSelector(TABPANEL_TABS_ITEM_CLASS)).get(0);
+        const $firstTab = this.$tabs.find(`.${TABPANEL_TABS_ITEM_CLASS}`).get(0);
         assert.strictEqual($($firstTab).hasClass(FOCUSED_DISABLED_NEXT_TAB_CLASS), false);
 
         keyboard.press('left');
@@ -1112,7 +1110,7 @@ QUnit.module('keyboard navigation', {
         assert.expect(3);
 
         this.instance.focus();
-        $(toSelector(TABS_ITEM_CLASS)).eq(1).trigger('dxpointerup');
+        $(`.${TABS_ITEM_CLASS}`).eq(1).trigger('dxpointerup');
         this.clock.tick(10);
 
         const tabsFocusedIndex = $(this.instance.option('focusedElement')).index();
@@ -1173,7 +1171,7 @@ QUnit.module('Disabled items', {
         });
 
         this.instance = this.$element.dxTabPanel('instance');
-        this.$tabs = this.$element.find(toSelector(TABS_CLASS));
+        this.$tabs = this.$element.find(`.${TABS_CLASS}`);
 
         this.instance.option('items[1].disabled', true);
         this.instance.focus();
@@ -1183,7 +1181,7 @@ QUnit.module('Disabled items', {
     }
 }, () => {
     QUnit.test('disabled item can be focused by keyboard', function(assert) {
-        const $disabledItem = $(toSelector(TABS_ITEM_CLASS)).eq(1);
+        const $disabledItem = $(`.${TABS_ITEM_CLASS}`).eq(1);
         const keyboard = keyboardMock(this.$tabs);
 
         keyboard.press('right');
@@ -1193,7 +1191,7 @@ QUnit.module('Disabled items', {
     });
 
     QUnit.test('multiview wrapper should have focused class if item is available', function(assert) {
-        const multiViewWrapper = this.$element.find(toSelector(MULTIVIEW_WRAPPER_CLASS));
+        const multiViewWrapper = this.$element.find(`.${MULTIVIEW_WRAPPER_CLASS}`);
         const keyboard = keyboardMock(this.$tabs);
 
         assert.strictEqual($(multiViewWrapper).hasClass('dx-state-focused'), true, 'focused class set');
@@ -1269,7 +1267,7 @@ QUnit.module('Tabs Indicator position', () => {
     ['top', 'right', 'bottom', 'left'].forEach(tabsPosition => {
         QUnit.test(`The tabs element must have the correct indicator position class when tabsPosition=${tabsPosition}`, function(assert) {
             const $tabPanel = $('#tabPanel').dxTabPanel({ items: [1, 2, 3], tabsPosition });
-            const $tabs = $tabPanel.find(toSelector(TABS_CLASS));
+            const $tabs = $tabPanel.find(`.${TABS_CLASS}`);
 
             assert.ok($tabs.hasClass(TABS_INDICATOR_POSITION_CLASS_BY_TABS_POSITION[tabsPosition]));
         });
@@ -1278,7 +1276,7 @@ QUnit.module('Tabs Indicator position', () => {
     QUnit.test('The tabs element must have the correct indicator position class when tabsPosition was changed', function(assert) {
         const $tabPanel = $('#tabPanel').dxTabPanel({ items: [1, 2, 3] });
         const tabPanel = $tabPanel.dxTabPanel('instance');
-        const $tabs = $tabPanel.find(toSelector(TABS_CLASS));
+        const $tabs = $tabPanel.find(`.${TABS_CLASS}`);
 
         assert.ok($tabs.hasClass(TABS_INDICATOR_POSITION_CLASS_BY_TABS_POSITION['top']));
 
@@ -1306,7 +1304,7 @@ QUnit.module('Tabs Indicator position', () => {
     QUnit.test('The tabs element must have the correct indicator position class when _tabsIndicatorPosition was changed', function(assert) {
         const $tabPanel = $('#tabPanel').dxTabPanel({ items: [1, 2, 3] });
         const tabPanel = $tabPanel.dxTabPanel('instance');
-        const $tabs = $tabPanel.find(toSelector(TABS_CLASS));
+        const $tabs = $tabPanel.find(`.${TABS_CLASS}`);
 
         assert.ok($tabs.hasClass(TABS_INDICATOR_POSITION_CLASS.bottom));
 

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets/tabs.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets/tabs.tests.js
@@ -64,8 +64,6 @@ const BUTTON_NEXT_ICON = 'chevronnext';
 const BUTTON_PREV_ICON = 'chevronprev';
 const TAB_OFFSET = 30;
 
-const toSelector = cssClass => `.${cssClass}`;
-
 QUnit.module('General', () => {
     QUnit.test('mouseup switch selected tab', function(assert) {
         const tabsElement = $('#tabs').dxTabs({
@@ -227,7 +225,7 @@ QUnit.module('General', () => {
         keyboard.press('right');
         keyboard.press('right');
 
-        const $items = $element.find(toSelector(TABS_ITEM_CLASS));
+        const $items = $element.find(`.${TABS_ITEM_CLASS}`);
 
         assert.notOk($items.eq(0).hasClass(FOCUSED_DISABLED_NEXT_TAB_CLASS), 'The first item does not have specific class');
         assert.ok($items.eq(1).hasClass(FOCUSED_DISABLED_NEXT_TAB_CLASS), 'The second item has specific class');
@@ -257,7 +255,7 @@ QUnit.module('General', () => {
         keyboard.press('right');
         keyboard.press('right');
 
-        const $items = $element.find(toSelector(TABS_ITEM_CLASS));
+        const $items = $element.find(`.${TABS_ITEM_CLASS}`);
 
         assert.notOk($items.eq(0).hasClass(FOCUSED_DISABLED_PREV_TAB_CLASS), 'The first item does not have specific class');
         assert.notOk($items.eq(3).hasClass(FOCUSED_DISABLED_PREV_TAB_CLASS), 'The fourth item does not have specific class');
@@ -664,7 +662,7 @@ QUnit.module('Tab select action', () => {
             }
         });
 
-        const $tab = $tabs.find(toSelector(TABS_ITEM_CLASS)).eq(1);
+        const $tab = $tabs.find(`.${TABS_ITEM_CLASS}`).eq(1);
 
         $tab
             .trigger('dxclick')
@@ -686,7 +684,7 @@ QUnit.module('Tab select action', () => {
             }
         });
 
-        const $tab = $tabs.find(toSelector(TABS_ITEM_CLASS)).eq(2);
+        const $tab = $tabs.find(`.${TABS_ITEM_CLASS}`).eq(2);
 
         pointerMock($tab).click();
     });
@@ -739,7 +737,7 @@ QUnit.module('Tab select action', () => {
 
         assert.ok(!instance.option('selectOnFocus'), 'option selectOnFocus must be false with turn on multiple mode');
 
-        const $tab = $element.find(toSelector(TABS_ITEM_CLASS)).eq(3);
+        const $tab = $element.find(`.${TABS_ITEM_CLASS}`).eq(3);
         pointerMock($tab).click();
 
         assert.equal(instance.option('selectedItems').length, 2, 'selected two items in multiple mode');


### PR DESCRIPTION
`toSelector` utility is outdated now while using of ES6 template literals is more clear and short for a modern developer