### PR TITLE
fix(nx-infra-plugin): normalize path separators in build-typescript executor on Windows

### DIFF
--- a/packages/nx-infra-plugin/src/executors/build-typescript/executor.ts
+++ b/packages/nx-infra-plugin/src/executors/build-typescript/executor.ts
@@ -137,6 +137,17 @@ async function resolveSourceFiles(
   return files;
 }
 
+function replacePathPrefix(filePath: string, from: string, to: string): string {
+  if (isWindowsOS()) {
+    return normalizeGlobPathForWindows(filePath).replace(
+      normalizeGlobPathForWindows(from),
+      normalizeGlobPathForWindows(to),
+    );
+  }
+
+  return filePath.replace(from, to);
+}
+
 function buildCompilerOptions(
   tsconfigContent: TsConfig,
   tsconfigPath: string,
@@ -178,7 +189,7 @@ async function emitWithAliasResolution(
     let finalContent = fileData;
 
     if (aliasTranspileFunc && aliasPath) {
-      const normalizedFilePath = filePath.replace(outDir, aliasPath);
+      const normalizedFilePath = replacePathPrefix(filePath, outDir, aliasPath);
       finalContent = aliasTranspileFunc(normalizedFilePath, fileData);
     }
 


### PR DESCRIPTION
<!--
Before you submit a pull request, review our contribution guidelines (CONTRIBUTING.md).

If your pull request contains a bug fix, its title should include "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What does the PR change?
2. How did you achieve this?
3. How can we verify these changes?

-->
