### PR TITLE
Bump devextreme-quill version to 1.6.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12776,9 +12776,9 @@
       "link": true
     },
     "node_modules/devextreme-quill": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/devextreme-quill/-/devextreme-quill-1.6.5.tgz",
-      "integrity": "sha512-xBUF7HQCyyADqzI7oAkqnBqWSLBsQw8EbVr6C2BeLBro2BCs2xMgn7kLFw8E8uBJNmwOkfKebdI4MSKN2b/pTA==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/devextreme-quill/-/devextreme-quill-1.6.6.tgz",
+      "integrity": "sha512-G0miS7yn5qehDcxE8z2cVD1LGs9UR59dj13OLFw31ER03m1mgKkyt379oI1fVRZjUtxXPH5Fq3gVgDYyQGP8OA==",
       "dependencies": {
         "core-js": "^3.34.0",
         "eventemitter3": "^4.0.7",
@@ -46812,7 +46812,7 @@
         "@devextreme/runtime": "3.0.13",
         "devexpress-diagram": "2.2.13",
         "devexpress-gantt": "4.1.56",
-        "devextreme-quill": "1.6.5",
+        "devextreme-quill": "1.6.6",
         "inferno": "^7.4.9",
         "inferno-hydrate": "^7.4.9",
         "jszip": "^3.10.1",
@@ -49366,7 +49366,7 @@
         "@devextreme/runtime": "3.0.13",
         "devexpress-diagram": "2.2.13",
         "devexpress-gantt": "4.1.56",
-        "devextreme-quill": "1.6.5",
+        "devextreme-quill": "1.6.6",
         "inferno": "^7.4.9",
         "inferno-hydrate": "^7.4.9",
         "jszip": "^3.10.1",

--- a/packages/devextreme/artifacts/npm/devextreme/package.json
+++ b/packages/devextreme/artifacts/npm/devextreme/package.json
@@ -32,7 +32,7 @@
     "@devextreme/runtime": "3.0.13",
     "devexpress-diagram": "2.2.13",
     "devexpress-gantt": "4.1.56",
-    "devextreme-quill": "1.6.5",
+    "devextreme-quill": "1.6.6",
     "showdown": "^2.1.0",
     "inferno": "^7.4.9",
     "inferno-hydrate": "^7.4.9",

--- a/packages/devextreme/package.json
+++ b/packages/devextreme/package.json
@@ -32,7 +32,7 @@
     "@devextreme/runtime": "3.0.13",
     "devexpress-diagram": "2.2.13",
     "devexpress-gantt": "4.1.56",
-    "devextreme-quill": "1.6.5",
+    "devextreme-quill": "1.6.6",
     "showdown": "^2.1.0",
     "inferno": "^7.4.9",
     "inferno-hydrate": "^7.4.9",


### PR DESCRIPTION
https://github.com/DevExpress/devextreme-quill/releases/tag/1.6.6