### PR TITLE
Bump devextreme-quill to 1.7.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29197,9 +29197,9 @@
       "link": true
     },
     "node_modules/devextreme-quill": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/devextreme-quill/-/devextreme-quill-1.7.5.tgz",
-      "integrity": "sha512-tb6YEqZgiNZXI/oUfjAYZr1gfiWGhB8TfG8Y9WiFnIeQQiJtS5zFCI4B7iWv1Yd8gxyLddGJONqqYKytOlNMSQ==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/devextreme-quill/-/devextreme-quill-1.7.6.tgz",
+      "integrity": "sha512-tIAnvHcQYarpPQwhjO9HaKmB4oDRdz/DPZ8Edo5EFeiYWcejgCl6kSeLgGoFWprPWlWkQUIZI3kBJXDRbXIOBg==",
       "dependencies": {
         "core-js": "^3.34.0",
         "eventemitter3": "^4.0.7",
@@ -65597,7 +65597,7 @@
         "@devextreme/runtime": "3.0.13",
         "devexpress-diagram": "2.2.18",
         "devexpress-gantt": "4.1.58",
-        "devextreme-quill": "1.7.5",
+        "devextreme-quill": "1.7.6",
         "inferno": "^7.4.9",
         "inferno-create-element": "7.4.11",
         "inferno-hydrate": "^7.4.9",
@@ -68239,7 +68239,7 @@
         "@devextreme/runtime": "3.0.13",
         "devexpress-diagram": "2.2.18",
         "devexpress-gantt": "4.1.58",
-        "devextreme-quill": "1.7.5",
+        "devextreme-quill": "1.7.6",
         "inferno": "^7.4.9",
         "inferno-create-element": "7.4.11",
         "inferno-hydrate": "^7.4.9",

--- a/packages/devextreme/artifacts/npm/devextreme/package.json
+++ b/packages/devextreme/artifacts/npm/devextreme/package.json
@@ -32,7 +32,7 @@
     "@devextreme/runtime": "3.0.13",
     "devexpress-diagram": "2.2.18",
     "devexpress-gantt": "4.1.58",
-    "devextreme-quill": "1.7.5",
+    "devextreme-quill": "1.7.6",
     "showdown": "^2.1.0",
     "inferno": "^7.4.9",
     "inferno-create-element": "7.4.11",

--- a/packages/devextreme/package.json
+++ b/packages/devextreme/package.json
@@ -32,7 +32,7 @@
     "@devextreme/runtime": "3.0.13",
     "devexpress-diagram": "2.2.18",
     "devexpress-gantt": "4.1.58",
-    "devextreme-quill": "1.7.5",
+    "devextreme-quill": "1.7.6",
     "showdown": "^2.1.0",
     "inferno": "^7.4.9",
     "inferno-create-element": "7.4.11",


### PR DESCRIPTION
https://github.com/DevExpress/devextreme-quill/releases/tag/1.7.6