### PR TITLE
MenuBase: refactor _updateSelectedItems method

### DIFF
--- a/packages/devextreme/js/__internal/ui/context_menu/menu_base.ts
+++ b/packages/devextreme/js/__internal/ui/context_menu/menu_base.ts
@@ -737,7 +737,6 @@ class MenuBase<
             this._toggleItemSelection(selectedNode, false);
           }
           this._toggleItemSelection(node, true);
-          this._updateSelectedItems();
         }
         break;
       }
@@ -779,25 +778,24 @@ class MenuBase<
     return result;
   }
 
-  // @ts-expect-error ts-error
-  _updateSelectedItems(
-    oldSelection?: Item,
-    newSelection?: Item | null,
+  _updateSelectedItem(
+    addedItem?: Item | null,
+    removedItem?: Item,
   ): void {
-    if (oldSelection || newSelection) {
-      this._fireSelectionChangeEvent(newSelection, oldSelection);
+    if (addedItem || removedItem) {
+      this._fireSelectionChangeEvent(addedItem, removedItem);
     }
   }
 
   _fireSelectionChangeEvent(
-    addedSelection: Item | null | undefined,
-    removedSelection: Item | undefined,
+    addedItem?: Item | null,
+    removedItem?: Item,
   ): void {
     this._createActionByOption('onSelectionChanged', {
       excludeValidators: ['disabled', 'readOnly'],
     })({
-      addedItems: [addedSelection],
-      removedItems: [removedSelection],
+      addedItems: [addedItem],
+      removedItems: [removedItem],
     });
   }
 
@@ -816,7 +814,7 @@ class MenuBase<
         this._toggleItemSelection(selectedNode, false);
       }
       this._toggleItemSelection(node, true);
-      this._updateSelectedItems(selectedItem, itemData);
+      this._updateSelectedItem(itemData, selectedItem);
       this._setOptionWithoutOptionChange('selectedItem', itemData);
     }
   }
@@ -828,7 +826,7 @@ class MenuBase<
 
     if (node?.internalFields.selected) {
       this._toggleItemSelection(node, false);
-      this._updateSelectedItems(selectedItem, null);
+      this._updateSelectedItem(null, selectedItem);
       this._setOptionWithoutOptionChange('selectedItem', null);
     }
   }

--- a/packages/devextreme/js/__internal/ui/context_menu/menu_base.ts
+++ b/packages/devextreme/js/__internal/ui/context_menu/menu_base.ts
@@ -778,6 +778,8 @@ class MenuBase<
     return result;
   }
 
+  _updateSelectedItems(): void {}
+
   _updateSelectedItem(
     addedItem?: Item | null,
     removedItem?: Item,

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets/menuBase.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets/menuBase.tests.js
@@ -1043,16 +1043,19 @@ QUnit.module('Selection', () => {
             selectByClick: true,
             onSelectionChanged: selectionChangedHandler,
         });
+        const $items = menuBase.element.find(`.${DX_MENU_ITEM_CLASS}`);
+        const $item1 = $items.eq(0);
+        const $item2 = $items.eq(1);
 
-        const $item2 = menuBase.element.find('.' + DX_MENU_ITEM_CLASS).eq(1);
         $item2.trigger('dxclick');
-        assert.equal(selectionChangedHandler.callCount, 1, 'onSelectionChanged was called for the first time');
+
+        assert.strictEqual(selectionChangedHandler.callCount, 1, 'onSelectionChanged was called for the first time');
         assert.deepEqual(selectionChangedHandler.args[0][0].addedItems, [{ text: 'item2', selected: true }], 'onSelectionChanged is called with selected item as added item');
         assert.deepEqual(selectionChangedHandler.args[0][0].removedItems, [null], 'onSelectionChanged first called with null as removed item');
 
-        const $item1 = menuBase.element.find('.' + DX_MENU_ITEM_CLASS).eq(0);
         $item1.trigger('dxclick');
-        assert.equal(selectionChangedHandler.callCount, 2, 'onSelectionChanged was called for the second time');
+
+        assert.strictEqual(selectionChangedHandler.callCount, 2, 'onSelectionChanged was called for the second time');
         assert.deepEqual(selectionChangedHandler.args[1][0].addedItems, [{ text: 'item1', selected: true }], 'onSelectionChanged is called with selected item as added item');
         assert.deepEqual(selectionChangedHandler.args[1][0].removedItems, [{ text: 'item2', selected: false }], 'onSelectionChanged is called with previously selected item as removed item');
     });
@@ -1069,15 +1072,17 @@ QUnit.module('Selection', () => {
             selectByClick: true,
             onSelectionChanged: selectionChangedHandler,
         });
+        const $item = menuBase.element.find(`.${DX_MENU_ITEM_CLASS}`).eq(1);
 
-        const $item = menuBase.element.find('.' + DX_MENU_ITEM_CLASS).eq(1);
         $item.trigger('dxclick');
