### PR TITLE
Make scheduler template doctags consistent

### DIFF
--- a/packages/devextreme/js/ui/scheduler.d.ts
+++ b/packages/devextreme/js/ui/scheduler.d.ts
@@ -446,6 +446,7 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
     /**
      * @docid
      * @default "appointmentCollector"
+     * @type_function_param1 data:{ui/scheduler:AppointmentCollectorTemplateData}
      * @public
      */
     appointmentCollectorTemplate?: template | ((data: AppointmentCollectorTemplateData, collectorElement: DxElement) => string | UserDefinedElement);
@@ -514,8 +515,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
      * @docid
      * @default "item"
      * @type_function_param1 model:{ui/scheduler:AppointmentTemplateData}
-     * @type_function_param1_field appointmentData:object
-     * @type_function_param1_field targetedAppointmentData:object
      * @public
      */
     appointmentTemplate?: template | ((model: AppointmentTemplateData, itemIndex: number, contentElement: DxElement) => string | UserDefinedElement);
@@ -523,8 +522,6 @@ export interface dxSchedulerOptions extends WidgetOptions<dxScheduler> {
      * @docid
      * @default "appointmentTooltip"
      * @type_function_param1 model:{ui/scheduler:AppointmentTooltipTemplateData}
-     * @type_function_param1_field appointmentData:object
-     * @type_function_param1_field targetedAppointmentData:object
      * @public
      */
     appointmentTooltipTemplate?: template | ((model: AppointmentTooltipTemplateData, itemIndex: number, contentElement: DxElement) => string | UserDefinedElement);


### PR DESCRIPTION
Appointment collector template doc tags differ from other appointment templates. `@type_function_param1_field` doc tags can be removed as they were used as a temporary fix.

These changes have no impact on wrappers, as all templates are constrained to the `any` type.

But they will affect doc generation by adding detailed view of `AppointmentCollectorTemplateData` type ([similar to other templates](https://js.devexpress.com/Angular/Documentation/ApiReference/UI_Components/dxScheduler/Configuration/#appointmentTemplate))

DocGen result: https://github.com/DevExpress/devextreme-documentation/pull/7850