### PR TITLE
ArrayStore - onPush TypeScript type does not match actual return value (T1316896)

### DIFF
--- a/e2e/compilation-cases/T1316896.ts
+++ b/e2e/compilation-cases/T1316896.ts
@@ -1,0 +1,54 @@
+import ArrayStore from 'devextreme/data/array_store';
+
+interface Entity {
+  id?: string;
+  name?: string;
+}
+
+type Change<TItem, TKey> = {
+  type: 'insert' | 'update' | 'remove';
+  data?: TItem;
+  key?: TKey;
+  index?: number;
+};
+
+function notify(changes: Array<Change<Entity, string>>): void {
+  const change = changes[0];
+  if (change?.data?.id && change.key) {
+    const identifier: string = change.key;
+    const newId: string = change.data.id;
+
+    const ensureString: string = `${identifier}:${newId}`;
+    // eslint-disable-next-line no-console
+    // console.log(ensureString);
+  }
+}
+
+const store = new ArrayStore<Entity, string>({
+  key: 'id',
+  data: [{ id: '1', name: 'Initial' }],
+  onPush: notify,
+});
+
+function load(items: Entity[]): void {
+  const changes: Array<Change<Entity, string>> = items.map((data): Change<Entity, string> => ({
+    key: data.id,
+    data,
+    type: 'insert',
+  }));
+
+  store.push(changes);
+}
+
+function pushSingle(): void {
+  store.push([
+    {
+      key: '2',
+      data: { id: '2', name: 'New entity' },
+      type: 'insert',
+    },
+  ]);
+}
+
+load([{ id: '3', name: 'Batch load' }]);
+pushSingle();

