### PR TITLE
dxFileManager: fix 'First item is selected when right-clicking on an empty area' (T1307139) (cherry-pick to 24_2)

### DIFF
--- a/packages/devextreme/js/ui/file_manager/ui.file_manager.items_list.thumbnails.list_box.js
+++ b/packages/devextreme/js/ui/file_manager/ui.file_manager.items_list.thumbnails.list_box.js
@@ -337,6 +337,8 @@ class FileManagerThumbnailListBox extends CollectionWidget {
 
     _focusOutHandler() {}
 
+    _focusInHandler() {}
+
     _getItems() {
         return this.option('items') || [];
     }

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets/fileManagerParts/thumbnailsView.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets/fileManagerParts/thumbnailsView.tests.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import 'ui/file_manager';
 import fx from 'common/core/animation/fx';
 import { FileManagerWrapper, createTestFileSystem, isDesktopDevice } from '../../../helpers/fileManagerHelpers.js';
+import pointerMock from '../../../helpers/pointerMock.js';
 
 const { test } = QUnit;
 
@@ -301,4 +302,13 @@ QUnit.module('Thumbnails View', moduleConfig, () => {
         assert.notOk(this.wrapper.isThumbnailsItemSelected('..'), 'parent folder is not visually highlited');
     });
 
+    test('Thumbnails view - should focus item only on selection (T1307139)', function(assert) {
+        this.wrapper.getThumbnailsViewPort().trigger('focusin');
+        assert.notOk(this.wrapper.isThumbnailsItemFocused('Folder 1'));
+
+        pointerMock(this.wrapper.findThumbnailsItem('Folder 1')).click();
+        this.clock.tick(400);
+        assert.ok(this.wrapper.isThumbnailsItemSelected('Folder 1'));
+        assert.ok(this.wrapper.isThumbnailsItemFocused('Folder 1'));
+    });
 });


### PR DESCRIPTION
Origin PR - https://github.com/DevExpress/DevExtreme/pull/31170.