### PR TITLE
Add flag ShowOnMainPage to show the component on demo list page

### DIFF
--- a/apps/demos/menuMeta.json
+++ b/apps/demos/menuMeta.json
@@ -5054,7 +5054,8 @@
             "NetCoreDescription": "",
             "MvcAdditionalFiles": [],
             "DemoType": "Web",
-            "Badge": "New"
+            "Badge": "New",
+            "ShowOnMainPage": true
           }
         ]
       },


### PR DESCRIPTION
Currently, the component is not displayed in the lists
https://js.devexpress.com/Angular/Demos/WidgetsGallery/

<!--
Before you submit a pull request, review our contribution guidelines (CONTRIBUTING.md).

If your pull request contains a bug fix, its title should include "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What does the PR change?
2. How did you achieve this?
3. How can we verify these changes?

-->