--- a/e2e/compilation-cases/T1316896.ts
+++ b/e2e/compilation-cases/T1316896.ts
@@ -1,4 +1,4 @@
-import ArrayStore from 'devextreme/data/array_store';
+import { ArrayStore } from 'devextreme/common/data';
 
 interface Entity {
   id?: string;

--- a/packages/devextreme/js/data/store.d.ts
+++ b/packages/devextreme/js/data/store.d.ts
@@ -7,6 +7,13 @@ import { FilterDescriptor, GroupDescriptor, LoadOptions } from '../common/data';
  * @namespace DevExpress.common.data
  * @hidden
  */
+type StoreChange<TItem = any, TKey = any > = {
+    type: 'insert' | 'update' | 'remove';
+    data?: DeepPartial<TItem>;
+    key?: TKey;
+    index?: number;
+};
+
 export type StoreOptions<
     TItem = any,
     TKey = any,
@@ -60,7 +67,7 @@ export type StoreOptions<
      * @action
      * @public
      */
-    onPush?: ((changes: Array<TItem>) => void);
+    onPush?: ((changes: Array<StoreChange<TItem, TKey>>) => void);
     /**
      * @docid StoreOptions.onRemoved
      * @type_function_param1 key:object|string|number
@@ -166,7 +173,7 @@ export class Store<
      * @param1 changes:Array<any>
      * @public
      */
-    push(changes: Array<{ type: 'insert' | 'update' | 'remove'; data?: DeepPartial<TItem>; key?: TKey; index?: number }>): void;
+    push(changes: Array<StoreChange<TItem, TKey>>): void;
     /**
      * @docid
      * @publicName remove(key)

--- a/packages/devextreme/js/data/store.d.ts
+++ b/packages/devextreme/js/data/store.d.ts
@@ -64,6 +64,7 @@ export type StoreOptions<
     onModifying?: Function;
     /**
      * @docid StoreOptions.onPush
+     * @type_function_param1 changes:Array<any>
      * @action
      * @public
      */

--- a/packages/devextreme/js/data/store.d.ts
+++ b/packages/devextreme/js/data/store.d.ts
@@ -2,11 +2,6 @@ import { DxPromise, DxExtendedPromise } from '../core/utils/deferred';
 import { DeepPartial } from '../core';
 import { FilterDescriptor, GroupDescriptor, LoadOptions } from '../common/data';
 
-/**
- * @docid StoreOptions
- * @namespace DevExpress.common.data
- * @hidden
- */
 type StoreChange<TItem = any, TKey = any > = {
     type: 'insert' | 'update' | 'remove';
     data?: DeepPartial<TItem>;
@@ -14,6 +9,11 @@ type StoreChange<TItem = any, TKey = any > = {
     index?: number;
 };
 
+/**
+ * @docid StoreOptions
+ * @namespace DevExpress.common.data
+ * @hidden
+ */
 export type StoreOptions<
     TItem = any,
     TKey = any,

--- a/packages/devextreme/ts/dx.all.d.ts
+++ b/packages/devextreme/ts/dx.all.d.ts
@@ -3194,7 +3194,7 @@ declare module DevExpress.common.data {
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
   export interface AbstractStoreOptions<TItem = any, TKey = any>
-    extends DevExpress.data.StoreOptions<TItem, TKey> {
+    extends StoreOptions<TItem, TKey> {
     /**
      * [descr:StoreOptions.onLoaded]
      */
@@ -3283,10 +3283,10 @@ declare module DevExpress.common.data {
   /**
    * [descr:CustomStoreOptions]
    */
-  export type CustomStoreOptions<
-    TItem = any,
-    TKey = any
-  > = DevExpress.data.StoreOptions<TItem, TKey> & {
+  export type CustomStoreOptions<TItem = any, TKey = any> = StoreOptions<
+    TItem,
+    TKey
+  > & {
     /**
      * [descr:CustomStoreOptions.byKey]
      */
@@ -4059,7 +4059,7 @@ declare module DevExpress.common.data {
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
   export class Store<TItem = any, TKey = any> {
-    constructor(options?: DevExpress.data.StoreOptions<TItem, TKey>);
+    constructor(options?: StoreOptions<TItem, TKey>);
     /**
      * [descr:Store.insert(values)]
      */
@@ -4094,7 +4094,7 @@ declare module DevExpress.common.data {
     /**
      * [descr:Store.push(changes)]
      */
-    push(changes: Array<StoreChange<TItem, TKey>>): void;
+    push(changes: Array<DevExpress.data.StoreChange<TItem, TKey>>): void;
     /**
      * [descr:Store.remove(key)]
      */
@@ -4115,14 +4115,58 @@ declare module DevExpress.common.data {
     ): DevExpress.core.utils.DxExtendedPromise<TItem>;
   }
   /**
-   * [descr:StoreOptions]
-   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
-   */
-  type StoreChange<TItem = any, TKey = any> = {
-    type: 'insert' | 'update' | 'remove';
-    data?: DevExpress.core.DeepPartial<TItem>;
-    key?: TKey;
-    index?: number;
+    * [descr:StoreOptions]
+    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
+    */
+   export type StoreOptions<TItem = any, TKey = any> = {
+    /**
+     * [descr:StoreOptions.errorHandler]
+     */
+    errorHandler?: Function;
+    /**
+     * [descr:StoreOptions.key]
+     */
+    key?: string | Array<string>;
+    /**
+     * [descr:StoreOptions.onInserted]
+     */
+    onInserted?: (values: TItem, key: TKey) => void;
+    /**
+     * [descr:StoreOptions.onInserting]
+     */
+    onInserting?: (values: TItem) => void;
+    /**
+     * [descr:StoreOptions.onLoading]
+     */
+    onLoading?: (loadOptions: LoadOptions<TItem>) => void;
+    /**
+     * [descr:StoreOptions.onModified]
+     */
+    onModified?: Function;
+    /**
+     * [descr:StoreOptions.onModifying]
+     */
+    onModifying?: Function;
+    /**
+     * [descr:StoreOptions.onPush]
+     */
+    onPush?: (changes: Array<DevExpress.data.StoreChange<TItem, TKey>>) => void;
+    /**
+     * [descr:StoreOptions.onRemoved]
+     */
+    onRemoved?: (key: TKey) => void;
+    /**
+     * [descr:StoreOptions.onRemoving]
+     */
+    onRemoving?: (key: TKey) => void;
+    /**
+     * [descr:StoreOptions.onUpdated]
+     */
+    onUpdated?: (key: TKey, values: TItem) => void;
+    /**
+     * [descr:StoreOptions.onUpdating]
+     */
+    onUpdating?: (key: TKey, values: TItem) => void;
   };
   /**
    * [descr:SummaryDescriptor]
@@ -7810,6 +7854,15 @@ declare module DevExpress.data {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
+  type StoreChange<TItem = any, TKey = any> = {
+    type: 'insert' | 'update' | 'remove';
+    data?: DevExpress.core.DeepPartial<TItem>;
+    key?: TKey;
+    index?: number;
+  };
+  /**
+   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
+   */
   type StoreEventName =
     | 'loaded'
     | 'loading'
@@ -7822,63 +7875,6 @@ declare module DevExpress.data {
     | 'removing'
     | 'modified'
     | 'modifying';
-  /**
-   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
-   */
-  export type StoreOptions<TItem = any, TKey = any> = {
-    /**
-     * [descr:StoreOptions.errorHandler]
-     */
-    errorHandler?: Function;
-    /**
-     * [descr:StoreOptions.key]
-     */
-    key?: string | Array<string>;
-    /**
-     * [descr:StoreOptions.onInserted]
-     */
-    onInserted?: (values: TItem, key: TKey) => void;
-    /**
-     * [descr:StoreOptions.onInserting]
-     */
-    onInserting?: (values: TItem) => void;
-    /**
-     * [descr:StoreOptions.onLoading]
-     */
-    onLoading?: (
-      loadOptions: DevExpress.common.data.LoadOptions<TItem>
-    ) => void;
-    /**
-     * [descr:StoreOptions.onModified]
-     */
-    onModified?: Function;
-    /**
-     * [descr:StoreOptions.onModifying]
-     */
-    onModifying?: Function;
-    /**
-     * [descr:StoreOptions.onPush]
-     */
-    onPush?: (
-      changes: Array<DevExpress.common.data.StoreChange<TItem, TKey>>
-    ) => void;
-    /**
-     * [descr:StoreOptions.onRemoved]
-     */
-    onRemoved?: (key: TKey) => void;
-    /**
-     * [descr:StoreOptions.onRemoving]
-     */
-    onRemoving?: (key: TKey) => void;
-    /**
-     * [descr:StoreOptions.onUpdated]
-     */
-    onUpdated?: (key: TKey, values: TItem) => void;
-    /**
-     * [descr:StoreOptions.onUpdating]
-     */
-    onUpdating?: (key: TKey, values: TItem) => void;
-  };
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */

--- a/packages/devextreme/ts/dx.all.d.ts
+++ b/packages/devextreme/ts/dx.all.d.ts
@@ -3194,7 +3194,7 @@ declare module DevExpress.common.data {
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
   export interface AbstractStoreOptions<TItem = any, TKey = any>
-    extends StoreOptions<TItem, TKey> {
+    extends DevExpress.data.StoreOptions<TItem, TKey> {
     /**
      * [descr:StoreOptions.onLoaded]
      */
@@ -3283,10 +3283,10 @@ declare module DevExpress.common.data {
   /**
    * [descr:CustomStoreOptions]
    */
-  export type CustomStoreOptions<TItem = any, TKey = any> = StoreOptions<
-    TItem,
-    TKey
-  > & {
+  export type CustomStoreOptions<
+    TItem = any,
+    TKey = any
+  > = DevExpress.data.StoreOptions<TItem, TKey> & {
     /**
      * [descr:CustomStoreOptions.byKey]
      */
@@ -4054,18 +4054,12 @@ declare module DevExpress.common.data {
    * [descr:SortDescriptor]
    */
   export type SortDescriptor<T> = DevExpress.data.SortDescriptor<T>;
-  type StoreChange<TItem = any, TKey = any> = {
-    type: 'insert' | 'update' | 'remove';
-    data?: DevExpress.core.DeepPartial<TItem>;
-    key?: TKey;
-    index?: number;
-  };
   /**
    * [descr:Store]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
   export class Store<TItem = any, TKey = any> {
-    constructor(options?: StoreOptions<TItem, TKey>);
+    constructor(options?: DevExpress.data.StoreOptions<TItem, TKey>);
     /**
      * [descr:Store.insert(values)]
      */
@@ -4124,55 +4118,11 @@ declare module DevExpress.common.data {
    * [descr:StoreOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export type StoreOptions<TItem = any, TKey = any> = {
-    /**
-     * [descr:StoreOptions.errorHandler]
-     */
-    errorHandler?: Function;
-    /**
-     * [descr:StoreOptions.key]
-     */
-    key?: string | Array<string>;
-    /**
-     * [descr:StoreOptions.onInserted]
-     */
-    onInserted?: (values: TItem, key: TKey) => void;
-    /**
-     * [descr:StoreOptions.onInserting]
-     */
-    onInserting?: (values: TItem) => void;
-    /**
-     * [descr:StoreOptions.onLoading]
-     */
-    onLoading?: (loadOptions: LoadOptions<TItem>) => void;
-    /**
-     * [descr:StoreOptions.onModified]
-     */
-    onModified?: Function;
-    /**
-     * [descr:StoreOptions.onModifying]
-     */
-    onModifying?: Function;
-    /**
-     * [descr:StoreOptions.onPush]
-     */
-    onPush?: (changes: Array<StoreChange<TItem, TKey>>) => void;
-    /**
-     * [descr:StoreOptions.onRemoved]
-     */
-    onRemoved?: (key: TKey) => void;
-    /**
-     * [descr:StoreOptions.onRemoving]
-     */
-    onRemoving?: (key: TKey) => void;
-    /**
-     * [descr:StoreOptions.onUpdated]
-     */
-    onUpdated?: (key: TKey, values: TItem) => void;
-    /**
-     * [descr:StoreOptions.onUpdating]
-     */
-    onUpdating?: (key: TKey, values: TItem) => void;
+  type StoreChange<TItem = any, TKey = any> = {
+    type: 'insert' | 'update' | 'remove';
+    data?: DevExpress.core.DeepPartial<TItem>;
+    key?: TKey;
+    index?: number;
   };
   /**
    * [descr:SummaryDescriptor]
@@ -7872,6 +7822,63 @@ declare module DevExpress.data {
     | 'removing'
     | 'modified'
     | 'modifying';
+  /**
+   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
+   */
+  export type StoreOptions<TItem = any, TKey = any> = {
+    /**
+     * [descr:StoreOptions.errorHandler]
+     */
+    errorHandler?: Function;
+    /**
+     * [descr:StoreOptions.key]
+     */
+    key?: string | Array<string>;
+    /**
+     * [descr:StoreOptions.onInserted]
+     */
+    onInserted?: (values: TItem, key: TKey) => void;
+    /**
+     * [descr:StoreOptions.onInserting]
+     */
+    onInserting?: (values: TItem) => void;
+    /**
+     * [descr:StoreOptions.onLoading]
+     */
+    onLoading?: (
+      loadOptions: DevExpress.common.data.LoadOptions<TItem>
+    ) => void;
+    /**
+     * [descr:StoreOptions.onModified]
+     */
+    onModified?: Function;
+    /**
+     * [descr:StoreOptions.onModifying]
+     */
+    onModifying?: Function;
+    /**
+     * [descr:StoreOptions.onPush]
+     */
+    onPush?: (
+      changes: Array<DevExpress.common.data.StoreChange<TItem, TKey>>
+    ) => void;
+    /**
+     * [descr:StoreOptions.onRemoved]
+     */
+    onRemoved?: (key: TKey) => void;
+    /**
+     * [descr:StoreOptions.onRemoving]
+     */
+    onRemoving?: (key: TKey) => void;
+    /**
+     * [descr:StoreOptions.onUpdated]
+     */
+    onUpdated?: (key: TKey, values: TItem) => void;
+    /**
+     * [descr:StoreOptions.onUpdating]
+     */
+    onUpdating?: (key: TKey, values: TItem) => void;
+  };
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */

--- a/packages/devextreme/ts/dx.all.d.ts
+++ b/packages/devextreme/ts/dx.all.d.ts
@@ -4054,6 +4054,12 @@ declare module DevExpress.common.data {
    * [descr:SortDescriptor]
    */
   export type SortDescriptor<T> = DevExpress.data.SortDescriptor<T>;
+  type StoreChange<TItem = any, TKey = any> = {
+    type: 'insert' | 'update' | 'remove';
+    data?: DevExpress.core.DeepPartial<TItem>;
+    key?: TKey;
+    index?: number;
+  };
   /**
    * [descr:Store]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
@@ -4094,14 +4100,7 @@ declare module DevExpress.common.data {
     /**
      * [descr:Store.push(changes)]
      */
-    push(
-      changes: Array<{
-        type: 'insert' | 'update' | 'remove';
-        data?: DevExpress.core.DeepPartial<TItem>;
-        key?: TKey;
-        index?: number;
-      }>
-    ): void;
+    push(changes: Array<StoreChange<TItem, TKey>>): void;
     /**
      * [descr:Store.remove(key)]
      */
@@ -4157,7 +4156,7 @@ declare module DevExpress.common.data {
     /**
      * [descr:StoreOptions.onPush]
      */
-    onPush?: (changes: Array<TItem>) => void;
+    onPush?: (changes: Array<StoreChange<TItem, TKey>>) => void;
     /**
      * [descr:StoreOptions.onRemoved]
      */

--- a/packages/devextreme/ts/dx.all.d.ts
+++ b/packages/devextreme/ts/dx.all.d.ts
@@ -4115,10 +4115,10 @@ declare module DevExpress.common.data {
     ): DevExpress.core.utils.DxExtendedPromise<TItem>;
   }
   /**
-    * [descr:StoreOptions]
-    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
-    */
-   export type StoreOptions<TItem = any, TKey = any> = {
+   * [descr:StoreOptions]
+   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
+   */
+  export type StoreOptions<TItem = any, TKey = any> = {
     /**
      * [descr:StoreOptions.errorHandler]
      */


### PR DESCRIPTION
<!--
Before you submit a pull request, review our contribution guidelines (CONTRIBUTING.md).

If your pull request contains a bug fix, its title should include "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What does the PR change?
2. How did you achieve this?
3. How can we verify these changes?

-->
