### PR TITLE
Vitest - fix the `window.getComputedStyle` error on Windows OS

### DIFF
--- a/packages/devextreme/js/ui/themes.js
+++ b/packages/devextreme/js/ui/themes.js
@@ -50,6 +50,8 @@ function readThemeMarker() {
             return null;
         }
         return result.substr(THEME_MARKER_PREFIX.length);
+    } catch(e) {
+        return null;
     } finally {
         element.remove();
     }

--- a/packages/devextreme/testing/tests/DevExpress.ui/themes.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui/themes.tests.js
@@ -825,3 +825,39 @@ QUnit.module('initialized method', (hooks) => {
         });
     });
 });
+
+QUnit.module('readThemeMarker error handling', () => {
+    test('readThemeMarker returns null when getComputedStyle throws an error', function(assert) {
+        const done = assert.async();
+        const originalGetComputedStyle = window.getComputedStyle;
+        window.getComputedStyle = function() { throw new Error('getComputedStyle fails'); };
+
+        try {
+            themes.resetTheme();
+            const value = themes.current();
+            assert.strictEqual(value, null, 'current() returns null on getComputedStyle error');
+        } finally {
+            window.getComputedStyle = originalGetComputedStyle;
+            done();
+        }
+    });
+
+    test('waitForThemeLoad resolves even if getComputedStyle continuously throws', function(assert) {
+        const done = assert.async();
+        const originalGetComputedStyle = window.getComputedStyle;
+        window.getComputedStyle = function() { throw new Error('boom'); };
+
+        const TEST_TIMEOUT = 30;
+        themes.resetTheme();
+        themes.setDefaultTimeout(TEST_TIMEOUT);
+
+        themes.ready(() => {
+            assert.strictEqual(themes.current(), null, 'theme remains null after timeout with errors');
+            window.getComputedStyle = originalGetComputedStyle;
+            themes.setDefaultTimeout(defaultTimeout);
+            done();
+        });
+
+        themes.waitForThemeLoad('some.nonexistent.theme');
+    });
+});


### PR DESCRIPTION
- Add try-catch block to handle potential errors in theme marker reading
- Return null on error to prevent exceptions from breaking theme detection
