### PR TITLE
T1308327 - DataGrid - Cell value is not restored after canceling changes in cell editing mode if repaintChangesOnly is enabled

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/__tests__/__mock__/model/cell/data_cell.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/__tests__/__mock__/model/cell/data_cell.ts
@@ -1,6 +1,9 @@
+import { TextBoxModel } from '@ts/ui/__tests__/__mock__/model/textbox';
+
 const SELECTORS = {
   editCell: 'dx-editor-cell',
   invalidCell: 'invalid',
+  textBox: 'dx-textbox',
 };
 
 export class DataCellModel {
@@ -26,5 +29,10 @@ export class DataCellModel {
 
   public getHTML(): string {
     return this.root?.innerHTML ?? '';
+  }
+
+  public getEditor(): TextBoxModel {
+    const editorElement = this.root?.querySelector(`.${SELECTORS.textBox}`) as HTMLElement;
+    return new TextBoxModel(editorElement);
   }
 }

--- a/packages/devextreme/js/__internal/grids/grid_core/__tests__/__mock__/model/grid_core.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/__tests__/__mock__/model/grid_core.ts
@@ -25,6 +25,7 @@ const SELECTORS = {
   editForm: 'edit-form',
   headerCellIndicators: 'dx-column-indicators',
   headerCellFilter: 'dx-header-filter',
+  revertButton: 'dx-revert-button',
 };
 
 export abstract class GridCoreModel<TInstance extends GridBase = GridBase> {
@@ -99,6 +100,10 @@ export abstract class GridCoreModel<TInstance extends GridBase = GridBase> {
 
   public getToast(): ToastModel {
     return new ToastModel(this.getToastContainer());
+  }
+
+  public getRevertButton(): HTMLElement {
+    return document.body.querySelector(`.${SELECTORS.revertButton}`) as HTMLElement;
   }
 
   public addWidgetPrefix(classNames: string): string {

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
@@ -51,6 +51,7 @@ import {
   EDIT_FORM_CLASS,
   EDIT_ICON_CLASS,
   EDIT_LINK_CLASS,
+  EDIT_MODE_BATCH,
   EDIT_MODE_POPUP,
   EDIT_MODE_ROW,
   EDIT_MODES,
@@ -214,6 +215,10 @@ class EditingControllerImpl extends modules.ViewController {
   public isCellBasedEditMode(): boolean {
     const editMode: GridsEditMode = this.getEditMode();
     return CELL_BASED_MODES.includes(editMode);
+  }
+
+  protected isBatchBasedEditMode(): boolean {
+    return this.getEditMode() === EDIT_MODE_BATCH;
   }
 
   private _getDefaultEditorTemplate() {

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
@@ -51,7 +51,6 @@ import {
   EDIT_FORM_CLASS,
   EDIT_ICON_CLASS,
   EDIT_LINK_CLASS,
-  EDIT_MODE_BATCH,
   EDIT_MODE_POPUP,
   EDIT_MODE_ROW,
   EDIT_MODES,
@@ -215,10 +214,6 @@ class EditingControllerImpl extends modules.ViewController {
   public isCellBasedEditMode(): boolean {
     const editMode: GridsEditMode = this.getEditMode();
     return CELL_BASED_MODES.includes(editMode);
-  }
-
-  protected isBatchBasedEditMode(): boolean {
-    return this.getEditMode() === EDIT_MODE_BATCH;
   }
 
   private _getDefaultEditorTemplate() {

--- a/packages/devextreme/js/__internal/grids/grid_core/validating/__tests__/validating.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/validating/__tests__/validating.integration.test.ts
@@ -1,62 +1,11 @@
 import {
   afterEach, beforeEach, describe, expect, it, jest,
 } from '@jest/globals';
-import type { dxElementWrapper } from '@js/core/renderer';
-import $ from '@js/core/renderer';
-import type { Properties as DataGridProperties } from '@js/ui/data_grid';
-import DataGrid from '@js/ui/data_grid';
-import errors from '@js/ui/widget/ui.errors';
-import { DataGridModel } from '@ts/grids/data_grid/__tests__/__mock__/model/data_grid';
-
-const SELECTORS = {
-  gridContainer: '#gridContainer',
-};
-
-const GRID_CONTAINER_ID = 'gridContainer';
-
-const createDataGrid = async (
-  options: DataGridProperties = {},
-): Promise<{
-  $container: dxElementWrapper;
-  component: DataGridModel;
-  instance: DataGrid;
-}> => new Promise((resolve) => {
-  const $container = $('<div>')
-    .attr('id', GRID_CONTAINER_ID)
-    .appendTo(document.body);
-
-  const dataGridOptions: DataGridProperties = {
-    keyExpr: 'id',
-    ...options,
-  };
-
-  const instance = new DataGrid($container.get(0) as HTMLDivElement, dataGridOptions);
-  const component = new DataGridModel($container.get(0) as HTMLElement);
-
-  jest.runAllTimers();
-
-  resolve({
-    $container,
-    component,
-    instance,
-  });
-});
-
-const beforeTest = (): void => {
-  jest.useFakeTimers();
-  jest.spyOn(errors, 'log').mockImplementation(jest.fn());
-  jest.spyOn(errors, 'Error').mockImplementation(() => ({}));
-};
-
-const afterTest = (): void => {
-  const $container = $(SELECTORS.gridContainer);
-  const dataGrid = ($container as any).dxDataGrid('instance') as DataGrid;
-
-  dataGrid.dispose();
-  $container.remove();
-  jest.clearAllMocks();
-  jest.useRealTimers();
-};
+import {
+  afterTest,
+  beforeTest,
+  createDataGrid,
+} from '@ts/grids/grid_core/__tests__/__mock__/helpers/utils';
 
 describe('Bugs', () => {
   beforeEach(beforeTest);

--- a/packages/devextreme/js/__internal/grids/grid_core/validating/__tests__/validating.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/validating/__tests__/validating.integration.test.ts
@@ -7,12 +7,13 @@ import {
   createDataGrid,
 } from '@ts/grids/grid_core/__tests__/__mock__/helpers/utils';
 
-describe('Bugs', () => {
+describe('DataGrid Cell Editing', () => {
   beforeEach(beforeTest);
   afterEach(afterTest);
 
-  describe('T1308327 - DataGrid - Cell value is not restored after canceling changes in cell editing mode if repaintChangesOnly is enabled', () => {
-    it('should restore cell value after canceling changes with validation error', async () => {
+  // T1308327
+  describe('when showEditorAlways and repaintChangesOnly is enabled', () => {
+    it('should restore the value after canceling changes with validation error (T1308327)', async () => {
       const data = [
         { id: 1, name: 'Job 1', article: 'Article A' },
         { id: 2, name: 'Job 2', article: 'Article B' },

--- a/packages/devextreme/js/__internal/grids/grid_core/validating/__tests__/validating.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/validating/__tests__/validating.integration.test.ts
@@ -1,0 +1,123 @@
+import {
+  afterEach, beforeEach, describe, expect, it, jest,
+} from '@jest/globals';
+import type { dxElementWrapper } from '@js/core/renderer';
+import $ from '@js/core/renderer';
+import type { Properties as DataGridProperties } from '@js/ui/data_grid';
+import DataGrid from '@js/ui/data_grid';
+import errors from '@js/ui/widget/ui.errors';
+import { DataGridModel } from '@ts/grids/data_grid/__tests__/__mock__/model/data_grid';
+
+const SELECTORS = {
+  gridContainer: '#gridContainer',
+};
+
+const GRID_CONTAINER_ID = 'gridContainer';
+
+const createDataGrid = async (
+  options: DataGridProperties = {},
+): Promise<{
+  $container: dxElementWrapper;
+  component: DataGridModel;
+  instance: DataGrid;
+}> => new Promise((resolve) => {
+  const $container = $('<div>')
+    .attr('id', GRID_CONTAINER_ID)
+    .appendTo(document.body);
+
+  const dataGridOptions: DataGridProperties = {
+    keyExpr: 'id',
+    ...options,
+  };
+
+  const instance = new DataGrid($container.get(0) as HTMLDivElement, dataGridOptions);
+  const component = new DataGridModel($container.get(0) as HTMLElement);
+
+  jest.runAllTimers();
+
+  resolve({
+    $container,
+    component,
+    instance,
+  });
+});
+
+const beforeTest = (): void => {
+  jest.useFakeTimers();
+  jest.spyOn(errors, 'log').mockImplementation(jest.fn());
+  jest.spyOn(errors, 'Error').mockImplementation(() => ({}));
+};
+
+const afterTest = (): void => {
+  const $container = $(SELECTORS.gridContainer);
+  const dataGrid = ($container as any).dxDataGrid('instance') as DataGrid;
+
+  dataGrid.dispose();
+  $container.remove();
+  jest.clearAllMocks();
+  jest.useRealTimers();
+};
+
+describe('Bugs', () => {
+  beforeEach(beforeTest);
+  afterEach(afterTest);
+
+  describe('T1308327 - DataGrid - Cell value is not restored after canceling changes in cell editing mode if repaintChangesOnly is enabled', () => {
+    it('should restore cell value after canceling changes with validation error', async () => {
+      const data = [
+        { id: 1, name: 'Job 1', article: 'Article A' },
+        { id: 2, name: 'Job 2', article: 'Article B' },
+      ];
+
+      const { instance, component } = await createDataGrid({
+        dataSource: data,
+        keyExpr: 'id',
+        repaintChangesOnly: true,
+        editing: {
+          mode: 'cell',
+          allowUpdating: true,
+        },
+        columns: [
+          {
+            dataField: 'name',
+            showEditorAlways: true,
+            validationRules: [
+              { type: 'required', message: 'Required field' },
+            ],
+          },
+          {
+            dataField: 'article',
+          },
+        ],
+      });
+
+      const firstCell = component.getDataCell(0, 0);
+      const firstEditor = firstCell.getEditor();
+
+      firstEditor.setValue('');
+      jest.runAllTimers();
+
+      expect(component.getDataCell(0, 0).isValidCell).toBe(false);
+
+      component.getRevertButton().click();
+      jest.runAllTimers();
+
+      expect(instance.cellValue(0, 'name')).toBe('Job 1');
+      expect(component.getDataCell(0, 0).isValidCell).toBe(true);
+
+      const secondCell = component.getDataCell(1, 0);
+      const secondEditor = secondCell.getEditor();
+
+      secondEditor.setValue('');
+      jest.runAllTimers();
+
+      expect(component.getDataCell(1, 0).isValidCell).toBe(false);
+
+      component.getRevertButton().click();
+      jest.runAllTimers();
+
+      expect(instance.cellValue(1, 'name')).toBe('Job 2');
+      expect(component.getDataCell(1, 0).isValidCell).toBe(true);
+    });
+  });
+});

--- a/packages/devextreme/js/__internal/grids/grid_core/validating/m_validating.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/validating/m_validating.ts
@@ -979,7 +979,11 @@ export const validatingEditingExtender = (Base: ModuleType<EditingController>) =
   }
 
   protected _beforeCancelEditData() {
-    this._validatingController.initValidationState();
+    // Don't reset a validation state if repaintChangesOnly is switched on
+    // to let the revert button get access to initial values via _getOldData()
+    if (!this.option('repaintChangesOnly')) {
+      this._validatingController.initValidationState();
+    }
 
     super._beforeCancelEditData();
   }

--- a/packages/devextreme/js/__internal/grids/grid_core/validating/m_validating.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/validating/m_validating.ts
@@ -115,6 +115,34 @@ export class ValidatingController extends modules.Controller {
     this._validationStateCache = {};
   }
 
+  public resetValidationStateForChanges(changes) {
+    if (!changes?.length) {
+      return;
+    }
+
+    changes.forEach(({ key }) => {
+      this._removeValidationData(key);
+    });
+  }
+
+  private _removeValidationData(key) {
+    if (!this._validationState?.length) {
+      return;
+    }
+
+    const keyHash = getKeyHash(key);
+    const isObjectKeyHash = isObject(keyHash);
+
+    if (!isObjectKeyHash && this._validationStateCache) {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete this._validationStateCache[keyHash];
+    }
+
+    this._validationState = this._validationState.filter((data) => (
+      isObjectKeyHash ? !equalByValue(data.key, key) : data.key !== key
+    ));
+  }
+
   public _rowIsValidated(change) {
     const validationData = this._getValidationData(change?.key);
 
@@ -972,10 +1000,14 @@ export const validatingEditingExtender = (Base: ModuleType<EditingController>) =
   }
 
   protected _beforeCancelEditData() {
+    const validatingController = this._validatingController;
     const shouldResetValidationState = this._shouldResetValidationState();
 
     if (shouldResetValidationState) {
-      this._validatingController.initValidationState();
+      validatingController.initValidationState();
+    } else {
+      const changes = this.getChanges();
+      validatingController.resetValidationStateForChanges(changes);
     }
 
     super._beforeCancelEditData();

--- a/packages/devextreme/js/__internal/grids/grid_core/validating/m_validating.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/validating/m_validating.ts
@@ -979,9 +979,12 @@ export const validatingEditingExtender = (Base: ModuleType<EditingController>) =
   }
 
   protected _beforeCancelEditData() {
+    const isBatchBasedEditMode = this.isBatchBasedEditMode();
+    const repaintChangesOnly = this.option('repaintChangesOnly');
+
     // Don't reset a validation state if repaintChangesOnly is switched on
     // to let the revert button get access to initial values via _getOldData()
-    if (!this.option('repaintChangesOnly')) {
+    if (isBatchBasedEditMode || !repaintChangesOnly) {
       this._validatingController.initValidationState();
     }
 

--- a/packages/devextreme/js/__internal/grids/grid_core/validating/m_validating.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/validating/m_validating.ts
@@ -936,14 +936,7 @@ export const validatingEditingExtender = (Base: ModuleType<EditingController>) =
       });
       this._focusEditingCell();
     } else if (!cancel) {
-      let shouldResetValidationState = true;
-
-      if (isCellEditMode) {
-        const columns = this._columnsController.getColumns();
-        const columnsWithValidatingEditors = columns.filter((col) => col.showEditorAlways && col.validationRules?.length > 0).length > 0;
-
-        shouldResetValidationState = !columnsWithValidatingEditors;
-      }
+      const shouldResetValidationState = this._shouldResetValidationState();
 
       if (shouldResetValidationState) {
         this._validatingController.initValidationState();
@@ -979,16 +972,28 @@ export const validatingEditingExtender = (Base: ModuleType<EditingController>) =
   }
 
   protected _beforeCancelEditData() {
-    const isBatchBasedEditMode = this.isBatchBasedEditMode();
-    const repaintChangesOnly = this.option('repaintChangesOnly');
+    const shouldResetValidationState = this._shouldResetValidationState();
 
-    // Don't reset a validation state if repaintChangesOnly is switched on
-    // to let the revert button get access to initial values via _getOldData()
-    if (isBatchBasedEditMode || !repaintChangesOnly) {
+    if (shouldResetValidationState) {
       this._validatingController.initValidationState();
     }
 
     super._beforeCancelEditData();
+  }
+
+  private _shouldResetValidationState(): boolean {
+    const isCellEditMode = this.getEditMode() === EDIT_MODE_CELL;
+
+    if (isCellEditMode) {
+      const columns = this._columnsController.getColumns();
+      const columnsWithValidatingEditors = columns.filter(
+        (col) => col.showEditorAlways && col.validationRules?.length > 0,
+      );
+
+      return columnsWithValidatingEditors.length === 0;
+    }
+
+    return true;
   }
 
   private _showErrorRow(change) {

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/editing.integration.tests.js
@@ -2809,10 +2809,9 @@ QUnit.module('Editing', baseModuleConfig, () => {
             this.clock.tick(10);
             $(grid.getCellElement(0, 1)).trigger('dxclick');
             this.clock.tick(10);
-            const callCount = action === 'close edit cell' ? 3 : 4;
 
             // assert
-            assert.equal(validationCallback.callCount, callCount, 'validation callback call count');
+            assert.equal(validationCallback.callCount, 3, 'validation callback call count');
         });
     });
 


### PR DESCRIPTION
<!--
Before you submit a pull request, review our contribution guidelines (CONTRIBUTING.md).

If your pull request contains a bug fix, its title should include "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What does the PR change?
2. How did you achieve this?
3. How can we verify these changes?

-->
