### PR TITLE
Scheduler: remove exceptionDate from appointment settings

### DIFF
--- a/packages/devextreme/js/__internal/scheduler/view_model/generate_view_model/m_settings_generator.ts
+++ b/packages/devextreme/js/__internal/scheduler/view_model/generate_view_model/m_settings_generator.ts
@@ -170,8 +170,6 @@ export class DateGeneratorBaseStrategy {
 
       return {
         ...item,
-        // TODO: Check usages & delete this field.
-        exceptionDate: new Date(item.startDate),
       };
     });
 
@@ -238,8 +236,6 @@ export class DateGeneratorBaseStrategy {
         ...item,
         startDate: newStartDate,
         endDate: newEndDate,
-        // TODO: Check usages & delete this field.
-        exceptionDate: new Date(newStartDate),
       };
     });
   }
@@ -321,7 +317,6 @@ export class DateGeneratorBaseStrategy {
       if (offsetDifference !== 0 && this._canProcessNotNativeTimezoneDates(appointmentAdapter)) {
         source.startDate = dateUtilsTs.addOffsets(source.startDate, [offsetDifference * toMs('minute')]);
         source.endDate = dateUtilsTs.addOffsets(source.endDate, [offsetDifference * toMs('minute')]);
-        source.exceptionDate = new Date(source.startDate);
       }
 
       const duration = source.endDate.getTime() - source.startDate.getTime();


### PR DESCRIPTION
Closes issue 742.
The goal of this task is to remove unused property "exceptionDate" from appointment settings (based on todos)
