### PR TITLE
Add lint target to the default workflow

### DIFF
--- a/.github/workflows/default_workflow.yml
+++ b/.github/workflows/default_workflow.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Run targets
       run: >
         pnpx nx run-many
-        -t test
+        -t lint,test
         --exclude
         devextreme
         devextreme-themebuilder

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -154,44 +154,6 @@ jobs:
       working-directory: ./packages/devextreme
       run: pnpx nx lint-texts
 
-  CSS:
-    runs-on: devextreme-shr2
-    timeout-minutes: 60
-    steps:
-    - name: Get sources
-      uses: actions/checkout@v4
-
-    - name: Use Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-
-    - uses: pnpm/action-setup@v4
-      with:
-        run_install: false
-
-    - name: Get pnpm store directory
-      shell: bash
-      run: |
-        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-    - uses: actions/cache@v4
-      name: Setup pnpm cache
-      with:
-        path: |
-          ${{ env.STORE_PATH }}
-          .nx/cache
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-store
-
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile
-
-    - name: Lint CSS
-      working-directory: ./packages/devextreme-scss
-      run: pnpx nx lint
-
   component_exports:
     runs-on: devextreme-shr2
     timeout-minutes: 10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -243,7 +243,7 @@ jobs:
   notify:
     runs-on: devextreme-shr2
     name: Send notifications
-    needs: [TS, JS, CSS, texts, component_exports]
+    needs: [TS, JS, texts, component_exports]
     if: github.event_name != 'pull_request' && contains(needs.*.result, 'failure')
 
     steps:

--- a/packages/devextreme-metadata/aspnet/enums.ts
+++ b/packages/devextreme-metadata/aspnet/enums.ts
@@ -12,15 +12,7 @@ export const enums = {
     ],
   },
   EdmType: {
-    items: [
-      'Guid',
-      'Int32',
-      'Int64',
-      'String',
-      'Boolean',
-      'Single',
-      'Decimal',
-    ],
+    items: ['Guid', 'Int32', 'Int64', 'String', 'Boolean', 'Single', 'Decimal'],
   },
   FilterOperations: {
     items: [
@@ -49,17 +41,10 @@ export const enums = {
       'triangleNeedle',
       'twoColorNeedle',
     ],
-    options: [
-      'GaugeIndicator.type',
-    ],
+    options: ['GaugeIndicator.type'],
   },
   GeoMapProvider: {
-    items: [
-      'bing',
-      'google',
-      'googleStatic',
-      'azure',
-    ],
+    items: ['bing', 'google', 'googleStatic', 'azure'],
   },
   SchedulerViewType: {
     items: [
@@ -73,109 +58,53 @@ export const enums = {
       'week',
       'workWeek',
     ],
-    options: [
-      'dxScheduler.views',
-    ],
+    options: ['dxScheduler.views'],
   },
   ShowScrollbarMode: {
-    items: [
-      'always',
-      'never',
-      'onHover',
-      'onScroll',
-    ],
-    options: [
-      'dxScrollView.showScrollbar',
-    ],
+    items: ['always', 'never', 'onHover', 'onScroll'],
+    options: ['dxScrollView.showScrollbar'],
   },
   TextEditorButtonWidget: {
-    items: [
-      'dxButton',
-    ],
+    items: ['dxButton'],
   },
   DiagramDataLayoutOrientation: {
-    items: [
-      'vertical',
-      'horizontal',
-    ],
+    items: ['vertical', 'horizontal'],
   },
   GanttSortingMode: {
-    items: [
-      'multiple',
-      'none',
-      'single',
-    ],
+    items: ['multiple', 'none', 'single'],
   },
   GridSortingMode: {
-    items: [
-      'multiple',
-      'none',
-      'single',
-    ],
+    items: ['multiple', 'none', 'single'],
   },
   PieChartLegendHoverMode: {
-    items: [
-      'none',
-      'allArgumentPoints',
-    ],
+    items: ['none', 'allArgumentPoints'],
   },
   PolarChartOverlappingBehavior: {
-    items: [
-      'none',
-      'hide',
-    ],
+    items: ['none', 'hide'],
   },
   SelectionMode: {
-    items: [
-      'multiple',
-      'none',
-      'single',
-    ],
+    items: ['multiple', 'none', 'single'],
   },
   PolarChartResolveLabelOverlapping: {
-    items: [
-      'hide',
-      'none',
-    ],
+    items: ['hide', 'none'],
   },
   ButtonGroupSelectionMode: {
-    items: [
-      'multiple',
-      'single',
-      'none',
-    ],
+    items: ['multiple', 'single', 'none'],
   },
   ChartElementSelectionMode: {
-    items: [
-      'multiple',
-      'single',
-    ],
+    items: ['multiple', 'single'],
   },
   FileManagerSelectionMode: {
-    items: [
-      'multiple',
-      'single',
-    ],
+    items: ['multiple', 'single'],
   },
   ListSelectionMode: {
-    items: [
-      'all',
-      'multiple',
-      'none',
-      'single',
-    ],
+    items: ['all', 'multiple', 'none', 'single'],
   },
   MenuSelectionMode: {
-    items: [
-      'none',
-      'single',
-    ],
+    items: ['none', 'single'],
   },
   NavSelectionMode: {
-    items: [
-      'multiple',
-      'single',
-    ],
+    items: ['multiple', 'single'],
   },
 };
 
@@ -321,7 +250,9 @@ export const enumAliases = {
     'SingleMultipleOrNone': 'GridSortingMode',
   },
 
-  '(dxDataGrid|dxTreeList)(.*)\\.columnRenderingMode': { 'DataRenderMode': 'GridColumnRenderingMode' },
+  '(dxDataGrid|dxTreeList)(.*)\\.columnRenderingMode': {
+    'DataRenderMode': 'GridColumnRenderingMode',
+  },
 
   '(dxDataGrid|dxTreeList)(.*)\\.rowRenderingMode': { 'DataRenderMode': 'GridRowRenderingMode' },
 

--- a/packages/devextreme-metadata/package.json
+++ b/packages/devextreme-metadata/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "format:check": "prettier --check .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "lint": "pnpm run format:check"
   },
   "devDependencies": {
     "@types/node": "catalog:tools",

--- a/packages/devextreme-scss/scss/widgets/fluent/actionSheet/_colors.scss
+++ b/packages/devextreme-scss/scss/widgets/fluent/actionSheet/_colors.scss
@@ -1,6 +1,6 @@
 @use "sass:color";
 @use "../sizes" as *;
-@use "../colors" as *;  
+@use "../colors" as *;
 
 // adduse
 

--- a/packages/devextreme-scss/scss/widgets/fluent/actionSheet/_colors.scss
+++ b/packages/devextreme-scss/scss/widgets/fluent/actionSheet/_colors.scss
@@ -1,6 +1,6 @@
 @use "sass:color";
 @use "../sizes" as *;
-@use "../colors" as *;
+@use "../colors" as *;  
 
 // adduse
 


### PR DESCRIPTION
### Cherry-picks
- #31147

### Practical Value
Reduces boilerplate for the `lint` target: `lint` targets of new projects don't require workflow changes.

### Details

- Dedicated job for `devextreme-scss:lint` removed since it's now included in the default workflow

- Test run with expected failures: https://github.com/DevExpress/DevExtreme/actions/runs/17919636107/job/50950916696?pr=31134

Note that all targets run even if some of them fail.

<img width="473" height="339" alt="image" src="https://github.com/user-attachments/assets/9f21f074-371b-41bd-92f7-42f428f168f3" />

