### PR TITLE
DataGrid - Refresh selectedItems on dataSource change when repaintChangesOnly=true (T1279797)

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/m_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/m_data_controller.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/method-signature-style */
 import ArrayStore from '@js/common/data/array_store';
 import { CustomStore } from '@js/common/data/custom_store';
 import $ from '@js/core/renderer';
@@ -607,7 +606,6 @@ export class DataController extends DataHelperMixin(modules.Controller) {
     this.pushed.fire(changes);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public fireError(...args: any[]) {
     this.dataErrorOccurred.fire(errors.Error.apply(errors, args));
   }
@@ -1640,7 +1638,7 @@ export class DataController extends DataHelperMixin(modules.Controller) {
     if (options === true) {
       options = { reload: true, changesOnly: true };
     } else if (!options) {
-      options = { lookup: true, selection: true, reload: true };
+      options = { reload: true, lookup: true };
     }
 
     const that = this;
@@ -1732,7 +1730,7 @@ export class DataController extends DataHelperMixin(modules.Controller) {
   /**
    * @extended: editing, virtual_scrolling
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   public reload(reload?, changesOnly?): any {
     return this._dataSource?.reload(reload, changesOnly);
   }

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
@@ -1855,6 +1855,7 @@ class EditingControllerImpl extends modules.ViewController {
     }
 
     when(dataController.refresh({
+      selection: isFullRefresh,
       reload: isFullRefresh,
       load: refreshMode === 'reshape',
       changesOnly: this.option('repaintChangesOnly'),

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
@@ -1855,7 +1855,6 @@ class EditingControllerImpl extends modules.ViewController {
     }
 
     when(dataController.refresh({
-      selection: isFullRefresh,
       reload: isFullRefresh,
       load: refreshMode === 'reshape',
       changesOnly: this.option('repaintChangesOnly'),

--- a/packages/devextreme/js/__internal/grids/grid_core/selection/m_selection.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/selection/m_selection.integration.test.ts
@@ -1,0 +1,106 @@
+import {
+  afterEach, describe, expect, it,
+} from '@jest/globals';
+import type { dxElementWrapper } from '@js/core/renderer';
+import $ from '@js/core/renderer';
+
+import type { Properties as DataGridProperties } from '../../../../ui/data_grid';
+import DataGrid from '../../../../ui/data_grid';
+
+const SELECTORS = {
+  gridContainer: '#gridContainer',
+  detailCell: 'dx-master-detail-cell',
+  detailContainer: 'dx-datagrid-master-detail-container',
+};
+
+const GRID_CONTAINER_ID = 'gridContainer';
+
+const createDataGrid = async (
+  options: DataGridProperties = {},
+): Promise<{ $container: dxElementWrapper; instance: DataGrid }> => new Promise((resolve) => {
+  const $container = $('<div>')
+    .attr('id', GRID_CONTAINER_ID)
+    .appendTo(document.body);
+
+  const instance = new DataGrid($container.get(0) as HTMLDivElement, options);
+
+  const contentReadyHandler = (): void => {
+    resolve({ $container, instance });
+    instance.off('contentReady', contentReadyHandler);
+  };
+
+  instance.on('contentReady', contentReadyHandler);
+});
+
+describe('GridCore master_detail', () => {
+  afterEach(() => {
+    const $container = $(SELECTORS.gridContainer);
+
+    const dataGrid = ($container as any).dxDataGrid('instance') as DataGrid;
+
+    dataGrid.dispose();
+    $container.remove();
+  });
+
+  describe('selectionChanged handler', () => {
+    [true, false].forEach((repaintChangesOnly) => {
+      it(`selectRowKeys are updated after refresh if selectedItem is not in dataSource anymore with repaintChangesOnly=${repaintChangesOnly}`, async () => {
+        const dataSource = [
+          { id: 1, name: 'Item 1' },
+          { id: 2, name: 'Item 2' },
+        ];
+
+        const { instance } = await createDataGrid({
+          dataSource,
+          columns: ['id', 'name'],
+          keyExpr: 'id',
+          selection: {
+            mode: 'single',
+          },
+          repaintChangesOnly: true,
+        });
+
+        await instance.selectRows([2], false);
+        expect(instance.getSelectedRowKeys()).toEqual([2]);
+
+        dataSource.splice(1, 1); // Remove the item with id 2
+
+        await instance.refresh(true);
+
+        expect(instance.getSelectedRowKeys()).toEqual([]);
+      });
+
+      it(`selectionChanged handler is not called after refresh if selectedItem still present in dataSource with repaintChangesOnly=${repaintChangesOnly}`, async () => {
+        const dataSource = [
+          { id: 1, name: 'Item 1' },
+          { id: 2, name: 'Item 2' },
+        ];
+
+        const { instance } = await createDataGrid({
+          dataSource,
+          columns: ['id', 'name'],
+          keyExpr: 'id',
+          selection: {
+            mode: 'single',
+          },
+          repaintChangesOnly,
+        });
+
+        let selectionChangedCount = 0;
+        instance.on('selectionChanged', () => {
+          selectionChangedCount += 1;
+        });
+
+        await instance.selectRows([1], false);
+        expect(instance.getSelectedRowKeys()).toEqual([1]);
+        expect(selectionChangedCount).toBe(1);
+
+        dataSource.splice(1, 1); // Remove the item with id 2
+        await instance.refresh(repaintChangesOnly);
+
+        expect(instance.getSelectedRowKeys()).toEqual([1]);
+        expect(selectionChangedCount).toBe(1);
+      });
+    });
+  });
+});

--- a/packages/devextreme/js/__internal/grids/grid_core/selection/m_selection.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/selection/m_selection.integration.test.ts
@@ -1,10 +1,11 @@
 import {
   afterEach, describe, expect, it,
 } from '@jest/globals';
+import { CustomStore } from '@js/common/data';
 import type { dxElementWrapper } from '@js/core/renderer';
 import $ from '@js/core/renderer';
 
-import type { Properties as DataGridProperties } from '../../../../ui/data_grid';
+import type { GridsEditRefreshMode, Properties as DataGridProperties } from '../../../../ui/data_grid';
 import DataGrid from '../../../../ui/data_grid';
 
 const SELECTORS = {
@@ -32,7 +33,7 @@ const createDataGrid = async (
   instance.on('contentReady', contentReadyHandler);
 });
 
-describe('GridCore master_detail', () => {
+describe('GridCore selection', () => {
   afterEach(() => {
     const $container = $(SELECTORS.gridContainer);
 
@@ -102,5 +103,74 @@ describe('GridCore master_detail', () => {
         expect(selectionChangedCount).toBe(1);
       });
     });
+  });
+
+  describe('remote dataSource', () => {
+    ([
+      { refreshMode: 'full', expectedCallCount: 2 },
+      { refreshMode: 'reshape', expectedCallCount: 1 },
+      { refreshMode: 'repaint', expectedCallCount: 0 },
+    ] as { refreshMode: GridsEditRefreshMode; expectedCallCount: number }[])
+      .forEach(({ refreshMode, expectedCallCount }) => {
+        it(`dataSource.load is not called to load selectedRow after data save with editing.refreshMode=${refreshMode}`, async () => {
+          let data = [
+            { id: 1, name: 'Item 1' },
+            { id: 2, name: 'Item 2' },
+            { id: 3, name: 'Item 3' },
+            { id: 4, name: 'Item 4' },
+          ];
+
+          const store = new CustomStore({
+            key: 'id',
+            load: (e) => {
+              const skip = e.skip ?? 0;
+              const take = e.take ?? data.length;
+              const pageData = data.slice(skip, skip + take);
+              return Promise.resolve({
+                data: pageData,
+                totalCount: data.length,
+              });
+            },
+            remove(key) {
+              data = data.filter((item) => item.id !== key);
+              return Promise.resolve();
+            },
+          });
+
+          const { instance } = await createDataGrid({
+            dataSource: store,
+            editing: {
+              mode: 'batch',
+              refreshMode,
+              allowDeleting: true,
+            },
+            remoteOperations: true,
+            paging: {
+              pageSize: 2,
+            },
+            columns: ['id', 'name'],
+            keyExpr: 'id',
+            selection: {
+              mode: 'multiple',
+              showCheckBoxesMode: 'always',
+            },
+          });
+
+          await instance.selectRows([4], false);
+
+          let callCount = 0;
+          store.on('loading', () => {
+            callCount += 1;
+          });
+
+          instance.option('editing.changes', [{
+            type: 'remove',
+            key: 1,
+          }]);
+          await instance.saveEditData();
+
+          expect(callCount).toBe(expectedCallCount);
+        });
+      });
   });
 });

--- a/packages/devextreme/js/__internal/grids/grid_core/selection/m_selection.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/selection/m_selection.integration.test.ts
@@ -57,7 +57,7 @@ describe('GridCore master_detail', () => {
           selection: {
             mode: 'single',
           },
-          repaintChangesOnly: true,
+          repaintChangesOnly,
         });
 
         await instance.selectRows([2], false);
@@ -76,6 +76,8 @@ describe('GridCore master_detail', () => {
           { id: 2, name: 'Item 2' },
         ];
 
+        let selectionChangedCount = 0;
+
         const { instance } = await createDataGrid({
           dataSource,
           columns: ['id', 'name'],
@@ -84,11 +86,9 @@ describe('GridCore master_detail', () => {
             mode: 'single',
           },
           repaintChangesOnly,
-        });
-
-        let selectionChangedCount = 0;
-        instance.on('selectionChanged', () => {
-          selectionChangedCount += 1;
+          onSelectionChanged: () => {
+            selectionChangedCount += 1;
+          },
         });
 
         await instance.selectRows([1], false);

--- a/packages/devextreme/js/__internal/grids/grid_core/selection/m_selection.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/selection/m_selection.integration.test.ts
@@ -65,7 +65,7 @@ describe('GridCore master_detail', () => {
 
         dataSource.splice(1, 1); // Remove the item with id 2
 
-        await instance.refresh(true);
+        await instance.refresh(repaintChangesOnly);
 
         expect(instance.getSelectedRowKeys()).toEqual([]);
       });

--- a/packages/devextreme/js/__internal/grids/grid_core/selection/m_selection.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/selection/m_selection.ts
@@ -11,7 +11,7 @@ import type { DeferredObj } from '@js/core/utils/deferred';
 import { Deferred } from '@js/core/utils/deferred';
 import { extend } from '@js/core/utils/extend';
 import { each } from '@js/core/utils/iterator';
-import { isDefined } from '@js/core/utils/type';
+import { isDefined, isObject } from '@js/core/utils/type';
 import errors from '@js/ui/widget/ui.errors';
 import supportUtils from '@ts/core/utils/m_support';
 import type { ColumnHeadersView } from '@ts/grids/grid_core/column_headers/m_column_headers';
@@ -654,6 +654,13 @@ export const dataSelectionExtenderMixin = (Base: ModuleType<DataController>) => 
     const d: DeferredObj<void> = new Deferred();
 
     super.refresh(options).done(() => {
+      const skipSelectionRefresh = isObject(options) && !(options as any).selection;
+
+      if (skipSelectionRefresh) {
+        d.resolve();
+        return;
+      }
+
       this._selectionController.refresh().done(d.resolve).fail(d.reject);
     }).fail(d.reject);
 

--- a/packages/devextreme/js/__internal/grids/grid_core/selection/m_selection.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/selection/m_selection.ts
@@ -649,17 +649,12 @@ export const dataSelectionExtenderMixin = (Base: ModuleType<DataController>) => 
     return dataItem;
   }
 
-  public refresh(options) {
-    const that = this;
+  public refresh(options): any {
     // @ts-expect-error
-    const d = new Deferred();
+    const d: DeferredObj<void> = new Deferred();
 
-    super.refresh.apply(this, arguments as any).done(() => {
-      if (!options || options.selection) {
-        that._selectionController.refresh().done(d.resolve).fail(d.reject);
-      } else {
-        d.resolve();
-      }
+    super.refresh(options).done(() => {
+      this._selectionController.refresh().done(d.resolve).fail(d.reject);
     }).fail(d.reject);
 
     return d.promise();

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/selection.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/selection.tests.js
@@ -1119,7 +1119,7 @@ QUnit.module('Selection', { beforeEach: setupSelectionModule, afterEach: teardow
         assert.strictEqual(selectionChangedCount, 2, 'selection changed raised');
     });
 
-    QUnit.test.skip('Not rise selectionChanged event on refresh with changesOnly', function(assert) {
+    QUnit.test('Rise selectionChanged event on refresh with changesOnly', function(assert) {
         let selectionChangedCount = 0;
 
         this.applyOptions({
@@ -1137,10 +1137,8 @@ QUnit.module('Selection', { beforeEach: setupSelectionModule, afterEach: teardow
         this.dataController.refresh(true);
 
         // assert
-
-        // Why we preserve in selectedRowKeys data that's not in dataSource anymore?
-        assert.deepEqual(this.selectionController.getSelectedRowKeys(), [{ name: 'Dan', age: 16 }, { name: 'Dmitry', age: 18 }]);
-        assert.strictEqual(selectionChangedCount, 1, 'selection changed is not raised');
+        assert.deepEqual(this.selectionController.getSelectedRowKeys(), [{ name: 'Dan', age: 16 }]);
+        assert.strictEqual(selectionChangedCount, 2, 'selection changed is raised');
     });
 
     QUnit.test('Not rise selectionChanged event on apply filter when selectedRows count not changed', function(assert) {

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/selection.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/selection.tests.js
@@ -1119,7 +1119,7 @@ QUnit.module('Selection', { beforeEach: setupSelectionModule, afterEach: teardow
         assert.strictEqual(selectionChangedCount, 2, 'selection changed raised');
     });
 
-    QUnit.test('Not rise selectionChanged event on refresh with changesOnly', function(assert) {
+    QUnit.test.skip('Not rise selectionChanged event on refresh with changesOnly', function(assert) {
         let selectionChangedCount = 0;
 
         this.applyOptions({
@@ -1137,6 +1137,8 @@ QUnit.module('Selection', { beforeEach: setupSelectionModule, afterEach: teardow
         this.dataController.refresh(true);
 
         // assert
+
+        // Why we preserve in selectedRowKeys data that's not in dataSource anymore?
         assert.deepEqual(this.selectionController.getSelectedRowKeys(), [{ name: 'Dan', age: 16 }, { name: 'Dmitry', age: 18 }]);
         assert.strictEqual(selectionChangedCount, 1, 'selection changed is not raised');
     });
@@ -2052,7 +2054,7 @@ QUnit.module('ChangeRowSelection for multiple selection. DataSource with key', {
         this.selectionController.changeItemSelection(3, { shift: true });
 
         // assert
-        assert.deepEqual(this.selectionController.getSelectedRowKeys(), [2, 4, 3], 'selectedRowKeys');
+        assert.deepEqual(this.selectionController.getSelectedRowKeys(), [2, 3, 4], 'selectedRowKeys');
     });
 
     // T547950


### PR DESCRIPTION
<!--
Before you submit a pull request, review our contribution guidelines (CONTRIBUTING.md).

If your pull request contains a bug fix, its title should include "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What does the PR change?
2. How did you achieve this?
3. How can we verify these changes?

-->
