### PR TITLE
Bump devexpress-diagram (T1321142)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,8 +80,8 @@ catalogs:
       specifier: ^4.11.1
       version: 4.11.1
     devexpress-diagram:
-      specifier: 2.2.24
-      version: 2.2.24
+      specifier: 2.2.25
+      version: 2.2.25
     devexpress-gantt:
       specifier: 4.1.64
       version: 4.1.64
@@ -392,7 +392,7 @@ importers:
         version: 2.6.12
       devexpress-diagram:
         specifier: 'catalog:'
-        version: 2.2.24
+        version: 2.2.25
       devexpress-gantt:
         specifier: 'catalog:'
         version: 4.1.64
@@ -1158,7 +1158,7 @@ importers:
         version: 1.8.0
       devexpress-diagram:
         specifier: 'catalog:'
-        version: 2.2.24
+        version: 2.2.25
       devexpress-gantt:
         specifier: 'catalog:'
         version: 4.1.64
@@ -1306,7 +1306,7 @@ importers:
         version: 1.8.0
       devexpress-diagram:
         specifier: 'catalog:'
-        version: 2.2.24
+        version: 2.2.25
       devexpress-gantt:
         specifier: 'catalog:'
         version: 4.1.64
@@ -9798,8 +9798,8 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
-  devexpress-diagram@2.2.24:
-    resolution: {integrity: sha512-PD3mW50OFS44PnqUq2ywJHYDeNFWCIPhXCeLHkzg2BEdDufGGpW73Ux5z3F9NtW91sP0qNE1f1PrsR+3CIN0jA==}
+  devexpress-diagram@2.2.25:
+    resolution: {integrity: sha512-gcj+7AyH6HEzURTbexqbIciCGNFOAbypM6Gi2OuyvtQNR04WQCYozh8C3H0kLfHBNpRm2nEyjJWpV9MWThM8hA==}
 
   devexpress-gantt@4.1.64:
     resolution: {integrity: sha512-q9+diTugmzf3YNzQ4Xutr7ndgCAdpH7IyjTzGy2SiY5I+ePf2BaAZ0R3LGADBC5TuFS2OamIhF0HOj4ALgkf+A==}
@@ -30220,7 +30220,7 @@ snapshots:
       defined: 1.0.1
       minimist: 1.2.8
 
-  devexpress-diagram@2.2.24:
+  devexpress-diagram@2.2.25:
     dependencies:
       '@devexpress/utils': 1.4.7
       es6-object-assign: 1.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ catalog:
   inferno-hydrate: ^8.2.3
   inferno-create-element: ^8.2.3
   inferno-server: ^8.2.3
-  devexpress-diagram: 2.2.24
+  devexpress-diagram: 2.2.25
   devexpress-gantt: 4.1.64
   devextreme-quill: 1.7.8
   eslint: 9.18.0


### PR DESCRIPTION
### 1. What does the PR change?
Updates the `devexpress-diagram` npm package to a version that includes a fix for the bug tracked in  
• DevExpress issue tracker: T1321142  

The bug is reproducible in our application but has already been fixed in the upstream package; this PR integrates that fix by bumping the dependency.

### 2. How did you achieve this?
Updated the `devexpress-diagram` package version in `package.json` to the latest release containing the upstream patch.

### 3. How can we verify these changes?
1. Install dependencies and rebuild the project.  
2. Reproduce the scenario described in T1321142.  
3. Confirm that the incorrect behavior is no longer observed after the version update.  