### PR TITLE
CI: Run angular wrapper tests on ubuntu-latest

### DIFF
--- a/.github/workflows/qunit_tests-renovation.yml
+++ b/.github/workflows/qunit_tests-renovation.yml
@@ -60,9 +60,7 @@ jobs:
         DOTNET_CLI_TELEMETRY_OPTOUT: "true"
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
         BUILD_INPROGRESS_RENOVATION: "true"
-      run: |
-        node ../../tools/scripts/performance_log.js &
-        pnpx nx build:dev
+      run: pnpx nx build:dev
 
     - name: Zip artifacts
       working-directory: ./packages/devextreme

--- a/.github/workflows/testcafe_tests.yml
+++ b/.github/workflows/testcafe_tests.yml
@@ -231,7 +231,6 @@ jobs:
         [ "${{ matrix.ARGS.platform }}" != "" ] && PLATFORM="--platform ${{ matrix.ARGS.platform }}"
         all_args="--browsers=chrome:devextreme-shr2 --componentFolder ${{ matrix.ARGS.componentFolder }} $CONCURRENCY $INDICES $PLATFORM $THEME"
         echo "$all_args"
-        node ../../tools/scripts/performance_log.js &
         pnpm run test $all_args
 
     - name: Sanitize job name

--- a/.github/workflows/wrapper_tests.yml
+++ b/.github/workflows/wrapper_tests.yml
@@ -110,13 +110,17 @@ jobs:
           fi
 
   test:
-    runs-on: devextreme-shr2
     timeout-minutes: 20
     needs: build
     strategy:
       fail-fast: false
       matrix:
-        framework: [angular, react, vue]
+        framework: [react, vue]
+        runner: [devextreme-shr2]
+        include:
+          - runner: ubuntu-latest
+            framework: angular
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - name: Get sources

--- a/.github/workflows/wrapper_tests.yml
+++ b/.github/workflows/wrapper_tests.yml
@@ -118,7 +118,7 @@ jobs:
         framework: [react, vue]
         runner: [devextreme-shr2]
         include:
-          - runner: ubuntu-latest
+          - runner: ubuntu-22.04
             framework: angular
     runs-on: ${{ matrix.runner }}
 


### PR DESCRIPTION
Use ubuntu-22.04 runner as a fallback, because:  
- Github-hosted runners have more disk space (16GB vs 8GB for self-hosted) it helps to avoid "no space left" error. 
- Tests with puppeteer fail on ubuntu 23+ with 'No usable sandbox!' error.

Remove performance_log script calls. 
