### PR TITLE
Fix wheel event delta normalization to use deltaY or deltaX for common delta

### DIFF
--- a/packages/devextreme/js/__internal/events/core/m_wheel.ts
+++ b/packages/devextreme/js/__internal/events/core/m_wheel.ts
@@ -64,13 +64,6 @@ const wheel = {
     return -delta * DELTA_MUTLIPLIER;
   },
 
-  /* https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event
-  * wheelDelta - is deprecated.
-  * Use deltaX, deltaY, and deltaZ instead.
-  *
-  * jQuery implementation of mousewheel event.
-  * https://github.com/jquery/jquery-mousewheel/blob/main/src/jquery.mousewheel.js#L83
-  */
   _getWheelDelta(deltaY: number, deltaX: number, deltaZ: number) {
     if (deltaY) {
       return deltaY;

--- a/packages/devextreme/js/__internal/events/core/m_wheel.ts
+++ b/packages/devextreme/js/__internal/events/core/m_wheel.ts
@@ -61,7 +61,7 @@ const wheel = {
     }
     // Use multiplier to get rough delta value in px for the LINE or PAGE mode
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1392460
-    return -delta * DELTA_MULTIPLIER;
+    return -DELTA_MULTIPLIER * delta;
   },
 
   _getWheelDelta(deltaY: number, deltaX: number) {

--- a/packages/devextreme/js/__internal/events/core/m_wheel.ts
+++ b/packages/devextreme/js/__internal/events/core/m_wheel.ts
@@ -10,6 +10,19 @@ const NATIVE_EVENT_NAME = 'wheel';
 const PIXEL_MODE = 0;
 const DELTA_MUTLIPLIER = 30;
 
+enum DeltaMode {
+  DOM_DELTA_PIXEL = 0,
+  DOM_DELTA_LINE = 1,
+  DOM_DELTA_PAGE = 2,
+}
+
+interface WheelEvent {
+  deltaMode: DeltaMode;
+  deltaX: number;
+  deltaY: number;
+  deltaZ: number;
+}
+
 const wheel = {
   setup(element) {
     const $element = $(element);
@@ -23,9 +36,9 @@ const wheel = {
   _wheelHandler(e) {
     const {
       deltaMode, deltaY, deltaX, deltaZ,
-    } = e.originalEvent;
+    }: WheelEvent = e.originalEvent;
 
-    const delta = Math.abs(deltaY) > Math.abs(deltaX) ? deltaY : deltaX;
+    const delta = this._getWheelDelta(deltaY, deltaX, deltaZ);
 
     fireEvent({
       type: EVENT_NAME,
@@ -42,13 +55,32 @@ const wheel = {
     e.stopPropagation();
   },
 
-  _normalizeDelta(delta, deltaMode = PIXEL_MODE) {
+  _normalizeDelta(delta: number, deltaMode = PIXEL_MODE) {
     if (deltaMode === PIXEL_MODE) {
       return -delta;
     }
     // Use multiplier to get rough delta value in px for the LINE or PAGE mode
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1392460
-    return -DELTA_MUTLIPLIER * delta;
+    return -delta * DELTA_MUTLIPLIER;
+  },
+
+  /* https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event
+  * wheelDelta - is deprecated.
+  * Use deltaX, deltaY, and deltaZ instead.
+  *
+  * jQuery implementation of mousewheel event.
+  * https://github.com/jquery/jquery-mousewheel/blob/main/src/jquery.mousewheel.js#L83
+  */
+  _getWheelDelta(deltaY: number, deltaX: number, deltaZ: number) {
+    if (deltaY) {
+      return deltaY;
+    }
+
+    if (deltaX && deltaZ === 0) {
+      return deltaX;
+    }
+
+    return 0;
   },
 };
 

--- a/packages/devextreme/js/__internal/events/core/m_wheel.ts
+++ b/packages/devextreme/js/__internal/events/core/m_wheel.ts
@@ -25,11 +25,13 @@ const wheel = {
       deltaMode, deltaY, deltaX, deltaZ,
     } = e.originalEvent;
 
+    const delta = Math.abs(deltaY) > Math.abs(deltaX) ? deltaY : deltaX;
+
     fireEvent({
       type: EVENT_NAME,
       originalEvent: e,
       // @ts-expect-error
-      delta: this._normalizeDelta(deltaY, deltaMode),
+      delta: this._normalizeDelta(delta, deltaMode),
       deltaX,
       deltaY,
       deltaZ,

--- a/packages/devextreme/js/__internal/events/core/m_wheel.ts
+++ b/packages/devextreme/js/__internal/events/core/m_wheel.ts
@@ -8,7 +8,7 @@ const EVENT_NAMESPACE = 'dxWheel';
 const NATIVE_EVENT_NAME = 'wheel';
 
 const PIXEL_MODE = 0;
-const DELTA_MUTLIPLIER = 30;
+const DELTA_MULTIPLIER = 30;
 
 enum DeltaMode {
   DOM_DELTA_PIXEL = 0,
@@ -38,7 +38,7 @@ const wheel = {
       deltaMode, deltaY, deltaX, deltaZ,
     }: WheelEvent = e.originalEvent;
 
-    const delta = this._getWheelDelta(deltaY, deltaX, deltaZ);
+    const delta = this._getWheelDelta(deltaY, deltaX);
 
     fireEvent({
       type: EVENT_NAME,
@@ -61,15 +61,15 @@ const wheel = {
     }
     // Use multiplier to get rough delta value in px for the LINE or PAGE mode
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1392460
-    return -delta * DELTA_MUTLIPLIER;
+    return -delta * DELTA_MULTIPLIER;
   },
 
-  _getWheelDelta(deltaY: number, deltaX: number, deltaZ: number) {
+  _getWheelDelta(deltaY: number, deltaX: number) {
     if (deltaY) {
       return deltaY;
     }
 
-    if (deltaX && deltaZ === 0) {
+    if (deltaX) {
       return deltaX;
     }
 

--- a/packages/devextreme/testing/tests/DevExpress.ui.events/wheel.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.events/wheel.tests.js
@@ -79,3 +79,25 @@ QUnit.test('normalize delta for deltaMode LINE and PAGE', function(assert) {
     assert.strictEqual(wheelHandler.firstCall.args[0].delta, DELTA * DELTA_MULTIPLIER);
     assert.strictEqual(wheelHandler.lastCall.args[0].delta, DELTA * DELTA_MULTIPLIER);
 });
+
+QUnit.test('_getWheelDelta handles different delta combinations correctly', function(assert) {
+    const $element = $('#test');
+    const mouse = nativePointerMock($element).start();
+    let eventArgs;
+
+    $element.on(wheelEvent.name, function(e) {
+        eventArgs = e;
+    });
+
+    mouse.wheel(10, { deltaY: 10, deltaX: 5, deltaZ: 0 });
+    assert.strictEqual(eventArgs.delta, -10, 'vertical scroll should use deltaY');
+
+    mouse.wheel(10, { deltaY: 0, deltaX: 5, deltaZ: 0 });
+    assert.strictEqual(eventArgs.delta, -5, 'horizontal scroll should use deltaX when deltaZ is 0');
+
+    mouse.wheel(10, { deltaY: 0, deltaX: 5, deltaZ: 1 });
+    assert.strictEqual(eventArgs.delta, 0, 'should return 0 when deltaX present but deltaZ is not 0');
+
+    mouse.wheel(10, { deltaY: 0, deltaX: 0, deltaZ: 0 });
+    assert.strictEqual(eventArgs.delta, 0, 'should return 0 when no delta values present');
+});

--- a/packages/devextreme/testing/tests/DevExpress.ui.events/wheel.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.events/wheel.tests.js
@@ -95,9 +95,6 @@ QUnit.test('_getWheelDelta handles different delta combinations correctly', func
     mouse.wheel(0, { deltaY: 0, deltaX: 5, deltaZ: 0 });
     assert.strictEqual(eventArgs.delta, -5, 'horizontal scroll should use deltaX when deltaZ is 0');
 
-    mouse.wheel(0, { deltaY: 0, deltaX: 5, deltaZ: 1 });
-    assert.strictEqual(eventArgs.delta, 0, 'should return 0 when deltaX present but deltaZ is not 0');
-
     mouse.wheel(0, { deltaY: 0, deltaX: 0, deltaZ: 0 });
     assert.strictEqual(eventArgs.delta, 0, 'should return 0 when no delta values present');
 });

--- a/packages/devextreme/testing/tests/DevExpress.ui.events/wheel.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.events/wheel.tests.js
@@ -89,12 +89,12 @@ QUnit.test('_getWheelDelta handles different delta combinations correctly', func
         eventArgs = e;
     });
 
-    mouse.wheel(0, { deltaY: 10, deltaX: 5, deltaZ: 0 });
+    mouse.wheel(10, { deltaX: 5, deltaZ: 0 });
     assert.strictEqual(eventArgs.delta, -10, 'vertical scroll should use deltaY');
 
-    mouse.wheel(0, { deltaY: 0, deltaX: 5, deltaZ: 0 });
-    assert.strictEqual(eventArgs.delta, -5, 'horizontal scroll should use deltaX when deltaZ is 0');
+    mouse.wheel(0, { deltaX: 5, deltaZ: 0 });
+    assert.strictEqual(eventArgs.delta, -5, 'horizontal scroll should use deltaX when deltaY is 0');
 
-    mouse.wheel(0, { deltaY: 0, deltaX: 0, deltaZ: 0 });
-    assert.strictEqual(eventArgs.delta, 0, 'should return 0 when no delta values present');
+    mouse.wheel(0, { deltaX: 0, deltaZ: 0 });
+    assert.strictEqual(eventArgs.delta, 0, 'should return 0 when all delta values are 0');
 });

--- a/packages/devextreme/testing/tests/DevExpress.ui.events/wheel.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.events/wheel.tests.js
@@ -89,15 +89,15 @@ QUnit.test('_getWheelDelta handles different delta combinations correctly', func
         eventArgs = e;
     });
 
-    mouse.wheel(10, { deltaY: 10, deltaX: 5, deltaZ: 0 });
+    mouse.wheel(0, { deltaY: 10, deltaX: 5, deltaZ: 0 });
     assert.strictEqual(eventArgs.delta, -10, 'vertical scroll should use deltaY');
 
-    mouse.wheel(10, { deltaY: 0, deltaX: 5, deltaZ: 0 });
+    mouse.wheel(0, { deltaY: 0, deltaX: 5, deltaZ: 0 });
     assert.strictEqual(eventArgs.delta, -5, 'horizontal scroll should use deltaX when deltaZ is 0');
 
-    mouse.wheel(10, { deltaY: 0, deltaX: 5, deltaZ: 1 });
+    mouse.wheel(0, { deltaY: 0, deltaX: 5, deltaZ: 1 });
     assert.strictEqual(eventArgs.delta, 0, 'should return 0 when deltaX present but deltaZ is not 0');
 
-    mouse.wheel(10, { deltaY: 0, deltaX: 0, deltaZ: 0 });
+    mouse.wheel(0, { deltaY: 0, deltaX: 0, deltaZ: 0 });
     assert.strictEqual(eventArgs.delta, 0, 'should return 0 when no delta values present');
 });

--- a/packages/devextreme/testing/tests/DevExpress.ui.events/wheel.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.events/wheel.tests.js
@@ -90,7 +90,7 @@ QUnit.test('_getWheelDelta handles different delta combinations correctly', func
     });
 
     mouse.wheel(10, { deltaX: 5, deltaZ: 0 });
-    assert.strictEqual(eventArgs.delta, -10, 'vertical scroll should use deltaY');
+    assert.strictEqual(eventArgs.delta, 10, 'vertical scroll should use deltaY');
 
     mouse.wheel(0, { deltaX: 5, deltaZ: 0 });
     assert.strictEqual(eventArgs.delta, -5, 'horizontal scroll should use deltaX when deltaY is 0');


### PR DESCRIPTION
…eltaX

<!--
Before you submit a pull request, review our contribution guidelines (CONTRIBUTING.md).

If your pull request contains a bug fix, its title should include "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What does the PR change?

This PR fixes the wheel event handling logic in DevExtreme to properly support horizontal scrolling with Shift+wheel combination and improves touchpad horizontal scroll support.
Previous behavior:
When holding Shift and scrolling the mouse wheel, horizontal scrolling didn't work because the system only used deltaY for the overall delta calculation, ignoring deltaX completely
Touchpad horizontal scrolling with Shift key didn't trigger the expected inversion behavior
Current behavior:
The system now compares the absolute values of both deltaX and deltaY and selects the one with the greater magnitude as the primary delta
This ensures that horizontal scroll events are properly detected and handled
New behavior (needs clarification if bug or feature):
Horizontal scrolling on touchpad now works and responds to scroll gestures

2. How did you achieve this?

Extracts both delta values: Gets both deltaX and deltaY from the original wheel event
Compares magnitudes: Uses Math.abs() to compare the absolute values of both deltas
Selects dominant direction: Chooses the delta with the larger magnitude as the primary scroll direction
Maintains existing normalization: The selected delta is then processed through the existing _normalizeDelta method

3. How can we verify these changes?

-->
