### PR TITLE
Grids: Add Default scrollByThumb Value for Desktop

### DIFF
--- a/packages/devextreme/js/common/grids.d.ts
+++ b/packages/devextreme/js/common/grids.d.ts
@@ -3101,6 +3101,7 @@ export interface ScrollingBase {
   /**
    * @docid GridBaseOptions.scrolling.scrollByThumb
    * @default false
+   * @default true &for(desktop)
    * @public
    */
   scrollByThumb?: boolean;


### PR DESCRIPTION
Add desktop-specific GridBaseOptions.scrolling.scrollByThumb default value to update docs. 