### PR TITLE
Scheduler - fix scrollTo deprecated API warning when groupValues are not set

### DIFF
--- a/packages/devextreme/js/__internal/scheduler/__tests__/scheduler.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/__tests__/scheduler.test.ts
@@ -35,7 +35,7 @@ describe('Scheduler scrollTo deprecation', () => {
     );
   });
 
-  it('should not deprecation warning when using scrollTo API with date only', async () => {
+  it('should not log deprecation warning when using scrollTo API with date only', async () => {
     setupSchedulerTestEnvironment();
     const loggerWarnSpy = jest.spyOn(logger, 'warn');
 

--- a/packages/devextreme/js/__internal/scheduler/__tests__/scheduler.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/__tests__/scheduler.test.ts
@@ -34,4 +34,29 @@ describe('Scheduler scrollTo deprecation', () => {
       expect.stringContaining('W0002'),
     );
   });
+
+  it('should not deprecation warning when using scrollTo API with date only', async () => {
+    setupSchedulerTestEnvironment();
+    const loggerWarnSpy = jest.spyOn(logger, 'warn');
+
+    const { scheduler } = await createScheduler({
+      dataSource: [{
+        text: 'Meeting',
+        startDate: new Date(2025, 0, 15, 9, 0),
+        endDate: new Date(2025, 0, 15, 10, 0),
+      }],
+      views: ['week'],
+      currentView: 'week',
+      currentDate: new Date(2025, 0, 15),
+      startDayHour: 8,
+      endDayHour: 18,
+    });
+    loggerWarnSpy.mockReset();
+
+    const testDate = new Date(2025, 0, 16, 14, 0);
+
+    scheduler.scrollTo(testDate);
+
+    expect(loggerWarnSpy).toHaveBeenCalledTimes(0);
+  });
 });

--- a/packages/devextreme/js/__internal/scheduler/m_scheduler.ts
+++ b/packages/devextreme/js/__internal/scheduler/m_scheduler.ts
@@ -2036,7 +2036,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       allDayValue = groupValuesOrOptions.allDay;
       align = groupValuesOrOptions.alignInView ?? 'center';
     } else {
-      if (groupValuesOrOptions) {
+      if (isDefined(groupValuesOrOptions) || isDefined(allDay)) {
         errors.log('W0002', 'dxScheduler', 'scrollTo', '26.1', 'Use an object with "group", "allDay" and "alignInView" properties instead of separate parameters.');
       }
 

--- a/packages/devextreme/js/__internal/scheduler/m_scheduler.ts
+++ b/packages/devextreme/js/__internal/scheduler/m_scheduler.ts
@@ -2036,7 +2036,10 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       allDayValue = groupValuesOrOptions.allDay;
       align = groupValuesOrOptions.alignInView ?? 'center';
     } else {
-      errors.log('W0002', 'dxScheduler', 'scrollTo', '26.1', 'Use an object with "group", "allDay" and "alignInView" properties instead of separate parameters.');
+      if (groupValuesOrOptions) {
+        errors.log('W0002', 'dxScheduler', 'scrollTo', '26.1', 'Use an object with "group", "allDay" and "alignInView" properties instead of separate parameters.');
+      }
+
       groupValues = groupValuesOrOptions;
       allDayValue = allDay;
     }

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/scrollTo.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/scrollTo.tests.js
@@ -106,16 +106,14 @@ module('ScrollTo', {
             scheduler.instance.scrollTo(new Date(2020, 8, 5));
             await waitAsync(0);
 
-            assert.equal(errors.log.callCount, 2, 'warnings have been called twice');
-            assert.equal(errors.log.getCall(0).args[0], 'W0002', 'first warning is deprecation warning');
-            assert.equal(errors.log.getCall(1).args[0], 'W1008', 'second warning has correct error id');
+            assert.equal(errors.log.callCount, 1, 'warnings have been called twice');
+            assert.equal(errors.log.getCall(0).args[0], 'W1008', 'second warning has correct error id');
 
             scheduler.instance.scrollTo(new Date(2020, 8, 14));
             await waitAsync(0);
 
-            assert.equal(errors.log.callCount, 4, 'warnings have been called four times total');
-            assert.equal(errors.log.getCall(2).args[0], 'W0002', 'third warning is deprecation warning');
-            assert.equal(errors.log.getCall(3).args[0], 'W1008', 'fourth warning has correct error id');
+            assert.equal(errors.log.callCount, 2, 'warnings have been called two times total');
+            assert.equal(errors.log.getCall(1).args[0], 'W1008', 'fourth warning has correct error id');
         });
 
         test(`A warning should not be thrown when scrolling to a valid date when ${scrolling.text} is used`, async function(assert) {
@@ -124,8 +122,7 @@ module('ScrollTo', {
             scheduler.instance.scrollTo(new Date(2020, 8, 7));
             await waitAsync(0);
 
-            assert.equal(errors.log.callCount, 1, 'deprecation warning has been called once');
-            assert.equal(errors.log.getCall(0).args[0], 'W0002', 'warning is deprecation warning for old API');
+            assert.equal(errors.log.callCount, 0, 'warning has not been called');
         });
 
         [{

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/scrollTo.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/scrollTo.tests.js
@@ -106,14 +106,14 @@ module('ScrollTo', {
             scheduler.instance.scrollTo(new Date(2020, 8, 5));
             await waitAsync(0);
 
-            assert.equal(errors.log.callCount, 1, 'warnings have been called twice');
-            assert.equal(errors.log.getCall(0).args[0], 'W1008', 'second warning has correct error id');
+            assert.equal(errors.log.callCount, 1, 'warnings have been called once');
+            assert.equal(errors.log.getCall(0).args[0], 'W1008', 'first warning has correct error id');
 
             scheduler.instance.scrollTo(new Date(2020, 8, 14));
             await waitAsync(0);
 
             assert.equal(errors.log.callCount, 2, 'warnings have been called two times total');
-            assert.equal(errors.log.getCall(1).args[0], 'W1008', 'fourth warning has correct error id');
+            assert.equal(errors.log.getCall(1).args[0], 'W1008', 'second warning has correct error id');
         });
 
         test(`A warning should not be thrown when scrolling to a valid date when ${scrolling.text} is used`, async function(assert) {


### PR DESCRIPTION
<!--
Before you submit a pull request, review our contribution guidelines (CONTRIBUTING.md).

If your pull request contains a bug fix, its title should include "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What does the PR change?
2. How did you achieve this?
3. How can we verify these changes?

-->
