### PR TITLE
Widget: get rid of using _activeStateUnit, _feedbackHideTimeout, _feedbackShowTimeout as class member

### DIFF
--- a/packages/devextreme/js/__internal/core/widget/widget.ts
+++ b/packages/devextreme/js/__internal/core/widget/widget.ts
@@ -31,6 +31,10 @@ export const FOCUSED_STATE_CLASS = 'dx-state-focused';
 export const HOVER_STATE_CLASS = 'dx-state-hover';
 const INVISIBLE_STATE_CLASS = 'dx-state-invisible';
 
+const EMPTY_ACTIVE_STATE_UNIT = '';
+const DEFAULT_FEEDBACK_HIDE_TIMEOUT = 400;
+const DEFAULT_FEEDBACK_SHOW_TIMEOUT = 30;
+
 export type SupportedKeyHandler = (
   e: DxEvent<KeyboardEvent>,
   options?: KeyboardKeyDownEvent
@@ -70,12 +74,6 @@ export interface WidgetProperties<TComponent = any> extends WidgetOptions<TCompo
 class Widget<
   TProperties extends WidgetProperties = WidgetProperties,
 > extends DOMComponent<Widget<TProperties>, TProperties> {
-  public _activeStateUnit!: string;
-
-  public _feedbackHideTimeout = 400;
-
-  private readonly _feedbackShowTimeout: number = 30;
-
   _contentReadyAction?: ((event?: Record<string, unknown>) => void) | null;
 
   protected _keyboardListenerId?: string | null;
@@ -95,6 +93,18 @@ class Widget<
     }
 
     return options;
+  }
+
+  protected _activeStateUnit(): string {
+    return EMPTY_ACTIVE_STATE_UNIT;
+  }
+
+  protected _feedbackHideTimeout(): number {
+    return DEFAULT_FEEDBACK_HIDE_TIMEOUT;
+  }
+
+  protected _feedbackShowTimeout(): number {
+    return DEFAULT_FEEDBACK_SHOW_TIMEOUT;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -285,13 +295,13 @@ class Widget<
   }
 
   _findActiveTarget($element: dxElementWrapper): dxElementWrapper {
-    return $element.find(this._activeStateUnit).not(`.${DISABLED_STATE_CLASS}`);
+    return $element.find(this._activeStateUnit()).not(`.${DISABLED_STATE_CLASS}`);
   }
 
   _getActiveElement(): dxElementWrapper {
     const activeElement = this._eventBindingTarget();
 
-    if (this._activeStateUnit) {
+    if (this._activeStateUnit()) {
       return this._findActiveTarget(activeElement);
     }
 
@@ -434,7 +444,7 @@ class Widget<
 
   _attachHoverEvents(): void {
     const { hoverStateEnabled } = this.option();
-    const selector = this._activeStateUnit;
+    const selector = this._activeStateUnit();
     const namespace = 'UIFeedback';
     const $el = this._eventBindingTarget();
 
@@ -453,7 +463,7 @@ class Widget<
 
   _attachFeedbackEvents(): void {
     const { activeStateEnabled } = this.option();
-    const selector = this._activeStateUnit;
+    const selector = this._activeStateUnit();
     const namespace = 'UIFeedback';
     const $el = this._eventBindingTarget();
 
@@ -468,8 +478,8 @@ class Widget<
           { excludeValidators: ['disabled', 'readOnly'] },
         ),
         {
-          showTimeout: this._feedbackShowTimeout,
-          hideTimeout: this._feedbackHideTimeout,
+          showTimeout: this._feedbackShowTimeout(),
+          hideTimeout: this._feedbackHideTimeout(),
           selector,
           namespace,
         },
@@ -521,7 +531,7 @@ class Widget<
   }
 
   _findHoverTarget($el?: dxElementWrapper): dxElementWrapper | undefined {
-    return $el?.closest(this._activeStateUnit || this._eventBindingTarget());
+    return $el?.closest(this._activeStateUnit() || this._eventBindingTarget());
   }
 
   _hover($el: dxElementWrapper | undefined, $previous: dxElementWrapper | undefined): void {

--- a/packages/devextreme/js/__internal/core/widget/widget.ts
+++ b/packages/devextreme/js/__internal/core/widget/widget.ts
@@ -31,7 +31,7 @@ export const FOCUSED_STATE_CLASS = 'dx-state-focused';
 export const HOVER_STATE_CLASS = 'dx-state-hover';
 const INVISIBLE_STATE_CLASS = 'dx-state-invisible';
 
-const EMPTY_ACTIVE_STATE_UNIT = '';
+export const EMPTY_ACTIVE_STATE_UNIT = '';
 const DEFAULT_FEEDBACK_HIDE_TIMEOUT = 400;
 const DEFAULT_FEEDBACK_SHOW_TIMEOUT = 30;
 

--- a/packages/devextreme/js/__internal/grids/grid_core/m_widget_base.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/m_widget_base.ts
@@ -7,11 +7,14 @@ import Widget from '@js/ui/widget/ui.widget';
 const GRID_CORE_ROW_SELECTOR = '.dx-row';
 
 export default class GridCoreWidget<TProperties> extends Widget<TProperties> {
-  private _activeStateUnit;
-
   private readonly _controllers: any;
 
   private readonly _views: any;
+
+  // eslint-disable-next-line class-methods-use-this
+  protected _activeStateUnit(): string {
+    return GRID_CORE_ROW_SELECTOR;
+  }
 
   private _getDefaultOptions() {
     // @ts-expect-error
@@ -27,7 +30,6 @@ export default class GridCoreWidget<TProperties> extends Widget<TProperties> {
   }
 
   protected _init() {
-    this._activeStateUnit = GRID_CORE_ROW_SELECTOR;
     // @ts-expect-error
     super._init();
   }

--- a/packages/devextreme/js/__internal/scheduler/workspaces/m_agenda.ts
+++ b/packages/devextreme/js/__internal/scheduler/workspaces/m_agenda.ts
@@ -8,6 +8,7 @@ import dateUtils from '@js/core/utils/date';
 import { extend } from '@js/core/utils/extend';
 import { each } from '@js/core/utils/iterator';
 import { setHeight, setOuterHeight } from '@js/core/utils/size';
+import { EMPTY_ACTIVE_STATE_UNIT } from '@ts/core/widget/widget';
 
 import {
   DATE_TABLE_CLASS,
@@ -49,7 +50,7 @@ class SchedulerAgenda extends WorkSpace {
 
   // eslint-disable-next-line class-methods-use-this
   protected _activeStateUnit(): string {
-    return '';
+    return EMPTY_ACTIVE_STATE_UNIT;
   }
 
   get type() { return VIEWS.AGENDA; }

--- a/packages/devextreme/js/__internal/scheduler/workspaces/m_agenda.ts
+++ b/packages/devextreme/js/__internal/scheduler/workspaces/m_agenda.ts
@@ -47,6 +47,11 @@ class SchedulerAgenda extends WorkSpace {
 
   _$noDataContainer: any;
 
+  // eslint-disable-next-line class-methods-use-this
+  protected _activeStateUnit(): string {
+    return '';
+  }
+
   get type() { return VIEWS.AGENDA; }
 
   get renderingStrategy() { return (this.invoke as any)('getLayoutManager').getRenderingStrategyInstance(); }
@@ -57,7 +62,6 @@ class SchedulerAgenda extends WorkSpace {
 
   _init() {
     super._init();
-    this._activeStateUnit = undefined;
   }
 
   _getDefaultOptions() {

--- a/packages/devextreme/js/__internal/scheduler/workspaces/m_work_space.ts
+++ b/packages/devextreme/js/__internal/scheduler/workspaces/m_work_space.ts
@@ -273,8 +273,6 @@ class SchedulerWorkSpace extends Widget<WorkspaceOptionsInternal> {
 
   _$timePanel: any;
 
-  _activeStateUnit: any;
-
   positionHelper!: PositionHelper;
 
   _$headerPanelContainer: any;
@@ -312,6 +310,13 @@ class SchedulerWorkSpace extends Widget<WorkspaceOptionsInternal> {
   renovatedGroupPanel: any;
 
   renovatedHeaderPanel: any;
+
+  readonly viewDirection: 'vertical' | 'horizontal' = 'vertical';
+
+  // eslint-disable-next-line class-methods-use-this
+  protected _activeStateUnit(): string {
+    return CELL_SELECTOR;
+  }
 
   // eslint-disable-next-line @typescript-eslint/class-literal-property-style
   get type(): string {
@@ -382,8 +387,6 @@ class SchedulerWorkSpace extends Widget<WorkspaceOptionsInternal> {
   }
 
   get verticalGroupTableClass() { return WORKSPACE_VERTICAL_GROUP_TABLE_CLASS; }
-
-  readonly viewDirection: 'vertical' | 'horizontal' = 'vertical';
 
   get renovatedHeaderPanelComponent() { return HeaderPanelComponent; }
 
@@ -2436,7 +2439,6 @@ class SchedulerWorkSpace extends Widget<WorkspaceOptionsInternal> {
     this._scrollSync = {};
     this._viewDataProvider = null;
     this._cellsSelectionState = null;
-    this._activeStateUnit = CELL_SELECTOR;
 
     // @ts-expect-error
     super._init();

--- a/packages/devextreme/js/__internal/ui/accordion.ts
+++ b/packages/devextreme/js/__internal/ui/accordion.ts
@@ -53,6 +53,10 @@ class Accordion extends CollectionWidgetLiveUpdate<AccordionProperties, Item, Co
 
   _deferredItems!: DeferredObj<unknown>[];
 
+  protected _activeStateUnit(): string {
+    return `.${ACCORDION_ITEM_CLASS}`;
+  }
+
   _getDefaultOptions(): AccordionProperties {
     return {
       ...super._getDefaultOptions(),
@@ -101,7 +105,6 @@ class Accordion extends CollectionWidgetLiveUpdate<AccordionProperties, Item, Co
   _init(): void {
     super._init();
 
-    this._activeStateUnit = `.${ACCORDION_ITEM_CLASS}`;
     const { collapsible, multiple } = this.option();
 
     this.option('selectionRequired', !collapsible);

--- a/packages/devextreme/js/__internal/ui/calendar/calendar.ts
+++ b/packages/devextreme/js/__internal/ui/calendar/calendar.ts
@@ -155,6 +155,10 @@ class Calendar<
 
   _valueSelected?: boolean;
 
+  protected _activeStateUnit(): string {
+    return `.${CALENDAR_CELL_CLASS}`;
+  }
+
   _getDefaultOptions(): TProperties {
     return {
       ...super._getDefaultOptions(),
@@ -547,7 +551,6 @@ class Calendar<
   _init(): void {
     super._init();
 
-    this._activeStateUnit = `.${CALENDAR_CELL_CLASS}`;
     this._initSelectionStrategy();
     this._correctZoomLevel();
     this._initCurrentDate();

--- a/packages/devextreme/js/__internal/ui/collection/collection_widget.base.ts
+++ b/packages/devextreme/js/__internal/ui/collection/collection_widget.base.ts
@@ -179,6 +179,10 @@ class CollectionWidget<
     }) => void;
   };
 
+  protected _activeStateUnit(): string {
+    return `.${ITEM_CLASS}`;
+  }
+
   _supportedKeys(): SupportedKeys {
     const space = (e: DxEvent<KeyboardEvent>): void => {
       e.preventDefault();
@@ -281,8 +285,6 @@ class CollectionWidget<
     // @ts-expect-error ts-error
     this._initDataController();
     super._init();
-
-    this._activeStateUnit = `.${ITEM_CLASS}`;
 
     this._cleanRenderedItems();
     // @ts-expect-error ts-error
@@ -432,7 +434,7 @@ class CollectionWidget<
   }
 
   _findActiveTarget($element: dxElementWrapper): dxElementWrapper {
-    return $element.find(this._activeStateUnit);
+    return $element.find(this._activeStateUnit());
   }
 
   _getActiveItem(last?: boolean): dxElementWrapper {

--- a/packages/devextreme/js/__internal/ui/context_menu/menu_base.ts
+++ b/packages/devextreme/js/__internal/ui/context_menu/menu_base.ts
@@ -81,6 +81,10 @@ class MenuBase<
   // eslint-disable-next-line no-restricted-globals
   _showSubmenusTimeout?: ReturnType<typeof setTimeout>;
 
+  protected _activeStateUnit(): string {
+    return `.${ITEM_CLASS}`;
+  }
+
   _getDefaultOptions(): TProperties {
     return {
       ...super._getDefaultOptions(),
@@ -176,7 +180,6 @@ class MenuBase<
 
   _init(): void {
     super._init();
-    this._activeStateUnit = `.${ITEM_CLASS}`;
 
     this._renderSelectedItem();
     this._initActions();

--- a/packages/devextreme/js/__internal/ui/gallery.ts
+++ b/packages/devextreme/js/__internal/ui/gallery.ts
@@ -150,6 +150,10 @@ class Gallery extends CollectionWidget<GalleryProperties, Item, CollectionItemKe
 
   _$indicator?: dxElementWrapper;
 
+  protected _activeStateUnit(): string {
+    return GALLERY_ITEM_SELECTOR;
+  }
+
   _getDefaultOptions(): GalleryProperties {
     return {
       ...super._getDefaultOptions(),
@@ -196,7 +200,6 @@ class Gallery extends CollectionWidget<GalleryProperties, Item, CollectionItemKe
 
     const { loop } = this.option();
 
-    this._activeStateUnit = GALLERY_ITEM_SELECTOR;
     this.option('loopItemFocus', loop);
   }
 

--- a/packages/devextreme/js/__internal/ui/list/list.base.ts
+++ b/packages/devextreme/js/__internal/ui/list/list.base.ts
@@ -162,6 +162,10 @@ export class ListBase extends CollectionWidget<ListBaseProperties, Item> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   _selectionChangeEventInstance?: any;
 
+  protected _feedbackShowTimeout(): number {
+    return LIST_FEEDBACK_SHOW_TIMEOUT;
+  }
+
   _supportedKeys(): SupportedKeys {
     return {
       ...super._supportedKeys(),
@@ -495,7 +499,7 @@ export class ListBase extends CollectionWidget<ListBaseProperties, Item> {
     return true;
   }
 
-  _updateActiveStateUnit(): void {
+  protected _activeStateUnit(): string {
     const { collapsibleGroups } = this.option();
 
     const selectors = [
@@ -507,20 +511,17 @@ export class ListBase extends CollectionWidget<ListBaseProperties, Item> {
       selectors.push(`.${LIST_GROUP_HEADER_CLASS}`);
     }
 
-    this._activeStateUnit = selectors.join(',');
+    return selectors.join(',');
   }
 
   _init(): void {
     super._init();
 
-    this._updateActiveStateUnit();
     this._dataController.resetDataSourcePageIndex();
     this._$container = this.$element();
 
     this._$listContainer = $('<div>').addClass(LIST_ITEMS_CLASS);
     this._initScrollView();
-    // @ts-expect-error ts-error
-    this._feedbackShowTimeout = LIST_FEEDBACK_SHOW_TIMEOUT;
     this._createGroupRenderAction();
   }
 
@@ -1364,7 +1365,6 @@ export class ListBase extends CollectionWidget<ListBaseProperties, Item> {
         this._invalidate();
         break;
       case 'collapsibleGroups':
-        this._updateActiveStateUnit();
         this._invalidate();
         break;
       case 'wrapItemText':

--- a/packages/devextreme/js/__internal/ui/multi_view/multi_view.ts
+++ b/packages/devextreme/js/__internal/ui/multi_view/multi_view.ts
@@ -72,6 +72,10 @@ class MultiView<
 
   _itemWidthValue?: number;
 
+  protected _activeStateUnit(): string {
+    return `.${MULTIVIEW_ITEM_CLASS}`;
+  }
+
   _supportedKeys(): Record<string, (e: KeyboardEvent) => void> {
     return {
       ...super._supportedKeys(),
@@ -186,8 +190,6 @@ class MultiView<
 
   _init(): void {
     super._init();
-
-    this._activeStateUnit = `.${MULTIVIEW_ITEM_CLASS}`;
 
     const $element = this.$element();
 

--- a/packages/devextreme/js/__internal/ui/radio_group/m_radio_group.ts
+++ b/packages/devextreme/js/__internal/ui/radio_group/m_radio_group.ts
@@ -32,8 +32,19 @@ class RadioGroup extends Editor<RadioGroupProperties> {
 
   private _$submitElement!: dxElementWrapper;
 
-  _dataSourceOptions() {
+  // eslint-disable-next-line class-methods-use-this
+  _dataSourceOptions(): { paginate: boolean } {
     return { paginate: false };
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  protected _activeStateUnit(): string {
+    return `.${RADIO_BUTTON_CLASS}`;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  protected _feedbackHideTimeout(): number {
+    return RADIO_FEEDBACK_HIDE_TIMEOUT;
   }
 
   _defaultOptionsRules(): DefaultOptionsRule<RadioGroupProperties>[] {
@@ -88,8 +99,6 @@ class RadioGroup extends Editor<RadioGroupProperties> {
   _init(): void {
     super._init();
 
-    this._activeStateUnit = `.${RADIO_BUTTON_CLASS}`;
-    this._feedbackHideTimeout = RADIO_FEEDBACK_HIDE_TIMEOUT;
     // @ts-expect-error
     this._initDataExpressions();
   }

--- a/packages/devextreme/js/__internal/ui/slider/m_slider.ts
+++ b/packages/devextreme/js/__internal/ui/slider/m_slider.ts
@@ -77,6 +77,11 @@ class Slider<
 
   _startOffset?: number;
 
+  // eslint-disable-next-line class-methods-use-this
+  protected _activeStateUnit(): string {
+    return SLIDER_HANDLE_SELECTOR;
+  }
+
   _supportedKeys(): SupportedKeys {
     const { rtlEnabled } = this.option();
 
@@ -186,12 +191,6 @@ class Slider<
       focusStateEnabled: true,
       valueChangeMode: 'onHandleMove',
     };
-  }
-
-  _init(): void {
-    super._init();
-
-    this._activeStateUnit = SLIDER_HANDLE_SELECTOR;
   }
 
   _toggleValidationMessage(visible: boolean): void {

--- a/packages/devextreme/js/__internal/ui/switch.ts
+++ b/packages/devextreme/js/__internal/ui/switch.ts
@@ -55,6 +55,10 @@ class Switch extends Editor<Properties> {
 
   _clickAction?: (event?: Record<string, unknown>) => void;
 
+  protected _feedbackHideTimeout(): number {
+    return 0;
+  }
+
   _supportedKeys(): SupportedKeys {
     const { rtlEnabled } = this.option();
 
@@ -111,7 +115,6 @@ class Switch extends Editor<Properties> {
   _init(): void {
     super._init();
 
-    this._feedbackHideTimeout = 0;
     this._animating = false;
   }
 

--- a/packages/devextreme/js/__internal/ui/tabs/tabs.ts
+++ b/packages/devextreme/js/__internal/ui/tabs/tabs.ts
@@ -153,6 +153,14 @@ class Tabs extends CollectionWidgetLiveUpdate<TabsProperties> {
 
   _$wrapper!: dxElementWrapper;
 
+  protected _activeStateUnit(): string {
+    return `.${TABS_ITEM_CLASS}`;
+  }
+
+  protected _feedbackHideTimeout(): number {
+    return FEEDBACK_HIDE_TIMEOUT;
+  }
+
   _getDefaultOptions(): TabsProperties {
     return {
       ...super._getDefaultOptions(),
@@ -231,7 +239,6 @@ class Tabs extends CollectionWidgetLiveUpdate<TabsProperties> {
 
     super._init();
 
-    this._activeStateUnit = `.${TABS_ITEM_CLASS}`;
     this.setAria('role', 'tablist');
     this.$element().addClass(TABS_CLASS);
     this._toggleScrollingEnabledClass(scrollingEnabled);
@@ -241,8 +248,6 @@ class Tabs extends CollectionWidgetLiveUpdate<TabsProperties> {
     this._toggleStylingModeClass(stylingMode);
     this._renderWrapper();
     this._renderMultiple();
-
-    this._feedbackHideTimeout = FEEDBACK_HIDE_TIMEOUT;
   }
 
   _prepareDefaultItemTemplate(data: Item, $container: dxElementWrapper): void {

--- a/packages/devextreme/js/__internal/ui/tile_view.ts
+++ b/packages/devextreme/js/__internal/ui/tile_view.ts
@@ -84,6 +84,10 @@ class TileView extends CollectionWidget<TileViewProperties> {
 
   _cells!: number[][];
 
+  protected _activeStateUnit(): string {
+    return TILEVIEW_ITEM_SELECTOR;
+  }
+
   _getDefaultOptions(): TileViewProperties {
     return {
       ...super._getDefaultOptions(),
@@ -135,8 +139,6 @@ class TileView extends CollectionWidget<TileViewProperties> {
 
   _init(): void {
     super._init();
-
-    this._activeStateUnit = TILEVIEW_ITEM_SELECTOR;
 
     this.$element().addClass(TILEVIEW_CLASS);
     this._initScrollView();

--- a/packages/devextreme/js/__internal/ui/toolbar/internal/toolbar.menu.list.ts
+++ b/packages/devextreme/js/__internal/ui/toolbar/internal/toolbar.menu.list.ts
@@ -19,12 +19,8 @@ const SCROLLVIEW_CONTENT_CLASS = 'dx-scrollview-content';
 
 type ActionableComponents = Extract<ToolbarItemComponent, 'dxButton' | 'dxButtonGroup'>;
 export default class ToolbarMenuList extends ListBase {
-  _activeStateUnit!: string;
-
-  _init(): void {
-    super._init();
-
-    this._activeStateUnit = `.${TOOLBAR_MENU_ACTION_CLASS}:not(.${TOOLBAR_HIDDEN_BUTTON_GROUP_CLASS})`;
+  protected _activeStateUnit(): string {
+    return `.${TOOLBAR_MENU_ACTION_CLASS}:not(.${TOOLBAR_HIDDEN_BUTTON_GROUP_CLASS})`;
   }
 
   _initMarkup(): void {

--- a/packages/devextreme/js/__internal/ui/tree_view/tree_view.base.ts
+++ b/packages/devextreme/js/__internal/ui/tree_view/tree_view.base.ts
@@ -121,6 +121,10 @@ class TreeViewBase extends HierarchicalCollectionWidget<TreeViewBaseProperties, 
 
   _selectAllValueChangedAction?: (event?: Record<string, unknown>) => void;
 
+  protected _activeStateUnit(): string {
+    return `.${ITEM_CLASS}`;
+  }
+
   _supportedKeys(): SupportedKeys {
     const click = (e: DxEvent<KeyboardEvent>): void => {
       const { focusedElement } = this.option();
@@ -506,8 +510,6 @@ class TreeViewBase extends HierarchicalCollectionWidget<TreeViewBaseProperties, 
   _init(): void {
     this._filter = {};
     super._init();
-
-    this._activeStateUnit = `.${ITEM_CLASS}`;
 
     this._initStoreChangeHandlers();
   }

--- a/packages/devextreme/testing/tests/DevExpress.knockout/collectionWidget.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.knockout/collectionWidget.tests.js
@@ -99,9 +99,12 @@ const ITEM_SELECTED_CLASS = 'dx-item-selected';
 class TestComponent extends CollectionWidget {
     ctor(element, options) {
         this.NAME = 'TestComponent';
-        this._activeStateUnit = '.item';
 
         super.ctor(element, options);
+    }
+
+    _activeStateUnit() {
+        return '.item';
     }
 
     _itemClass() {

--- a/packages/devextreme/testing/tests/DevExpress.ui/collectionWidget.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui/collectionWidget.tests.js
@@ -35,9 +35,9 @@ class TestComponent extends CollectionWidget {
     constructor(element, options) {
         super(element, options);
         this.NAME = 'TestComponent';
-        this._activeStateUnit = '.item';
     }
 
+    _activeStateUnit() { return '.item'; }
     _itemClass() { return ITEM_CUSTOM_CLASS; }
     _itemDataKey() { return '123'; }
     _itemContainer() { return this.$element(); }

--- a/packages/devextreme/testing/tests/DevExpress.ui/collectionWidgetParts/editingTests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui/collectionWidgetParts/editingTests.js
@@ -18,9 +18,9 @@ class TestComponent extends CollectionWidget {
     constructor(element, options) {
         super(element, options);
         this.NAME = 'TestComponent';
-        this._activeStateUnit = '.item';
     }
 
+    _activeStateUnit() { return '.item'; }
     _itemClass() { return 'item'; }
     _itemDataKey() { return '123'; }
     _itemContainer() { return this.$element(); }

--- a/packages/devextreme/testing/tests/DevExpress.ui/collectionWidgetParts/liveUpdateTests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui/collectionWidgetParts/liveUpdateTests.js
@@ -17,9 +17,9 @@ class TestComponent extends CollectionWidget {
     constructor(element, options) {
         super(element, options);
         this.NAME = 'TestComponent';
-        this._activeStateUnit = '.item';
     }
 
+    _activeStateUnit() { return '.item'; }
     _itemClass() { return 'item'; }
     _itemDataKey() { return '123'; }
     _itemContainer() { return this.$element(); }

--- a/packages/devextreme/testing/tests/DevExpress.ui/hierarchicalCollectionWidgetParts/hierarchicalCollectionWidget.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui/hierarchicalCollectionWidgetParts/hierarchicalCollectionWidget.js
@@ -10,8 +10,10 @@ class TestComponent extends HierarchicalCollectionWidget {
     constructor(element, options) {
         super(element, options);
         this.NAME = 'TestComponent';
-        this._activeStateUnit = '.item';
     }
+
+    _activeStateUnit() { return '.item'; }
+
     _itemContainer() { return this.$element(); }
 
     _createActionByOption(optionName, config) {

--- a/packages/devextreme/testing/tests/DevExpress.ui/widget.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui/widget.tests.js
@@ -734,7 +734,7 @@ QUnit.module('ui feedback', {
             .append(item1)
             .append(item2);
 
-        instance._activeStateUnit = '.widget-item-hover';
+        instance._activeStateUnit = () => '.widget-item-hover';
         instance.option('hoverStateEnabled', true);
 
         element.trigger({ target: item1.get(0), type: 'dxpointerenter', pointerType: 'mouse' });


### PR DESCRIPTION
Cherry-pick of: #30976, #30982 