-        assert.equal(selectionChangedHandler.callCount, 1, 'onSelectionChanged was called for the first time');
+
+        assert.strictEqual(selectionChangedHandler.callCount, 1, 'onSelectionChanged was called for the first time');
         assert.deepEqual(selectionChangedHandler.args[0][0].addedItems, [{ text: 'item2', selected: true }], 'onSelectionChanged was called with selected item as added item');
         assert.deepEqual(selectionChangedHandler.args[0][0].removedItems, [null], 'onSelectionChanged first called with null as removed item');
 
         $item.trigger('dxclick');
-        assert.equal(selectionChangedHandler.callCount, 2, 'onSelectionChanged was called for the second time');
+
+        assert.strictEqual(selectionChangedHandler.callCount, 2, 'onSelectionChanged was called for the second time');
         assert.deepEqual(selectionChangedHandler.args[1][0].addedItems, [null], 'onSelectionChanged was called with null as added item');
         assert.deepEqual(selectionChangedHandler.args[1][0].removedItems, [{ text: 'item2', selected: false }], 'onSelectionChanged was called with previously selected item as removed item');
     });

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets/menuBase.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets/menuBase.tests.js
@@ -1031,6 +1031,57 @@ QUnit.module('Selection', () => {
         $item.trigger('dxclick');
     });
 
+    QUnit.test('onSelectionChanged should have been called with correct arguments', function(assert) {
+        const items = [
+            { text: 'item1' },
+            { text: 'item2' },
+        ];
+        const selectionChangedHandler = sinon.stub();
+        const menuBase = createMenu({
+            items: items,
+            selectionMode: 'single',
+            selectByClick: true,
+            onSelectionChanged: selectionChangedHandler,
+        });
+
+        const $item2 = menuBase.element.find('.' + DX_MENU_ITEM_CLASS).eq(1);
+        $item2.trigger('dxclick');
+        assert.equal(selectionChangedHandler.callCount, 1, 'onSelectionChanged was called for the first time');
+        assert.deepEqual(selectionChangedHandler.args[0][0].addedItems, [{ text: 'item2', selected: true }], 'onSelectionChanged is called with selected item as added item');
+        assert.deepEqual(selectionChangedHandler.args[0][0].removedItems, [null], 'onSelectionChanged first called with null as removed item');
+
+        const $item1 = menuBase.element.find('.' + DX_MENU_ITEM_CLASS).eq(0);
+        $item1.trigger('dxclick');
+        assert.equal(selectionChangedHandler.callCount, 2, 'onSelectionChanged was called for the second time');
+        assert.deepEqual(selectionChangedHandler.args[1][0].addedItems, [{ text: 'item1', selected: true }], 'onSelectionChanged is called with selected item as added item');
+        assert.deepEqual(selectionChangedHandler.args[1][0].removedItems, [{ text: 'item2', selected: false }], 'onSelectionChanged is called with previously selected item as removed item');
+    });
+
+    QUnit.test('onSelectionChanged should have been called with correct arguments on unselect', function(assert) {
+        const items = [
+            { text: 'item1' },
+            { text: 'item2' },
+        ];
+        const selectionChangedHandler = sinon.stub();
+        const menuBase = createMenu({
+            items: items,
+            selectionMode: 'single',
+            selectByClick: true,
+            onSelectionChanged: selectionChangedHandler,
+        });
+
+        const $item = menuBase.element.find('.' + DX_MENU_ITEM_CLASS).eq(1);
+        $item.trigger('dxclick');
+        assert.equal(selectionChangedHandler.callCount, 1, 'onSelectionChanged was called for the first time');
+        assert.deepEqual(selectionChangedHandler.args[0][0].addedItems, [{ text: 'item2', selected: true }], 'onSelectionChanged was called with selected item as added item');
+        assert.deepEqual(selectionChangedHandler.args[0][0].removedItems, [null], 'onSelectionChanged first called with null as removed item');
+
+        $item.trigger('dxclick');
+        assert.equal(selectionChangedHandler.callCount, 2, 'onSelectionChanged was called for the second time');
+        assert.deepEqual(selectionChangedHandler.args[1][0].addedItems, [null], 'onSelectionChanged was called with null as added item');
+        assert.deepEqual(selectionChangedHandler.args[1][0].removedItems, [{ text: 'item2', selected: false }], 'onSelectionChanged was called with previously selected item as removed item');
+    });
+
     QUnit.test('Prevent selection item on click', function(assert) {
         const items = [
             { text: 'item1' },


### PR DESCRIPTION
_updateSelectedItems in menu_base had 1purpose to call _fireSelectionChangeEvent if needed
since it does not take collections as arguments, its name was changed to _updateSelectedItem and the order of old/new items was changed, to correspond to the same params in _fireSelectionChangeEvent method

added tests to ensure that resulted onSelectionChanged is called with the same arguments as before this changes