### PR TITLE
Splitter: prevent selection of pane content on double click on resize handler (T1302984) (#30656)

### DIFF
--- a/packages/devextreme-scss/scss/widgets/base/splitter/_index.scss
+++ b/packages/devextreme-scss/scss/widgets/base/splitter/_index.scss
@@ -33,6 +33,7 @@
   align-items: center;
   gap: 8px;
   overflow: hidden;
+  user-select: none;
 
   .dx-resize-handle-collapse-prev-pane,
   .dx-resize-handle-collapse-next-pane {

--- a/packages/devextreme/js/__internal/ui/splitter/resize_handle.ts
+++ b/packages/devextreme/js/__internal/ui/splitter/resize_handle.ts
@@ -3,7 +3,7 @@ import { name as CLICK_EVENT } from '@js/common/core/events/click';
 import eventsEngine from '@js/common/core/events/core/events_engine';
 import { name as DOUBLE_CLICK_EVENT } from '@js/common/core/events/double_click';
 import { end as dragEventEnd, move as dragEventMove, start as dragEventStart } from '@js/common/core/events/drag';
-import { addNamespace, isCommandKeyPressed } from '@js/common/core/events/utils/index';
+import { addNamespace, isCommandKeyPressed } from '@js/common/core/events/utils';
 import messageLocalization from '@js/common/core/localization/message';
 import Guid from '@js/core/guid';
 import type { dxElementWrapper } from '@js/core/renderer';

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets/splitter.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets/splitter.tests.js
@@ -34,7 +34,7 @@ QUnit.testStart(() => {
                 border: 10px solid black;
             }
         </style>
-        
+
         <div id="splitter"></div>
         <div id="splitterParentContainer">
             <div id="splitterInContainer"></div>


### PR DESCRIPTION
Cherry-pick of #30656 
