### PR TITLE
Fix React DataGrid SimpleArray demo: Remove defaultColumns prop

### DIFF
--- a/apps/demos/Demos/DataGrid/SimpleArray/React/App.tsx
+++ b/apps/demos/Demos/DataGrid/SimpleArray/React/App.tsx
@@ -8,7 +8,6 @@ const App = () => (
   <DataGrid
     dataSource={customers}
     keyExpr="ID"
-    defaultColumns={columns}
     showBorders={true}
   >
     { columns.map((column, index) => <Column dataField={column} key={index} />) }

--- a/apps/demos/Demos/DataGrid/SimpleArray/ReactJs/App.js
+++ b/apps/demos/Demos/DataGrid/SimpleArray/ReactJs/App.js
@@ -7,7 +7,6 @@ const App = () => (
   <DataGrid
     dataSource={customers}
     keyExpr="ID"
-    defaultColumns={columns}
     showBorders={true}
   >
     {columns.map((column, index) => (


### PR DESCRIPTION
- Use Column components mapped from columns array for better clarity
- Remove defaultColumns prop which is redundant 