### PR TITLE
Rename devextreme-metadata nx target build -> generate

### DIFF
--- a/packages/devextreme-angular/project.json
+++ b/packages/devextreme-angular/project.json
@@ -34,7 +34,7 @@
     },
     "regenerate": {
       "executor": "nx:run-script",
-      "dependsOn": ["devextreme-metadata:build"],
+      "dependsOn": ["devextreme-metadata:generate"],
       "options": {
         "script": "regenerate"
       }

--- a/packages/devextreme-metadata/project.json
+++ b/packages/devextreme-metadata/project.json
@@ -69,7 +69,7 @@
         "{projectRoot}/dist/integration-data.json"
       ]
     },
-    "build": {
+    "generate": {
       "dependsOn": [
         "make-angular-metadata",
         "make-aspnet-metadata",
@@ -82,7 +82,7 @@
       ]
     },
     "pack": {
-      "dependsOn": ["build"],
+      "dependsOn": ["generate"],
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",

--- a/packages/devextreme-react/project.json
+++ b/packages/devextreme-react/project.json
@@ -33,7 +33,7 @@
     },
     "regenerate": {
       "executor": "nx:run-script",
-      "dependsOn": ["devextreme-metadata:build"],
+      "dependsOn": ["devextreme-metadata:generate"],
       "options": {
         "script": "regenerate"
       }

--- a/packages/devextreme-vue/project.json
+++ b/packages/devextreme-vue/project.json
@@ -19,7 +19,7 @@
     },
     "regenerate": {
       "executor": "nx:run-script",
-      "dependsOn": ["devextreme-metadata:build"],
+      "dependsOn": ["devextreme-metadata:generate"],
       "options": {
         "script": "regenerate"
       }


### PR DESCRIPTION
`Build` targets are used as a default in main [nx.json](https://github.com/DevExpress/DevExtreme/blob/25_2/nx.json#L15) config for all dependencies. For example, dep graph `react-playground -> devextreme-react -> devextreme` means that by default we run `build` targets for devextreme and devextreme-react before running `build` for playground. This is a correct behavior and we should not override it in package/app configs. 

But devextreme-metadata generation (current `build` target) is something different. We don't need metadata to be generated except for `regenerate` wrappers' scripts. Builds should not depend on it at all. I think the best solution will be to rename target to avoid misunderstanding.