### PR TITLE
devextreme-quill: bump to 1.7.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ catalogs:
       specifier: 4.1.62
       version: 4.1.62
     devextreme-quill:
-      specifier: 1.7.3
-      version: 1.7.3
+      specifier: 1.7.4
+      version: 1.7.4
     eslint:
       specifier: 9.18.0
       version: 9.18.0
@@ -376,7 +376,7 @@ importers:
         version: 4.4.2
       devextreme-quill:
         specifier: 'catalog:'
-        version: 1.7.3
+        version: 1.7.4
       devextreme-react:
         specifier: workspace:*
         version: link:../../packages/devextreme-react/npm
@@ -1031,7 +1031,7 @@ importers:
         version: link:../../packages/devextreme/artifacts/npm/devextreme-dist
       devextreme-quill:
         specifier: 'catalog:'
-        version: 1.7.3
+        version: 1.7.4
       devextreme-react:
         specifier: workspace:~
         version: link:../../packages/devextreme-react/npm
@@ -1170,7 +1170,7 @@ importers:
         version: 4.1.62
       devextreme-quill:
         specifier: 'catalog:'
-        version: 1.7.3
+        version: 1.7.4
       inferno:
         specifier: 'catalog:'
         version: 8.2.3
@@ -10070,8 +10070,8 @@ packages:
     engines: {node: '>=12.0.0'}
     hasBin: true
 
-  devextreme-quill@1.7.3:
-    resolution: {integrity: sha512-YPE9e8UOOByf/QUBAGZRmCDHFzQDnM+hyPet6vFNFGm2UsJAIz4xkL6gDhfan/a6otInQUB5wLsbPZqldZrliQ==}
+  devextreme-quill@1.7.4:
+    resolution: {integrity: sha512-Jb8rkK/frapLCZjQuVszyQdDSpJd7L84Zpym5c4KNS3oCDe8idXGaeRG1JP1rE5g2HjHTVQDwKBT1nOwMyCpkw==}
 
   devextreme-schematics@1.7.1:
     resolution: {integrity: sha512-K+FNrji2/G7QPkfWYhWiNNaXcmxdlXDTOVpIiISoMr6fumRhz5PindoIYlOx0HXtnpvcBWzb2Fqadujr8qop2g==}
@@ -30869,7 +30869,7 @@ snapshots:
       winston: 3.10.0
       yargs: 17.7.2
 
-  devextreme-quill@1.7.3:
+  devextreme-quill@1.7.4:
     dependencies:
       core-js: 3.39.0
       eventemitter3: 4.0.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ catalog:
   inferno-server: ^8.2.3
   devexpress-diagram: 2.2.19
   devexpress-gantt: 4.1.62
-  devextreme-quill: 1.7.3
+  devextreme-quill: 1.7.4
   eslint: 9.18.0
   eslint-config-airbnb-typescript: 18.0.0
   eslint-plugin-i18n: 2.4.0


### PR DESCRIPTION
Release details - https://github.com/DevExpress/devextreme-quill/releases/tag/1.7.4
Main fixes:
- https://github.com/DevExpress/devextreme-quill/pull/141
- https://github.com/DevExpress/devextreme-quill/pull/142
- https://github.com/DevExpress/devextreme-quill/pull/136 as a subtask for T1295949