### PR TITLE
refactor(Scheduler): rename _getAppointmentTemplate and _checkRecurringAppointment

### DIFF
--- a/packages/devextreme/js/__internal/scheduler/m_compact_appointments_helper.ts
+++ b/packages/devextreme/js/__internal/scheduler/m_compact_appointments_helper.ts
@@ -164,7 +164,7 @@ export class CompactAppointmentsHelper {
 
   _createTemplate(count, isCompact) {
     this._initButtonTemplate(count, isCompact);
-    return this.instance._getAppointmentTemplate('appointmentCollectorTemplate');
+    return this.instance.getAppointmentTemplate('appointmentCollectorTemplate');
   }
 
   _initButtonTemplate(count, isCompact) {

--- a/packages/devextreme/js/__internal/scheduler/m_recurrence_editor.ts
+++ b/packages/devextreme/js/__internal/scheduler/m_recurrence_editor.ts
@@ -73,38 +73,38 @@ const days = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
 const getStylingModeFunc = (): string | undefined => (isFluent(current()) ? 'filled' : undefined);
 
 class RecurrenceRule {
-  _recurrenceRule: any;
+  private recurrenceRule: any;
 
   constructor(rule) {
-    this._recurrenceRule = parseRecurrenceRule(rule);
+    this.recurrenceRule = parseRecurrenceRule(rule);
   }
 
   makeRules(string) {
-    this._recurrenceRule = parseRecurrenceRule(string);
+    this.recurrenceRule = parseRecurrenceRule(string);
   }
 
   makeRule(field, value) {
     if (!value || (Array.isArray(value) && !value.length)) {
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-      delete this._recurrenceRule[field];
+      delete this.recurrenceRule[field];
       return;
     }
 
     if (isDefined(field)) {
       if (field === 'until') {
-        delete this._recurrenceRule.count;
+        delete this.recurrenceRule.count;
       }
 
       if (field === 'count') {
-        delete this._recurrenceRule.until;
+        delete this.recurrenceRule.until;
       }
 
-      this._recurrenceRule[field] = value;
+      this.recurrenceRule[field] = value;
     }
   }
 
   getRepeatEndRule() {
-    const rules = this._recurrenceRule;
+    const rules = this.recurrenceRule;
 
     if ('count' in rules) {
       return 'count';
@@ -118,30 +118,30 @@ class RecurrenceRule {
   }
 
   getRecurrenceString() {
-    return getRecurrenceString(this._recurrenceRule);
+    return getRecurrenceString(this.recurrenceRule);
   }
 
   getRules() {
-    return this._recurrenceRule;
+    return this.recurrenceRule;
   }
 
   getDaysFromByDayRule() {
-    return daysFromByDayRule(this._recurrenceRule);
+    return daysFromByDayRule(this.recurrenceRule);
   }
 }
 
 class RecurrenceEditor extends Editor {
-  _recurrenceRule!: RecurrenceRule;
+  private recurrenceRule!: RecurrenceRule;
 
-  _$container: any;
+  private $container: any;
 
-  _weekEditor: any;
+  private weekEditor: any;
 
-  _editors!: any[];
+  private editors!: any[];
 
-  _$repeatOnWeek: any;
+  private $repeatOnWeek: any;
 
-  _recurrenceForm: any;
+  private recurrenceForm: any;
 
   _getDefaultOptions() {
     // @ts-expect-error
@@ -156,12 +156,12 @@ class RecurrenceEditor extends Editor {
     });
   }
 
-  _getFirstDayOfWeek() {
+  private getFirstDayOfWeek() {
     const firstDayOfWeek = this.option('firstDayOfWeek');
     return isDefined(firstDayOfWeek) ? firstDayOfWeek : dateLocalization.firstDayOfWeekIndex();
   }
 
-  _createComponent(element, name, config = {}) {
+  private createComponent(element, name, config = {}) {
     // @ts-expect-error
     this._extendConfig(config, {
       readOnly: this.option('readOnly'),
@@ -174,7 +174,7 @@ class RecurrenceEditor extends Editor {
   _init() {
     // @ts-expect-error
     super._init();
-    this._recurrenceRule = new RecurrenceRule(this.option('value'));
+    this.recurrenceRule = new RecurrenceRule(this.option('value'));
   }
 
   _render() {
@@ -183,13 +183,13 @@ class RecurrenceEditor extends Editor {
 
     (this.$element() as any).addClass(RECURRENCE_EDITOR);
 
-    this._$container = $('<div>')
+    this.$container = $('<div>')
       .addClass(RECURRENCE_EDITOR_CONTAINER)
       .appendTo(this.$element());
 
-    this._prepareEditors();
-    this._renderEditors(this._$container);
-    this._updateRepeatInputAriaLabel();
+    this.prepareEditors();
+    this.renderEditors(this.$container);
+    this.updateRepeatInputAriaLabel();
   }
 
   getEditorByField(fieldName) {
@@ -198,7 +198,7 @@ class RecurrenceEditor extends Editor {
     if (!isDefined(editor)) {
       switch (fieldName) {
         case 'byday':
-          editor = this._weekEditor;
+          editor = this.weekEditor;
           break;
         default:
           break;
@@ -208,31 +208,31 @@ class RecurrenceEditor extends Editor {
     return editor;
   }
 
-  _prepareEditors() {
-    const freq = (this._recurrenceRule.getRules().freq || frequenciesMessages[defaultRecurrenceTypeIndex].value).toLowerCase();
+  private prepareEditors() {
+    const freq = (this.recurrenceRule.getRules().freq || frequenciesMessages[defaultRecurrenceTypeIndex].value).toLowerCase();
 
-    this._editors = [
-      this._createFreqEditor(freq),
-      this._createIntervalEditor(freq),
-      this._createRepeatOnLabel(freq),
+    this.editors = [
+      this.createFreqEditor(freq),
+      this.createIntervalEditor(freq),
+      this.createRepeatOnLabel(freq),
       {
         itemType: 'group',
         cssClass: REPEAT_ON_EDITOR,
         colCount: 2,
         colCountByScreen: { xs: 2 },
-        items: this._createRepeatOnEditor(freq),
+        items: this.createRepeatOnEditor(freq),
       },
       {
         itemType: 'group',
         colCount: 2,
-        items: this._createRepeatEndEditor(),
+        items: this.createRepeatEndEditor(),
       },
     ];
 
-    return this._editors;
+    return this.editors;
   }
 
-  _createFreqEditor(freq) {
+  private createFreqEditor(freq) {
     return {
       dataField: 'freq',
       name: 'FREQ',
@@ -249,7 +249,7 @@ class RecurrenceEditor extends Editor {
         elementAttr: {
           class: FREQUENCY_EDITOR,
         },
-        onValueChanged: (args) => this._valueChangedHandler(args),
+        onValueChanged: (args) => this.valueChangedHandler(args),
       },
       label: {
         text: messageLocalization.format('dxScheduler-editorLabelRecurrence'),
@@ -257,8 +257,8 @@ class RecurrenceEditor extends Editor {
     };
   }
 
-  _createIntervalEditor(freq) {
-    const interval = this._recurrenceRule.getRules().interval || 1;
+  private createIntervalEditor(freq) {
+    const interval = this.recurrenceRule.getRules().interval || 1;
     return {
       itemType: 'group',
       colCount: 2,
@@ -280,7 +280,7 @@ class RecurrenceEditor extends Editor {
             elementAttr: {
               class: INTERVAL_EDITOR,
             },
-            onValueChanged: (args) => this._valueChangedHandler(args),
+            onValueChanged: (args) => this.valueChangedHandler(args),
           },
           label: {
             text: messageLocalization.format('dxScheduler-recurrenceRepeatEvery'),
@@ -295,7 +295,7 @@ class RecurrenceEditor extends Editor {
     };
   }
 
-  _createRepeatOnLabel(freq) {
+  private createRepeatOnLabel(freq) {
     return {
       itemType: 'group',
       cssClass: `${REPEAT_ON_EDITOR}${LABEL_POSTFIX}`,
@@ -310,30 +310,30 @@ class RecurrenceEditor extends Editor {
     };
   }
 
-  _createRepeatOnEditor(freq) {
+  private createRepeatOnEditor(freq) {
     return [
-      this._createByDayEditor(freq),
-      this._createByMonthEditor(freq),
-      this._createByMonthDayEditor(freq),
+      this.createByDayEditor(freq),
+      this.createByMonthEditor(freq),
+      this.createByMonthDayEditor(freq),
     ];
   }
 
-  _createByDayEditor(freq) {
+  private createByDayEditor(freq) {
     return {
       dataField: 'byday',
       colSpan: 2,
       template: (_, itemElement) => {
-        const firstDayOfWeek = this._getFirstDayOfWeek() as any;
-        const byDay = this._daysOfWeekByRules();
+        const firstDayOfWeek = this.getFirstDayOfWeek() as any;
+        const byDay = this.daysOfWeekByRules();
 
         const localDaysNames = dateLocalization.getDayNames('abbreviated');
         const dayNames = days.slice(firstDayOfWeek).concat(days.slice(0, firstDayOfWeek));
 
         const itemsButtonGroup = localDaysNames.slice(firstDayOfWeek).concat(localDaysNames.slice(0, firstDayOfWeek)).map((item, index) => ({ text: item, key: dayNames[index] }));
 
-        this._$repeatOnWeek = $('<div>').addClass(RECURRENCE_BUTTON_GROUP).appendTo(itemElement);
+        this.$repeatOnWeek = $('<div>').addClass(RECURRENCE_BUTTON_GROUP).appendTo(itemElement);
 
-        this._weekEditor = this._createComponent(this._$repeatOnWeek, ButtonGroup, {
+        this.weekEditor = this.createComponent(this.$repeatOnWeek, ButtonGroup, {
           items: itemsButtonGroup,
           field: 'byday',
           selectionMode: 'multiple',
@@ -343,10 +343,10 @@ class RecurrenceEditor extends Editor {
             const selectedItemKeys = e.component.option('selectedItemKeys');
             const selectedKeys = selectedItemKeys?.length
               ? selectedItemKeys
-              : this._getDefaultByDayValue();
+              : this.getDefaultByDayValue();
 
-            this._recurrenceRule.makeRule('byday', selectedKeys);
-            this._changeEditorValue();
+            this.recurrenceRule.makeRule('byday', selectedKeys);
+            this.changeEditorValue();
           },
         });
       },
@@ -357,7 +357,7 @@ class RecurrenceEditor extends Editor {
     };
   }
 
-  _createByMonthEditor(freq) {
+  private createByMonthEditor(freq) {
     const monthsName = (dateLocalization.getMonthNames as any)('wide');
     const months = [...Array(12)].map((_, i) => ({ value: `${i + 1}`, text: monthsName[i] }));
 
@@ -368,14 +368,14 @@ class RecurrenceEditor extends Editor {
         stylingMode: getStylingModeFunc(),
         field: 'bymonth',
         items: months,
-        value: this._monthOfYearByRules(),
+        value: this.monthOfYearByRules(),
         width: recurrentEditorSelectBoxWidth,
         displayExpr: 'text',
         valueExpr: 'value',
         elementAttr: {
           class: MONTH_OF_YEAR,
         },
-        onValueChanged: (args) => this._valueChangedHandler(args),
+        onValueChanged: (args) => this.valueChangedHandler(args),
       },
       visible: freq === 'yearly',
       label: {
@@ -384,7 +384,7 @@ class RecurrenceEditor extends Editor {
     };
   }
 
-  _createByMonthDayEditor(freq) {
+  private createByMonthDayEditor(freq) {
     return {
       dataField: 'bymonthday',
       editorType: 'dxNumberBox',
@@ -397,11 +397,11 @@ class RecurrenceEditor extends Editor {
         field: 'bymonthday',
         showSpinButtons: true,
         useLargeSpinButtons: false,
-        value: this._dayOfMonthByRules(),
+        value: this.dayOfMonthByRules(),
         elementAttr: {
           class: DAY_OF_MONTH,
         },
-        onValueChanged: (args) => this._valueChangedHandler(args),
+        onValueChanged: (args) => this.valueChangedHandler(args),
       },
       visible: freq === 'monthly' || freq === 'yearly',
       label: {
@@ -410,8 +410,8 @@ class RecurrenceEditor extends Editor {
     };
   }
 
-  _createRepeatEndEditor() {
-    const repeatType = this._recurrenceRule.getRepeatEndRule();
+  private createRepeatEndEditor() {
+    const repeatType = this.recurrenceRule.getRepeatEndRule();
 
     return [{
       colSpan: 2,
@@ -438,71 +438,71 @@ class RecurrenceEditor extends Editor {
         },
         layout: 'vertical',
         elementAttr: { class: REPEAT_END_TYPE_EDITOR },
-        onValueChanged: (args) => this._repeatEndValueChangedHandler(args),
+        onValueChanged: (args) => this.repeatEndValueChangedHandler(args),
       },
     }, {
       colSpan: 1,
       itemType: 'group',
       items: [
-        this._getRepeatUntilEditorOptions(),
-        this._getRepeatCountEditorOptions(),
+        this.getRepeatUntilEditorOptions(),
+        this.getRepeatCountEditorOptions(),
       ],
     }];
   }
 
-  _renderEditors($container) {
-    this._recurrenceForm = this._createComponent($container, Form, {
-      items: this._editors,
+  private renderEditors($container) {
+    this.recurrenceForm = this.createComponent($container, Form, {
+      items: this.editors,
       showValidationSummary: false,
       scrollingEnabled: true,
       showColonAfterLabel: false,
       labelLocation: 'top',
     });
 
-    this._changeRepeatEndInputsVisibility();
+    this.changeRepeatEndInputsVisibility();
   }
 
   getRecurrenceForm() {
-    return this._recurrenceForm;
+    return this.recurrenceForm;
   }
 
   changeValueByVisibility(value) {
     if (value) {
       if (!this.option('value')) {
-        this._handleDefaults();
+        this.handleDefaults();
       }
     } else {
-      this._recurrenceRule.makeRules('');
+      this.recurrenceRule.makeRules('');
       this.option('value', '');
     }
   }
 
-  _handleDefaults() {
-    this._recurrenceRule.makeRule('freq', frequenciesMessages[defaultRecurrenceTypeIndex].value);
-    this._changeEditorValue();
+  private handleDefaults() {
+    this.recurrenceRule.makeRule('freq', frequenciesMessages[defaultRecurrenceTypeIndex].value);
+    this.changeEditorValue();
   }
 
-  _changeEditorValue() {
-    this.option('value', this._recurrenceRule.getRecurrenceString() ?? '');
+  private changeEditorValue() {
+    this.option('value', this.recurrenceRule.getRecurrenceString() ?? '');
   }
 
-  _daysOfWeekByRules() {
-    let daysByRule = this._recurrenceRule.getDaysFromByDayRule();
+  private daysOfWeekByRules() {
+    let daysByRule = this.recurrenceRule.getDaysFromByDayRule();
     if (!daysByRule.length) {
-      daysByRule = this._getDefaultByDayValue();
+      daysByRule = this.getDefaultByDayValue();
     }
 
     return daysByRule;
   }
 
-  _getDefaultByDayValue() {
+  private getDefaultByDayValue() {
     const startDate = this.option('startDate') as any;
     const startDay = startDate.getDay();
     return [days[startDay]];
   }
 
-  _dayOfMonthByRules() {
-    let dayByRule = this._recurrenceRule.getRules().bymonthday;
+  private dayOfMonthByRules() {
+    let dayByRule = this.recurrenceRule.getRules().bymonthday;
 
     if (!dayByRule) {
       dayByRule = (this.option('startDate') as any).getDate();
@@ -511,8 +511,8 @@ class RecurrenceEditor extends Editor {
     return dayByRule;
   }
 
-  _monthOfYearByRules() {
-    let monthByRule = this._recurrenceRule.getRules().bymonth;
+  private monthOfYearByRules() {
+    let monthByRule = this.recurrenceRule.getRules().bymonth;
 
     if (!monthByRule) {
       monthByRule = (this.option('startDate') as any).getMonth() + 1;
@@ -521,43 +521,43 @@ class RecurrenceEditor extends Editor {
     return String(monthByRule);
   }
 
-  _repeatEndValueChangedHandler(args) {
+  private repeatEndValueChangedHandler(args) {
     const { value } = args;
 
-    this._changeRepeatEndInputsVisibility(value);
+    this.changeRepeatEndInputsVisibility(value);
 
     if (value === 'until') {
-      this._recurrenceRule.makeRule(value, this._getUntilValue());
+      this.recurrenceRule.makeRule(value, this.getUntilValue());
     }
     if (value === 'count') {
-      this._recurrenceRule.makeRule(value, this._recurrenceForm.option('formData.count'));
+      this.recurrenceRule.makeRule(value, this.recurrenceForm.option('formData.count'));
     }
     if (value === 'never') {
-      this._recurrenceRule.makeRule('count', '');
-      this._recurrenceRule.makeRule('until', '');
+      this.recurrenceRule.makeRule('count', '');
+      this.recurrenceRule.makeRule('until', '');
     }
 
-    this._changeEditorValue();
-    this._updateRepeatInputAriaLabel();
+    this.changeEditorValue();
+    this.updateRepeatInputAriaLabel();
   }
 
-  _changeRepeatEndInputsVisibility(value = this._recurrenceRule.getRepeatEndRule()) {
+  private changeRepeatEndInputsVisibility(value = this.recurrenceRule.getRepeatEndRule()) {
     if (value === 'until') {
-      this._recurrenceForm.itemOption('until', 'visible', true);
-      this._recurrenceForm.itemOption('count', 'visible', false);
+      this.recurrenceForm.itemOption('until', 'visible', true);
+      this.recurrenceForm.itemOption('count', 'visible', false);
     }
     if (value === 'count') {
-      this._recurrenceForm.itemOption('until', 'visible', false);
-      this._recurrenceForm.itemOption('count', 'visible', true);
+      this.recurrenceForm.itemOption('until', 'visible', false);
+      this.recurrenceForm.itemOption('count', 'visible', true);
     }
     if (value === 'never') {
-      this._recurrenceForm.itemOption('until', 'visible', false);
-      this._recurrenceForm.itemOption('count', 'visible', false);
+      this.recurrenceForm.itemOption('until', 'visible', false);
+      this.recurrenceForm.itemOption('count', 'visible', false);
     }
   }
 
-  _getRepeatCountEditorOptions() {
-    const count = this._recurrenceRule.getRules().count || 1;
+  private getRepeatCountEditorOptions() {
+    const count = this.recurrenceRule.getRules().count || 1;
 
     return {
       dataField: 'count',
@@ -573,39 +573,39 @@ class RecurrenceEditor extends Editor {
         showSpinButtons: true,
         useLargeSpinButtons: false,
         value: count,
-        onValueChanged: this._repeatCountValueChangeHandler.bind(this),
+        onValueChanged: this.repeatCountValueChangeHandler.bind(this),
         inputAttr: { 'aria-label': messageLocalization.format('dxScheduler-recurrenceOccurrenceLabel') },
       },
     };
   }
 
-  _updateRepeatInputAriaLabel(): void {
+  private updateRepeatInputAriaLabel(): void {
     const radioButtons = this.getEditorByField('repeatEnd').itemElements();
     const untilLabel = messageLocalization.format('dxScheduler-recurrenceOn');
-    const untilValue = this._recurrenceForm.getEditor('until').option('value');
+    const untilValue = this.recurrenceForm.getEditor('until').option('value');
     const untilValueFormat = `${dateLocalization.format(untilValue, 'd')} ${dateLocalization.format(untilValue, 'monthAndYear')}`;
-    const isUntilVisible = this._recurrenceForm.itemOption('until').visible;
+    const isUntilVisible = this.recurrenceForm.itemOption('until').visible;
 
     const countLabel = messageLocalization.format('dxScheduler-recurrenceAfter');
     const countPostfix = messageLocalization.format('dxScheduler-recurrenceRepeatCount');
-    const countValue = this._recurrenceForm.getEditor('count').option('value');
-    const isCountVisible = this._recurrenceForm.itemOption('count').visible;
+    const countValue = this.recurrenceForm.getEditor('count').option('value');
+    const isCountVisible = this.recurrenceForm.itemOption('count').visible;
 
     radioButtons[1].setAttribute('aria-label', isUntilVisible ? `${untilLabel} ${untilValueFormat}` : untilLabel);
     radioButtons[2].setAttribute('aria-label', isCountVisible ? `${countLabel} ${countValue} ${countPostfix}` : countLabel);
   }
 
-  _repeatCountValueChangeHandler(args) {
-    if (this._recurrenceRule.getRepeatEndRule() === 'count') {
+  private repeatCountValueChangeHandler(args) {
+    if (this.recurrenceRule.getRepeatEndRule() === 'count') {
       const { value } = args;
-      this._recurrenceRule.makeRule('count', value);
-      this._changeEditorValue();
-      this._updateRepeatInputAriaLabel();
+      this.recurrenceRule.makeRule('count', value);
+      this.changeEditorValue();
+      this.updateRepeatInputAriaLabel();
     }
   }
 
-  _getRepeatUntilEditorOptions() {
-    const until = this._getUntilValue();
+  private getRepeatUntilEditorOptions() {
+    const until = this.getUntilValue();
 
     return {
       dataField: 'until',
@@ -618,9 +618,9 @@ class RecurrenceEditor extends Editor {
         value: until,
         type: 'date',
         width: repeatInputWidth,
-        onValueChanged: this._repeatUntilValueChangeHandler.bind(this),
+        onValueChanged: this.repeatUntilValueChangeHandler.bind(this),
         calendarOptions: {
-          firstDayOfWeek: this._getFirstDayOfWeek(),
+          firstDayOfWeek: this.getFirstDayOfWeek(),
         },
         useMaskBehavior: true,
         inputAttr: { 'aria-label': messageLocalization.format('dxScheduler-recurrenceUntilDateLabel') },
@@ -628,8 +628,8 @@ class RecurrenceEditor extends Editor {
     };
   }
 
-  _formatUntilDate(date: Date): Date {
-    const untilDate = this._recurrenceRule.getRules().until;
+  private formatUntilDate(date: Date): Date {
+    const untilDate = this.recurrenceRule.getRules().until;
     const isSameDate = dateUtils.sameDate(untilDate, date);
 
     return untilDate && isSameDate
@@ -637,9 +637,9 @@ class RecurrenceEditor extends Editor {
       : dateUtils.setToDayEnd(date);
   }
 
-  _repeatUntilValueChangeHandler(args) {
-    if (this._recurrenceRule.getRepeatEndRule() === 'until') {
-      const dateInTimeZone = this._formatUntilDate(new Date(args.value));
+  private repeatUntilValueChangeHandler(args) {
+    if (this.recurrenceRule.getRepeatEndRule() === 'until') {
+      const dateInTimeZone = this.formatUntilDate(new Date(args.value));
       const getStartDateTimeZone: any = this.option('getStartDateTimeZone');
       const appointmentTimeZone = getStartDateTimeZone();
 
@@ -647,90 +647,90 @@ class RecurrenceEditor extends Editor {
       const dateInLocaleTimeZone = (this.option('timeZoneCalculator') as any)
         .createDate(dateInTimeZone, path, appointmentTimeZone);
 
-      this._recurrenceRule.makeRule('until', dateInLocaleTimeZone);
-      this._changeEditorValue();
-      this._updateRepeatInputAriaLabel();
+      this.recurrenceRule.makeRule('until', dateInLocaleTimeZone);
+      this.changeEditorValue();
+      this.updateRepeatInputAriaLabel();
     }
   }
 
-  _valueChangedHandler(args) {
+  private valueChangedHandler(args) {
     const { value, previousValue } = args;
     const field = args.component.option('field');
 
     if (!this.option('visible')) {
       this.option('value', '');
     } else {
-      this._recurrenceRule.makeRule(field, value);
+      this.recurrenceRule.makeRule(field, value);
       if (field === 'freq') {
-        this._makeRepeatOnRule(value);
-        this._changeRepeatOnVisibility(value, previousValue);
+        this.makeRepeatOnRule(value);
+        this.changeRepeatOnVisibility(value, previousValue);
       }
-      this._changeEditorValue();
+      this.changeEditorValue();
     }
   }
 
-  _makeRepeatOnRule(value) {
+  private makeRepeatOnRule(value) {
     if (value === 'daily' || value === 'hourly') {
-      this._recurrenceRule.makeRule('byday', '');
-      this._recurrenceRule.makeRule('bymonth', '');
-      this._recurrenceRule.makeRule('bymonthday', '');
+      this.recurrenceRule.makeRule('byday', '');
+      this.recurrenceRule.makeRule('bymonth', '');
+      this.recurrenceRule.makeRule('bymonthday', '');
     }
     if (value === 'weekly') {
-      this._recurrenceRule.makeRule('byday', this._daysOfWeekByRules());
-      this._recurrenceRule.makeRule('bymonth', '');
-      this._recurrenceRule.makeRule('bymonthday', '');
+      this.recurrenceRule.makeRule('byday', this.daysOfWeekByRules());
+      this.recurrenceRule.makeRule('bymonth', '');
+      this.recurrenceRule.makeRule('bymonthday', '');
     }
 
     if (value === 'monthly') {
-      this._recurrenceRule.makeRule('bymonthday', this._dayOfMonthByRules());
-      this._recurrenceRule.makeRule('bymonth', '');
-      this._recurrenceRule.makeRule('byday', '');
+      this.recurrenceRule.makeRule('bymonthday', this.dayOfMonthByRules());
+      this.recurrenceRule.makeRule('bymonth', '');
+      this.recurrenceRule.makeRule('byday', '');
     }
 
     if (value === 'yearly') {
-      this._recurrenceRule.makeRule('bymonthday', this._dayOfMonthByRules());
-      this._recurrenceRule.makeRule('bymonth', this._monthOfYearByRules());
-      this._recurrenceRule.makeRule('byday', '');
+      this.recurrenceRule.makeRule('bymonthday', this.dayOfMonthByRules());
+      this.recurrenceRule.makeRule('bymonth', this.monthOfYearByRules());
+      this.recurrenceRule.makeRule('byday', '');
     }
   }
 
   _optionChanged(args) {
     switch (args.name) {
       case 'readOnly':
-        this._recurrenceForm?.option('readOnly', args.value);
-        this._weekEditor?.option('readOnly', args.value);
+        this.recurrenceForm?.option('readOnly', args.value);
+        this.weekEditor?.option('readOnly', args.value);
         // @ts-expect-error
         super._optionChanged(args);
         break;
       case 'value':
-        this._recurrenceRule.makeRules(args.value);
+        this.recurrenceRule.makeRules(args.value);
 
-        this._changeRepeatIntervalLabel();
-        this._changeRepeatEndInputsVisibility();
-        this._changeEditorsValue(this._recurrenceRule.getRules());
+        this.changeRepeatIntervalLabel();
+        this.changeRepeatEndInputsVisibility();
+        this.changeEditorsValue(this.recurrenceRule.getRules());
 
         // @ts-expect-error
         super._optionChanged(args);
         break;
       case 'startDate':
-        this._makeRepeatOnRule(this._recurrenceRule.getRules().freq);
+        this.makeRepeatOnRule(this.recurrenceRule.getRules().freq);
 
-        if (isDefined(this._recurrenceRule.getRecurrenceString())) {
-          this._changeEditorValue();
+        if (isDefined(this.recurrenceRule.getRecurrenceString())) {
+          this.changeEditorValue();
         }
 
         break;
       case 'firstDayOfWeek':
-        if (this._weekEditor) {
+        if (this.weekEditor) {
           const localDaysNames = dateLocalization.getDayNames('abbreviated');
           const dayNames = days.slice(args.value).concat(days.slice(0, args.value));
 
           const itemsButtonGroup = localDaysNames.slice(args.value).concat(localDaysNames.slice(0, args.value)).map((item, index) => ({ text: item, key: dayNames[index] }));
 
-          this._weekEditor.option('items', itemsButtonGroup);
+          this.weekEditor.option('items', itemsButtonGroup);
         }
-        if (this._recurrenceForm.itemOption('until').visible) {
-          this._recurrenceForm.getEditor('until').option('calendarOptions.firstDayOfWeek', this._getFirstDayOfWeek());
+        if (this.recurrenceForm.itemOption('until').visible) {
+          this.recurrenceForm.getEditor('until').option('calendarOptions.firstDayOfWeek', this.getFirstDayOfWeek());
         }
         break;
       default:
@@ -739,95 +739,95 @@ class RecurrenceEditor extends Editor {
     }
   }
 
-  _changeRepeatOnVisibility(freq, previousFreq) {
+  private changeRepeatOnVisibility(freq, previousFreq) {
     if (freq !== previousFreq) {
-      this._recurrenceForm.itemOption('byday', 'visible', false);
-      this._recurrenceForm.itemOption('bymonthday', 'visible', false);
-      this._recurrenceForm.itemOption('bymonth', 'visible', false);
+      this.recurrenceForm.itemOption('byday', 'visible', false);
+      this.recurrenceForm.itemOption('bymonthday', 'visible', false);
+      this.recurrenceForm.itemOption('bymonth', 'visible', false);
 
-      this._recurrenceForm.itemOption('repeatOnLabel', 'visible', freq && freq !== 'daily' && freq !== 'hourly');
+      this.recurrenceForm.itemOption('repeatOnLabel', 'visible', freq && freq !== 'daily' && freq !== 'hourly');
 
       if (freq === 'weekly') {
-        this._recurrenceForm.itemOption('byday', 'visible', true);
+        this.recurrenceForm.itemOption('byday', 'visible', true);
       }
       if (freq === 'monthly') {
-        this._recurrenceForm.itemOption('bymonthday', 'visible', true);
+        this.recurrenceForm.itemOption('bymonthday', 'visible', true);
       }
       if (freq === 'yearly') {
-        this._recurrenceForm.itemOption('bymonthday', 'visible', true);
-        this._recurrenceForm.itemOption('bymonth', 'visible', true);
+        this.recurrenceForm.itemOption('bymonthday', 'visible', true);
+        this.recurrenceForm.itemOption('bymonth', 'visible', true);
       }
     }
   }
 
-  _changeRepeatIntervalLabel() {
-    const { freq } = this._recurrenceRule.getRules();
+  private changeRepeatIntervalLabel() {
+    const { freq } = this.recurrenceRule.getRules();
 
-    freq && this._recurrenceForm.itemOption('intervalLabel', 'template', messageLocalization.format(`dxScheduler-recurrenceRepeat${freq.charAt(0).toUpperCase()}${freq.substr(1).toLowerCase()}`));
+    freq && this.recurrenceForm.itemOption('intervalLabel', 'template', messageLocalization.format(`dxScheduler-recurrenceRepeat${freq.charAt(0).toUpperCase()}${freq.substr(1).toLowerCase()}`));
   }
 
-  _changeEditorsValue(rules) {
-    this._recurrenceForm.getEditor('freq').option('value', (rules.freq || frequenciesMessages[defaultRecurrenceTypeIndex].value).toLowerCase());
+  private changeEditorsValue(rules) {
+    this.recurrenceForm.getEditor('freq').option('value', (rules.freq || frequenciesMessages[defaultRecurrenceTypeIndex].value).toLowerCase());
 
-    this._changeDayOfWeekValue();
-    this._changeDayOfMonthValue();
-    this._changeMonthOfYearValue();
+    this.changeDayOfWeekValue();
+    this.changeDayOfMonthValue();
+    this.changeMonthOfYearValue();
 
-    this._changeIntervalValue(rules.interval);
+    this.changeIntervalValue(rules.interval);
 
-    this._changeRepeatCountValue();
-    this._changeRepeatEndValue();
-    this._changeRepeatUntilValue();
+    this.changeRepeatCountValue();
+    this.changeRepeatEndValue();
+    this.changeRepeatUntilValue();
   }
 
-  _changeIntervalValue(value) {
-    this._recurrenceForm.getEditor('interval').option('value', value || 1);
+  private changeIntervalValue(value) {
+    this.recurrenceForm.getEditor('interval').option('value', value || 1);
   }
 
-  _changeRepeatEndValue() {
-    const repeatType = this._recurrenceRule.getRepeatEndRule();
+  private changeRepeatEndValue() {
+    const repeatType = this.recurrenceRule.getRepeatEndRule();
 
-    this._recurrenceForm.getEditor('repeatEnd').option('value', repeatType);
+    this.recurrenceForm.getEditor('repeatEnd').option('value', repeatType);
   }
 
-  _changeDayOfWeekValue() {
-    const isEditorVisible = this._recurrenceForm.itemOption('byday').visible;
+  private changeDayOfWeekValue() {
+    const isEditorVisible = this.recurrenceForm.itemOption('byday').visible;
     if (isEditorVisible) {
-      const days = this._daysOfWeekByRules();
+      const days = this.daysOfWeekByRules();
       this.getEditorByField('byday').option('selectedItemKeys', days);
     }
   }
 
-  _changeDayOfMonthValue() {
-    const isEditorVisible = this._recurrenceForm.itemOption('bymonthday').visible;
+  private changeDayOfMonthValue() {
+    const isEditorVisible = this.recurrenceForm.itemOption('bymonthday').visible;
     if (isEditorVisible) {
-      const day = this._dayOfMonthByRules();
-      this._recurrenceForm.getEditor('bymonthday').option('value', day);
+      const day = this.dayOfMonthByRules();
+      this.recurrenceForm.getEditor('bymonthday').option('value', day);
     }
   }
 
-  _changeMonthOfYearValue() {
-    const isEditorVisible = this._recurrenceForm.itemOption('bymonth').visible;
+  private changeMonthOfYearValue() {
+    const isEditorVisible = this.recurrenceForm.itemOption('bymonth').visible;
     if (isEditorVisible) {
-      const month = this._monthOfYearByRules();
-      this._recurrenceForm.getEditor('bymonth').option('value', month);
+      const month = this.monthOfYearByRules();
+      this.recurrenceForm.getEditor('bymonth').option('value', month);
     }
   }
 
-  _changeRepeatCountValue() {
-    const count = this._recurrenceRule.getRules().count || 1;
-    this._recurrenceForm.getEditor('count').option('value', count);
+  private changeRepeatCountValue() {
+    const count = this.recurrenceRule.getRules().count || 1;
+    this.recurrenceForm.getEditor('count').option('value', count);
   }
 
-  _changeRepeatUntilValue() {
-    this._recurrenceForm.getEditor('until').option('value', this._getUntilValue());
+  private changeRepeatUntilValue() {
+    this.recurrenceForm.getEditor('until').option('value', this.getUntilValue());
   }
 
-  _getUntilValue() {
-    const untilDate = this._recurrenceRule.getRules().until;
+  private getUntilValue() {
+    const untilDate = this.recurrenceRule.getRules().until;
 
     if (!untilDate) {
-      return this._formatUntilDate(new Date());
+      return this.formatUntilDate(new Date());
     }
 
     const getStartDateTimeZone: any = this.option('getStartDateTimeZone');

--- a/packages/devextreme/js/__internal/scheduler/m_scheduler.ts
+++ b/packages/devextreme/js/__internal/scheduler/m_scheduler.ts
@@ -163,15 +163,15 @@ const RECURRENCE_EDITING_MODE = {
 class Scheduler extends SchedulerOptionsBaseWidget {
   // NOTE: Do not initialize variables here, because `_initMarkup` function runs before constructor,
   // and initialization in constructor will erase the data
-  _timeZoneCalculator!: any;
+  private _timeZoneCalculator!: any;
 
   postponedOperations: any;
 
-  _a11yStatus!: dxElementWrapper;
+  private a11yStatus!: dxElementWrapper;
 
   _workSpace: any;
 
-  _header?: SchedulerHeader;
+  private header?: SchedulerHeader;
 
   _appointments: any;
 
@@ -183,47 +183,47 @@ class Scheduler extends SchedulerOptionsBaseWidget {
 
   resourceManager!: ResourceManager;
 
-  _actions: any;
+  private actions: any;
 
   _createActionByOption: any;
 
-  _appointmentTooltip!: MobileTooltipStrategy | DesktopTooltipStrategy;
+  private appointmentTooltip!: MobileTooltipStrategy | DesktopTooltipStrategy;
 
-  _readyToRenderAppointments?: boolean;
+  private readyToRenderAppointments?: boolean;
 
-  _editing: any;
+  private editing: any;
 
-  _workSpaceRecalculation: any;
+  private workSpaceRecalculation: any;
 
-  _appointmentPopup: any;
+  private appointmentPopup: any;
 
   _compactAppointmentsHelper!: CompactAppointmentsHelper;
 
-  _asyncTemplatesTimers!: any[];
+  private asyncTemplatesTimers!: any[];
 
-  _updatingAppointments: Set<Appointment> = new Set();
+  private readonly updatingAppointments: Set<Appointment> = new Set();
 
-  _dataSourceLoadedCallback: any;
+  private dataSourceLoadedCallback: any;
 
-  _subscribes: any;
+  private subscribes: any;
 
-  _notifyScheduler!: NotifyScheduler;
+  private notifyScheduler!: NotifyScheduler;
 
-  _recurrenceDialog: any;
+  private recurrenceDialog: any;
 
   _layoutManager!: AppointmentLayoutManager;
 
-  _appointmentForm: any;
+  private appointmentForm: any;
 
-  _mainContainer: any;
+  private mainContainer: any;
 
-  _all: any;
+  private readonly all: any;
 
   _options: any;
 
-  _editAppointmentData: any;
+  private editAppointmentData: any;
 
-  _timeZonesPromise!: Promise<TimezoneLabel[]>;
+  private timeZonesPromise!: Promise<TimezoneLabel[]>;
 
   get timeZoneCalculator() {
     if (!this._timeZoneCalculator) {
@@ -233,11 +233,11 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     return this._timeZoneCalculator;
   }
 
-  _postponeDataSourceLoading(promise?: any) {
-    this.postponedOperations.add('_reloadDataSource', this._reloadDataSource.bind(this), promise);
+  private postponeDataSourceLoading(promise?: any) {
+    this.postponedOperations.add('_reloadDataSource', this.reloadDataSource.bind(this), promise);
   }
 
-  _postponeResourceLoading(forceReload = false) {
+  private postponeResourceLoading(forceReload = false) {
     const whenLoaded = this.postponedOperations.add('loadResources', () => {
       const groups = this.getViewOption('groups');
 
@@ -251,7 +251,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       resolveCallbacks.resolve();
     });
 
-    this._postponeDataSourceLoading(whenLoaded);
+    this.postponeDataSourceLoading(whenLoaded);
 
     return resolveCallbacks.promise();
   }
@@ -263,64 +263,64 @@ class Scheduler extends SchedulerOptionsBaseWidget {
 
     switch (args.name) {
       case 'customizeDateNavigatorText':
-        this._updateOption('header', name, value);
+        this.updateOption('header', name, value);
         break;
       case 'firstDayOfWeek':
-        this._updateOption('workSpace', name, value);
-        this._updateOption('header', name, value);
-        this._cleanPopup();
+        this.updateOption('workSpace', name, value);
+        this.updateOption('header', name, value);
+        this.cleanPopup();
         break;
       case 'currentDate': {
         const dateValue = this.getViewOption(name);
         this.option('selectedCellData', []);
-        this._updateOption('workSpace', name, dateValue);
-        this._updateOption('header', name, dateValue);
-        this._updateOption('header', 'startViewDate', this.getStartViewDate());
+        this.updateOption('workSpace', name, dateValue);
+        this.updateOption('header', name, dateValue);
+        this.updateOption('header', 'startViewDate', this.getStartViewDate());
         this._appointments.option('items', []);
-        this._setRemoteFilterIfNeeded();
+        this.setRemoteFilterIfNeeded();
 
-        this._postponeDataSourceLoading();
+        this.postponeDataSourceLoading();
         break;
       }
       case 'dataSource':
         // @ts-expect-error
         this._initDataSource();
 
-        this._postponeResourceLoading().done(() => {
+        this.postponeResourceLoading().done(() => {
           this.appointmentDataSource.setDataSource(this._dataSource);
-          this._setRemoteFilterIfNeeded();
-          this._updateOption('workSpace', 'showAllDayPanel', this.option('showAllDayPanel'));
+          this.setRemoteFilterIfNeeded();
+          this.updateOption('workSpace', 'showAllDayPanel', this.option('showAllDayPanel'));
         });
         break;
       case 'min':
       case 'max': {
         const value = this.getViewOption(name);
-        this._updateOption('header', name, value);
-        this._updateOption('workSpace', name, value);
+        this.updateOption('header', name, value);
+        this.updateOption('workSpace', name, value);
         break;
       }
       case 'views':
         if (this.currentView) {
           this.repaint();
         } else {
-          this._updateOption('header', 'views', this.views);
+          this.updateOption('header', 'views', this.views);
         }
         break;
       case 'useDropDownViewSwitcher':
-        this._updateOption('header', name, value);
+        this.updateOption('header', name, value);
         break;
       case 'currentView':
         this._appointments.option({
           items: [],
-          allowDrag: this._allowDragging(),
-          allowResize: this._allowResizing(),
+          allowDrag: this.allowDragging(),
+          allowResize: this.allowResizing(),
           itemTemplate: this._getAppointmentTemplate('appointmentTemplate'),
         });
 
-        this._postponeResourceLoading().done(() => {
-          this._refreshWorkSpace();
-          this._header?.option(this._headerConfig());
-          this._setRemoteFilterIfNeeded();
+        this.postponeResourceLoading().done(() => {
+          this.refreshWorkSpace();
+          this.header?.option(this.headerConfig());
+          this.setRemoteFilterIfNeeded();
           this._appointments.option('allowAllDayResize', value !== 'day');
         });
         // NOTE:
@@ -339,9 +339,9 @@ class Scheduler extends SchedulerOptionsBaseWidget {
         this.repaint();
         break;
       case 'groups':
-        this._postponeResourceLoading().done(() => {
-          this._refreshWorkSpace();
-          this._setRemoteFilterIfNeeded();
+        this.postponeResourceLoading().done(() => {
+          this.refreshWorkSpace();
+          this.setRemoteFilterIfNeeded();
         });
         break;
       case 'resources':
@@ -349,11 +349,11 @@ class Scheduler extends SchedulerOptionsBaseWidget {
         this.resourceManager = new ResourceManager(this.option('resources'));
         this.updateAppointmentDataSource();
 
-        this._postponeResourceLoading().done(() => {
+        this.postponeResourceLoading().done(() => {
           this._appointments.option('items', []);
-          this._refreshWorkSpace();
-          this._setRemoteFilterIfNeeded();
-          this._createAppointmentPopupForm();
+          this.refreshWorkSpace();
+          this.setRemoteFilterIfNeeded();
+          this.createAppointmentPopupForm();
         });
         break;
       case 'startDayHour':
@@ -361,11 +361,11 @@ class Scheduler extends SchedulerOptionsBaseWidget {
         this.updateAppointmentDataSource();
 
         this._appointments.option('items', []);
-        this._updateOption('workSpace', name, value);
+        this.updateOption('workSpace', name, value);
         this._appointments.repaint();
-        this._setRemoteFilterIfNeeded();
+        this.setRemoteFilterIfNeeded();
 
-        this._postponeDataSourceLoading();
+        this.postponeDataSourceLoading();
         break;
         // TODO Vinogradov refactoring: merge it with startDayHour / endDayHour
       case 'offset':
@@ -373,11 +373,11 @@ class Scheduler extends SchedulerOptionsBaseWidget {
         this.updateAppointmentDataSource();
 
         this._appointments.option('items', []);
-        this._updateOption('workSpace', 'viewOffset', this.normalizeViewOffsetValue(value));
+        this.updateOption('workSpace', 'viewOffset', this.normalizeViewOffsetValue(value));
         this._appointments.repaint();
-        this._setRemoteFilterIfNeeded();
+        this.setRemoteFilterIfNeeded();
 
-        this._postponeDataSourceLoading();
+        this.postponeDataSourceLoading();
         break;
       case StoreEventNames.ADDING:
       case StoreEventNames.ADDED:
@@ -387,10 +387,10 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       case StoreEventNames.DELETED:
       case 'onAppointmentFormOpening':
       case 'onAppointmentTooltipShowing':
-        this._actions[name] = this._createActionByOption(name);
+        this.actions[name] = this._createActionByOption(name);
         break;
       case 'onAppointmentRendered':
-        this._appointments.option('onItemRendered', this._getAppointmentRenderedAction());
+        this._appointments.option('onItemRendered', this.getAppointmentRenderedAction());
         break;
       case 'onAppointmentClick':
         this._appointments.option('onItemClick', this._createActionByOption(name));
@@ -400,50 +400,50 @@ class Scheduler extends SchedulerOptionsBaseWidget {
         break;
       case 'onAppointmentContextMenu':
         this._appointments.option('onItemContextMenu', this._createActionByOption(name));
-        this._appointmentTooltip._options.onItemContextMenu = this._createActionByOption(name);
+        this.appointmentTooltip._options.onItemContextMenu = this._createActionByOption(name);
         break;
       case 'noDataText':
       case 'allowMultipleCellSelection':
       case 'selectedCellData':
       case 'accessKey':
       case 'onCellClick':
-        this._updateOption('workSpace', name, value);
+        this.updateOption('workSpace', name, value);
         break;
       case 'onCellContextMenu':
-        this._updateOption('workSpace', name, value);
+        this.updateOption('workSpace', name, value);
         break;
       case 'crossScrollingEnabled':
-        this._postponeResourceLoading().done(() => {
+        this.postponeResourceLoading().done(() => {
           this._appointments.option('items', []);
-          this._refreshWorkSpace();
-          if (this._readyToRenderAppointments) {
+          this.refreshWorkSpace();
+          if (this.readyToRenderAppointments) {
             this._appointments.option('items', this._layoutManager.generateViewModel());
           }
         });
         break;
       case 'cellDuration':
-        this._updateOption('workSpace', name, value);
+        this.updateOption('workSpace', name, value);
         this._appointments.option('items', []);
-        if (this._readyToRenderAppointments) {
-          this._updateOption('workSpace', 'hoursInterval', value / 60);
+        if (this.readyToRenderAppointments) {
+          this.updateOption('workSpace', 'hoursInterval', value / 60);
           this._appointments.option('items', this._layoutManager.generateViewModel());
         }
         break;
       case 'tabIndex':
       case 'focusStateEnabled':
-        this._updateOption('header', name, value);
-        this._updateOption('workSpace', name, value);
+        this.updateOption('header', name, value);
+        this.updateOption('workSpace', name, value);
         this._appointments.option(name, value);
         // @ts-expect-error
         super._optionChanged(args);
         break;
       case 'width':
         // TODO: replace with css
-        this._updateOption('header', name, value);
+        this.updateOption('header', name, value);
         if (this.option('crossScrollingEnabled')) {
-          this._updateOption('workSpace', 'width', value);
+          this.updateOption('workSpace', 'width', value);
         }
-        this._updateOption('workSpace', 'schedulerWidth', value);
+        this.updateOption('workSpace', 'schedulerWidth', value);
         // @ts-expect-error
         super._optionChanged(args);
         this._dimensionChanged(null, true);
@@ -452,16 +452,16 @@ class Scheduler extends SchedulerOptionsBaseWidget {
         // @ts-expect-error
         super._optionChanged(args);
         this._dimensionChanged(null, true);
-        this._updateOption('workSpace', 'schedulerHeight', value);
+        this.updateOption('workSpace', 'schedulerHeight', value);
         break;
       case 'editing': {
-        this._initEditing();
-        const editing = this._editing;
+        this.initEditing();
+        const { editing } = this;
 
-        this._bringEditingModeToAppointments(editing);
+        this.bringEditingModeToAppointments(editing);
 
         this.hideAppointmentTooltip();
-        this._cleanPopup();
+        this.cleanPopup();
         break;
       }
       case 'showAllDayPanel':
@@ -472,12 +472,12 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       case 'indicatorUpdateInterval':
       case 'shadeUntilCurrentTime':
       case 'groupByDate':
-        this._updateOption('workSpace', name, value);
+        this.updateOption('workSpace', name, value);
         this.repaint();
         break;
       case 'indicatorTime':
-        this._updateOption('workSpace', name, value);
-        this._updateOption('header', name, value);
+        this.updateOption('workSpace', name, value);
+        this.updateOption('header', name, value);
         this.repaint();
         break;
       case 'appointmentDragging':
@@ -509,32 +509,32 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       case 'recurrenceExceptionExpr':
       case 'disabledExpr':
       case 'visibleExpr':
-        this._updateExpression(name, value);
-        this._initAppointmentTemplate();
+        this.updateExpression(name, value);
+        this.initAppointmentTemplate();
         this.repaint();
         break;
       case 'adaptivityEnabled':
-        this._toggleAdaptiveClass();
+        this.toggleAdaptiveClass();
         this.repaint();
         break;
       case 'scrolling':
-        this.option('crossScrollingEnabled', this._isHorizontalVirtualScrolling() || this.option('crossScrollingEnabled'));
+        this.option('crossScrollingEnabled', this.isHorizontalVirtualScrolling() || this.option('crossScrollingEnabled'));
 
-        this._updateOption('workSpace', args.fullName, value);
+        this.updateOption('workSpace', args.fullName, value);
         break;
       case 'allDayPanelMode':
         this.updateAppointmentDataSource();
-        this._updateOption('workSpace', args.fullName, value);
+        this.updateOption('workSpace', args.fullName, value);
         break;
       case 'renovateRender':
-        this._updateOption('workSpace', name, value);
+        this.updateOption('workSpace', name, value);
         break;
       case '_draggingMode':
-        this._updateOption('workSpace', 'draggingMode', value);
+        this.updateOption('workSpace', 'draggingMode', value);
         break;
       case 'toolbar':
-        this._header
-          ? this._header.onToolbarOptionChanged(args.fullName, value)
+        this.header
+          ? this.header.onToolbarOptionChanged(args.fullName, value)
           : this.repaint();
         break;
       default:
@@ -543,46 +543,46 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     }
   }
 
-  _bringEditingModeToAppointments(editing) {
+  private bringEditingModeToAppointments(editing) {
     const editingConfig: any = {
       allowDelete: editing.allowUpdating && editing.allowDeleting,
     };
 
-    if (!this._isAgenda()) {
+    if (!this.isAgenda()) {
       editingConfig.allowDrag = editing.allowDragging;
       editingConfig.allowResize = editing.allowResizing;
-      editingConfig.allowAllDayResize = editing.allowResizing && this._supportAllDayResizing();
+      editingConfig.allowAllDayResize = editing.allowResizing && this.supportAllDayResizing();
     }
 
     this._appointments.option(editingConfig);
     this.repaint();
   }
 
-  _isAgenda() {
+  private isAgenda() {
     return this.currentView.type === 'agenda';
   }
 
-  _allowDragging() {
-    return this._editing.allowDragging && !this._isAgenda();
+  private allowDragging() {
+    return this.editing.allowDragging && !this.isAgenda();
   }
 
-  _allowResizing() {
-    return this._editing.allowResizing && !this._isAgenda();
+  private allowResizing() {
+    return this.editing.allowResizing && !this.isAgenda();
   }
 
-  _allowAllDayResizing() {
-    return this._editing.allowResizing && this._supportAllDayResizing();
+  private allowAllDayResizing() {
+    return this.editing.allowResizing && this.supportAllDayResizing();
   }
 
-  _supportAllDayResizing() {
+  private supportAllDayResizing() {
     return this.currentView.type !== 'day' || this.currentView.intervalCount > 1;
   }
 
-  _isAllDayExpanded() {
+  private isAllDayExpanded() {
     return this.option('showAllDayPanel') && this._layoutManager.hasAllDayAppointments();
   }
 
-  _setRemoteFilterIfNeeded(): void {
+  private setRemoteFilterIfNeeded(): void {
     const dataSource = this._dataSource;
     const remoteFiltering = this.option('remoteFiltering');
 
@@ -609,7 +609,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     dataSource.filter(filter);
   }
 
-  _reloadDataSource() {
+  private reloadDataSource() {
     // @ts-expect-error
     const result = new Deferred();
 
@@ -644,8 +644,8 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       result?.resolve();
     };
 
-    if (this._workSpaceRecalculation) {
-      this._workSpaceRecalculation?.done(() => {
+    if (this.workSpaceRecalculation) {
+      this.workSpaceRecalculation?.done(() => {
         fireContentReady();
       });
     } else {
@@ -662,18 +662,18 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       return;
     }
 
-    this._toggleSmallClass();
+    this.toggleSmallClass();
 
     const workspace = this.getWorkSpace();
 
     if (
-      !this._isAgenda()
+      !this.isAgenda()
       && this._layoutManager
       && workspace
       && !isAgendaWorkspaceComponent(workspace)
     ) {
       if (isForce || (!isFixedHeight || !isFixedWidth)) {
-        workspace.option('allDayExpanded', this._isAllDayExpanded());
+        workspace.option('allDayExpanded', this.isAllDayExpanded());
         workspace._dimensionChanged();
         const appointments = this._layoutManager.generateViewModel();
 
@@ -684,22 +684,22 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     this.hideAppointmentTooltip();
 
     // TODO popup
-    this._appointmentPopup.triggerResize();
-    this._appointmentPopup.updatePopupFullScreenMode();
+    this.appointmentPopup.triggerResize();
+    this.appointmentPopup.updatePopupFullScreenMode();
   }
 
   _clean() {
-    this._cleanPopup();
+    this.cleanPopup();
     // @ts-expect-error
     super._clean();
   }
 
-  _toggleSmallClass() {
+  private toggleSmallClass() {
     const { width } = getBoundingRect((this.$element() as any).get(0));
     (this.$element() as any).toggleClass(WIDGET_SMALL_CLASS, width < WIDGET_SMALL_WIDTH);
   }
 
-  _toggleAdaptiveClass() {
+  private toggleAdaptiveClass() {
     (this.$element() as any).toggleClass(WIDGET_ADAPTIVE_CLASS, this.option('adaptivityEnabled'));
   }
 
@@ -711,15 +711,15 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     return { paginate: false };
   }
 
-  _initAllDayPanel() {
+  private initAllDayPanel() {
     if (this.option('allDayPanelMode') === 'hidden') {
       this.option('showAllDayPanel', false);
     }
   }
 
   _init() {
-    this._timeZonesPromise = timeZoneUtils.cacheTimeZones();
-    this._initExpressions({
+    this.timeZonesPromise = timeZoneUtils.cacheTimeZones();
+    this.initExpressions({
       startDateExpr: this.option('startDateExpr'),
       endDateExpr: this.option('endDateExpr'),
       startDateTimeZoneExpr: this.option('startDateTimeZoneExpr'),
@@ -735,32 +735,32 @@ class Scheduler extends SchedulerOptionsBaseWidget {
 
     super._init();
 
-    this._initAllDayPanel();
+    this.initAllDayPanel();
 
     // @ts-expect-error
     this._initDataSource();
 
-    this._customizeDataSourceLoadOptions();
+    this.customizeDataSourceLoadOptions();
 
     (this.$element() as any).addClass(WIDGET_CLASS);
 
-    this._initEditing();
+    this.initEditing();
 
     this.updateAppointmentDataSource();
 
-    this._initActions();
+    this.initActions();
 
     this._compactAppointmentsHelper = new CompactAppointmentsHelper(this);
 
-    this._asyncTemplatesTimers = [];
+    this.asyncTemplatesTimers = [];
 
-    this._dataSourceLoadedCallback = Callbacks();
+    this.dataSourceLoadedCallback = Callbacks();
 
-    this._subscribes = subscribes;
+    this.subscribes = subscribes;
 
     this.resourceManager = new ResourceManager(this.option('resources'));
 
-    this._notifyScheduler = new NotifyScheduler({ scheduler: this });
+    this.notifyScheduler = new NotifyScheduler({ scheduler: this });
   }
 
   createAppointmentDataSource() {
@@ -776,7 +776,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     }
   }
 
-  _customizeDataSourceLoadOptions() {
+  private customizeDataSourceLoadOptions() {
     this._dataSource?.on('customizeStoreLoadOptions', ({ storeLoadOptions }) => {
       storeLoadOptions.startDate = this.getStartViewDate();
       storeLoadOptions.endDate = this.getEndViewDate();
@@ -784,7 +784,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
   }
 
   _initTemplates() {
-    this._initAppointmentTemplate();
+    this.initAppointmentTemplate();
 
     this._templateManager.addDefaultTemplates({
       appointmentTooltip: new EmptyTemplate(),
@@ -794,7 +794,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     super._initTemplates();
   }
 
-  _initAppointmentTemplate() {
+  private initAppointmentTemplate() {
     const { expr } = this._dataAccessors;
     const createGetter = (property) => compileGetter(`appointmentData.${property}`);
 
@@ -841,11 +841,11 @@ class Scheduler extends SchedulerOptionsBaseWidget {
   }
 
   _dataSourceChangedHandler(result?: Appointment[]) {
-    if (this._readyToRenderAppointments) {
-      this._workSpaceRecalculation.done(() => {
+    if (this.readyToRenderAppointments) {
+      this.workSpaceRecalculation.done(() => {
         this._layoutManager.prepareAppointments(result);
-        this._renderAppointments();
-        this._updateA11yStatus();
+        this.renderAppointments();
+        this.updateA11yStatus();
       });
     }
   }
@@ -862,11 +862,11 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     return scrolling?.mode === 'virtual';
   }
 
-  _renderAppointments() {
+  private renderAppointments() {
     const workspace = this.getWorkSpace();
     this._layoutManager.filterAppointments();
 
-    workspace.option('allDayExpanded', this._isAllDayExpanded());
+    workspace.option('allDayExpanded', this.isAllDayExpanded());
 
     // @ts-expect-error
     const viewModel: AppointmentViewModelPlain[] = this._isVisible()
@@ -875,12 +875,12 @@ class Scheduler extends SchedulerOptionsBaseWidget {
 
     this._appointments.option('items', viewModel);
     this.appointmentDataSource.cleanState();
-    if (this._isAgenda()) {
+    if (this.isAgenda()) {
       this._workSpace.renderAgendaLayout(viewModel);
     }
   }
 
-  _initExpressions(fields: IFieldExpr) {
+  private initExpressions(fields: IFieldExpr) {
     this._dataAccessors = new AppointmentDataAccessor(
       fields,
       Boolean(config().forceIsoDateParsing),
@@ -888,14 +888,14 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     );
   }
 
-  _updateExpression(name: string, value: string) {
+  private updateExpression(name: string, value: string) {
     this._dataAccessors.updateExpression(name, value);
   }
 
-  _initEditing() {
+  private initEditing() {
     const editing = this.option('editing');
 
-    this._editing = {
+    this.editing = {
       allowAdding: Boolean(editing),
       allowUpdating: Boolean(editing),
       allowDeleting: Boolean(editing),
@@ -905,14 +905,14 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     };
 
     if (isObject(editing)) {
-      this._editing = extend(this._editing, editing);
+      this.editing = extend(this.editing, editing);
     }
 
-    this._editing.allowDragging = this._editing.allowDragging && this._editing.allowUpdating;
-    this._editing.allowResizing = this._editing.allowResizing && this._editing.allowUpdating;
+    this.editing.allowDragging = this.editing.allowDragging && this.editing.allowUpdating;
+    this.editing.allowResizing = this.editing.allowResizing && this.editing.allowUpdating;
 
     const isReadOnly = Object.values({
-      ...this._editing,
+      ...this.editing,
       form: undefined,
       popup: undefined,
     }).every((value) => !value);
@@ -922,14 +922,14 @@ class Scheduler extends SchedulerOptionsBaseWidget {
 
   _dispose() {
     this.resourceManager?.dispose();
-    this._appointmentTooltip?.dispose();
-    this._recurrenceDialog?.hide(RECURRENCE_EDITING_MODE.CANCEL);
+    this.appointmentTooltip?.dispose();
+    this.recurrenceDialog?.hide(RECURRENCE_EDITING_MODE.CANCEL);
 
     this.hideAppointmentPopup();
     this.hideAppointmentTooltip();
 
-    this._asyncTemplatesTimers.forEach(clearTimeout);
-    this._asyncTemplatesTimers = [];
+    this.asyncTemplatesTimers.forEach(clearTimeout);
+    this.asyncTemplatesTimers = [];
 
     // NOTE: Stop all scheduled macro tasks
     macroTaskArray.dispose();
@@ -938,8 +938,8 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     super._dispose();
   }
 
-  _initActions() {
-    this._actions = {
+  private initActions() {
+    this.actions = {
       onAppointmentAdding: this._createActionByOption(StoreEventNames.ADDING),
       onAppointmentAdded: this._createActionByOption(StoreEventNames.ADDED),
       onAppointmentUpdating: this._createActionByOption(StoreEventNames.UPDATING),
@@ -951,7 +951,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     };
   }
 
-  _getAppointmentRenderedAction() {
+  private getAppointmentRenderedAction() {
     return this._createActionByOption('onAppointmentRendered', {
       excludeValidators: ['disabled', 'readOnly'],
     });
@@ -959,7 +959,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
 
   _renderFocusTarget() { return noop(); }
 
-  _updateA11yStatus() {
+  private updateA11yStatus() {
     const dateRange = this._workSpace.getDateRange();
     const indicatorTime = this.option('showCurrentTimeIndicator')
       ? getToday(this.option('indicatorTime') as Date, this.timeZoneCalculator)
@@ -974,46 +974,46 @@ class Scheduler extends SchedulerOptionsBaseWidget {
 
     // @ts-expect-error
     this.setAria({ label });
-    this._a11yStatus.text(label);
+    this.a11yStatus.text(label);
   }
 
-  _renderA11yStatus() {
-    this._a11yStatus = createA11yStatusContainer();
-    this._a11yStatus.prependTo(this.$element());
+  private renderA11yStatus() {
+    this.a11yStatus = createA11yStatusContainer();
+    this.a11yStatus.prependTo(this.$element());
     // @ts-expect-error
     this.setAria({ role: 'application' });
   }
 
-  _initMarkupOnResourceLoaded() {
+  private initMarkupOnResourceLoaded() {
     if (!(this as any)._disposed) {
-      this._initMarkupCore();
-      this._reloadDataSource();
+      this.initMarkupCore();
+      this.reloadDataSource();
     }
   }
 
   _initMarkup(): void {
     super._initMarkup();
 
-    this._renderA11yStatus();
-    this._renderMainContainer();
-    this._renderHeader();
-    this._toggleAdaptiveClass();
+    this.renderA11yStatus();
+    this.renderMainContainer();
+    this.renderHeader();
+    this.toggleAdaptiveClass();
 
     this._layoutManager = new AppointmentLayoutManager(this);
 
     // @ts-expect-error
-    this._appointments = this._createComponent('<div>', AppointmentCollection, this._appointmentsConfig());
+    this._appointments = this._createComponent('<div>', AppointmentCollection, this.appointmentsConfig());
     this._appointments.option('itemTemplate', this._getAppointmentTemplate('appointmentTemplate'));
 
-    this._appointmentTooltip = new (this.option('adaptivityEnabled')
+    this.appointmentTooltip = new (this.option('adaptivityEnabled')
       ? MobileTooltipStrategy
-      : DesktopTooltipStrategy)(this._getAppointmentTooltipOptions());
+      : DesktopTooltipStrategy)(this.getAppointmentTooltipOptions());
 
-    this._createAppointmentPopupForm();
+    this.createAppointmentPopupForm();
 
     // @ts-expect-error
-    if (this._isDataSourceLoaded() || this._isDataSourceLoading()) {
-      this._initMarkupCore();
+    if (this.isDataSourceLoaded() || this._isDataSourceLoading()) {
+      this.initMarkupCore();
       this._dataSourceChangedHandler(this._dataSource.items());
       this._fireContentReadyAction();
     } else {
@@ -1021,27 +1021,27 @@ class Scheduler extends SchedulerOptionsBaseWidget {
 
       if (groups?.length) {
         this.resourceManager.loadGroupResources(groups, true)
-          .then(() => this._initMarkupOnResourceLoaded());
+          .then(() => this.initMarkupOnResourceLoaded());
       } else {
-        this._initMarkupOnResourceLoaded();
+        this.initMarkupOnResourceLoaded();
       }
     }
   }
 
-  _createAppointmentPopupForm() {
-    if (this._appointmentForm) {
-      this._appointmentForm.form?.dispose();
+  private createAppointmentPopupForm() {
+    if (this.appointmentForm) {
+      this.appointmentForm.form?.dispose();
     }
-    this._appointmentForm = this.createAppointmentForm();
+    this.appointmentForm = this.createAppointmentForm();
 
-    this._appointmentPopup?.dispose();
-    this._appointmentPopup = this.createAppointmentPopup(this._appointmentForm);
+    this.appointmentPopup?.dispose();
+    this.appointmentPopup = this.createAppointmentPopup(this.appointmentForm);
   }
 
-  _renderMainContainer() {
-    this._mainContainer = $('<div>').addClass('dx-scheduler-container');
+  private renderMainContainer() {
+    this.mainContainer = $('<div>').addClass('dx-scheduler-container');
 
-    this.$element().append(this._mainContainer);
+    this.$element().append(this.mainContainer);
   }
 
   createAppointmentForm() {
@@ -1051,7 +1051,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       // @ts-expect-error
       createComponent: (element, component, options) => this._createComponent(element, component, options),
 
-      getEditingConfig: () => this._editing,
+      getEditingConfig: () => this.editing,
       getResourceManager: () => this.resourceManager,
 
       getFirstDayOfWeek: () => this.option('firstDayOfWeek'),
@@ -1060,7 +1060,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       getTimeZoneCalculator: () => this.timeZoneCalculator,
     };
 
-    if (this._editing.legacyForm) {
+    if (this.editing.legacyForm) {
       (scheduler as any).createResourceEditorModel = () => createResourceEditorModel(this.resourceManager.resourceById);
 
       return new AppointmentLegacyForm(scheduler);
@@ -1078,12 +1078,12 @@ class Scheduler extends SchedulerOptionsBaseWidget {
 
       getResourceManager: () => this.resourceManager,
 
-      getEditingConfig: () => this._editing,
+      getEditingConfig: () => this.editing,
 
       getTimeZoneCalculator: () => this.timeZoneCalculator,
       getDataAccessors: () => this._dataAccessors,
-      getAppointmentFormOpening: () => this._actions.onAppointmentFormOpening,
-      processActionResult: (arg, canceled) => this._processActionResult(arg, canceled),
+      getAppointmentFormOpening: () => this.actions.onAppointmentFormOpening,
+      processActionResult: (arg, canceled) => this.processActionResult(arg, canceled),
 
       addAppointment: (appointment) => this.addAppointment(appointment),
       updateAppointment: (sourceAppointment, updatedAppointment) => this.updateAppointment(sourceAppointment, updatedAppointment),
@@ -1092,12 +1092,12 @@ class Scheduler extends SchedulerOptionsBaseWidget {
         this._workSpace.updateScrollPosition(startDate, appointmentGroupValues, inAllDayRow);
       },
     };
-    return this._editing.legacyForm
+    return this.editing.legacyForm
       ? new AppointmentLegacyPopup(scheduler, form)
       : new AppointmentPopup(scheduler, form);
   }
 
-  _getAppointmentTooltipOptions() {
+  private getAppointmentTooltipOptions() {
     const that = this;
     return {
       // @ts-expect-error
@@ -1149,7 +1149,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     );
   }
 
-  _getExtraAppointmentTooltipOptions() {
+  private getExtraAppointmentTooltipOptions() {
     return {
       rtlEnabled: this.option('rtlEnabled'),
       focusStateEnabled: this.option('focusStateEnabled'),
@@ -1165,25 +1165,25 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     return itTakesAllDay && workSpace.supportAllDayRow() && workSpace.option('showAllDayPanel');
   }
 
-  _initMarkupCore() {
-    this._readyToRenderAppointments = hasWindow();
+  private initMarkupCore() {
+    this.readyToRenderAppointments = hasWindow();
 
-    this._workSpace && this._cleanWorkspace();
+    this._workSpace && this.cleanWorkspace();
 
-    this._renderWorkSpace();
+    this.renderWorkSpace();
     this._appointments.option({
       fixedContainer: this._workSpace.getFixedContainer(),
       allDayContainer: this._workSpace.getAllDayContainer(),
     });
-    this._waitAsyncTemplate(() => this._workSpaceRecalculation?.resolve());
+    this.waitAsyncTemplate(() => this.workSpaceRecalculation?.resolve());
 
     this.createAppointmentDataSource();
-    this._setRemoteFilterIfNeeded();
-    this._validateKeyFieldIfAgendaExist();
-    this._updateA11yStatus();
+    this.setRemoteFilterIfNeeded();
+    this.validateKeyFieldIfAgendaExist();
+    this.updateA11yStatus();
   }
 
-  _isDataSourceLoaded() {
+  private isDataSourceLoaded() {
     return this._dataSource?.isLoaded();
   }
 
@@ -1194,21 +1194,21 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     super._render();
   }
 
-  _renderHeader() {
+  private renderHeader() {
     const toolbarOptions = this.option('toolbar');
     const isHeaderShown = Boolean(
       toolbarOptions.visible ?? toolbarOptions.items?.length,
     );
 
     if (isHeaderShown) {
-      const $header = $('<div>').appendTo(this._mainContainer);
-      const headerOptions = this._headerConfig();
+      const $header = $('<div>').appendTo(this.mainContainer);
+      const headerOptions = this.headerConfig();
       // @ts-expect-error
-      this._header = this._createComponent($header, SchedulerHeader, headerOptions);
+      this.header = this._createComponent($header, SchedulerHeader, headerOptions);
     }
   }
 
-  _headerConfig(): HeaderOptions {
+  private headerConfig(): HeaderOptions {
     return {
       currentView: this.currentView,
       views: this.views,
@@ -1232,23 +1232,23 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     };
   }
 
-  _appointmentsConfig() {
+  private appointmentsConfig() {
     const config = {
       getResourceManager: () => this.resourceManager,
 
       getAppointmentDataSource: () => this.appointmentDataSource,
       dataAccessors: this._dataAccessors,
-      notifyScheduler: this._notifyScheduler,
-      onItemRendered: this._getAppointmentRenderedAction(),
+      notifyScheduler: this.notifyScheduler,
+      onItemRendered: this.getAppointmentRenderedAction(),
       onItemClick: this._createActionByOption('onAppointmentClick'),
       onItemContextMenu: this._createActionByOption('onAppointmentContextMenu'),
       onAppointmentDblClick: this._createActionByOption('onAppointmentDblClick'),
       tabIndex: this.option('tabIndex'),
       focusStateEnabled: this.option('focusStateEnabled'),
-      allowDrag: this._allowDragging(),
-      allowDelete: this._editing.allowUpdating && this._editing.allowDeleting,
-      allowResize: this._allowResizing(),
-      allowAllDayResize: this._allowAllDayResizing(),
+      allowDrag: this.allowDragging(),
+      allowDelete: this.editing.allowUpdating && this.editing.allowDeleting,
+      allowResize: this.allowResizing(),
+      allowAllDayResize: this.allowAllDayResizing(),
       rtlEnabled: this.option('rtlEnabled'),
       groups: this.getViewOption('groups'),
       groupByDate: this.getViewOption('groupByDate'),
@@ -1259,72 +1259,72 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       isVerticalGroupedWorkSpace: () => this._workSpace._isVerticalGroupedWorkSpace(),
       isDateAndTimeView: () => isDateAndTimeView(this._workSpace.type),
       onContentReady: () => {
-        this._workSpace?.option('allDayExpanded', this._isAllDayExpanded());
+        this._workSpace?.option('allDayExpanded', this.isAllDayExpanded());
       },
     };
 
     return config;
   }
 
-  _renderWorkSpace() {
+  private renderWorkSpace() {
     const currentViewOptions = this.currentView;
     if (!currentViewOptions) {
       return;
     }
 
-    if (this._isAgenda()) {
+    if (this.isAgenda()) {
       this.renderAgendaWorkspace();
     } else {
       this.renderGridWorkspace();
     }
 
-    this._recalculateWorkspace();
+    this.recalculateWorkspace();
     if (currentViewOptions.startDate) {
-      this._updateOption('header', 'currentDate', this._workSpace._getHeaderDate());
+      this.updateOption('header', 'currentDate', this._workSpace._getHeaderDate());
     }
   }
 
   renderGridWorkspace(): void {
-    if (this._readyToRenderAppointments) {
-      this._toggleSmallClass();
+    if (this.readyToRenderAppointments) {
+      this.toggleSmallClass();
       // TODO(9): Get rid of it as soon as you can. Workspace didn't render
       Promise.resolve().then(() => {
-        this._toggleSmallClass();
+        this.toggleSmallClass();
         this._workSpace?.updateHeaderEmptyCellWidth();
       });
     }
-    const $workSpace = $('<div>').appendTo(this._mainContainer);
+    const $workSpace = $('<div>').appendTo(this.mainContainer);
 
     const currentViewType = this.currentView.type;
     const workSpaceComponent = VIEWS_CONFIG[currentViewType].workSpace;
-    const workSpaceConfig = this._workSpaceConfig(this.currentView);
+    const workSpaceConfig = this.workSpaceConfig(this.currentView);
     // @ts-expect-error
     this._workSpace = this._createComponent($workSpace, workSpaceComponent, workSpaceConfig);
 
-    this._allowDragging() && this._workSpace.initDragBehavior(this, this._all);
+    this.allowDragging() && this._workSpace.initDragBehavior(this, this.all);
     this._workSpace._attachTablesEvents();
     this._workSpace.getWorkArea().append(this._appointments.$element());
   }
 
   renderAgendaWorkspace(): void {
-    const $workSpace = $('<div>').appendTo(this._mainContainer);
-    const workSpaceConfig = this._workSpaceConfig(this.currentView);
+    const $workSpace = $('<div>').appendTo(this.mainContainer);
+    const workSpaceConfig = this.workSpaceConfig(this.currentView);
     const workSpaceComponent = VIEWS_CONFIG.agenda.workSpace;
     // @ts-expect-error
     this._workSpace = this._createComponent($workSpace, workSpaceComponent, workSpaceConfig);
     this._workSpace.getWorkArea().append(this._appointments.$element());
   }
 
-  _recalculateWorkspace() {
+  private recalculateWorkspace() {
     // @ts-expect-error
-    this._workSpaceRecalculation = new Deferred();
+    this.workSpaceRecalculation = new Deferred();
     triggerResizeEvent(this._workSpace.$element());
-    this._waitAsyncTemplate(() => {
+    this.waitAsyncTemplate(() => {
       this._workSpace.renderCurrentDateTimeLineAndShader();
     });
   }
 
-  _workSpaceConfig(currentViewOptions: NormalizedView) {
+  private workSpaceConfig(currentViewOptions: NormalizedView) {
     const scrolling = this.getViewOption('scrolling');
     const isVirtualScrolling = scrolling.mode === 'virtual';
     const horizontalVirtualScrollingAllowed = isVirtualScrolling
@@ -1374,17 +1374,17 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       allDayPanelMode: this.option('allDayPanelMode'),
       onSelectedCellsClick: this.showAddAppointmentPopup.bind(this),
       onRenderAppointments: () => {
-        this._renderAppointments();
+        this.renderAppointments();
       },
       onShowAllDayPanel: (value) => this.option('showAllDayPanel', value),
-      getHeaderHeight: () => utils.DOM.getHeaderHeight(this._header),
+      getHeaderHeight: () => utils.DOM.getHeaderHeight(this.header),
       onScrollEnd: () => this._appointments.updateResizableArea(),
 
       // TODO: SSR does not work correctly with renovated render
-      renovateRender: this._isRenovatedRender(isVirtualScrolling),
+      renovateRender: this.isRenovatedRender(isVirtualScrolling),
     }, currentViewOptions);
 
-    result.notifyScheduler = this._notifyScheduler;
+    result.notifyScheduler = this.notifyScheduler;
     result.groups = this.resourceManager.groupResources();
     result.onCellClick = this._createActionByOption('onCellClick');
     result.onCellContextMenu = this._createActionByOption('onCellContextMenu');
@@ -1399,17 +1399,17 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     return result;
   }
 
-  _isRenovatedRender(isVirtualScrolling) {
+  private isRenovatedRender(isVirtualScrolling) {
     return (this.option('renovateRender') && hasWindow()) || isVirtualScrolling;
   }
 
-  _waitAsyncTemplate(callback) {
+  private waitAsyncTemplate(callback) {
     if (this._options.silent('templatesRenderAsynchronously')) {
       const timer = setTimeout(() => {
         callback();
         clearTimeout(timer);
       });
-      this._asyncTemplatesTimers.push(timer);
+      this.asyncTemplatesTimers.push(timer);
     } else {
       callback();
     }
@@ -1424,27 +1424,31 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     return this._getTemplateByOption(optionName);
   }
 
-  _updateOption<T>(viewName: 'workSpace' | 'header', optionName: string, value: T): void {
-    this[`_${viewName}`]?.option(optionName, value);
+  private updateOption<T>(viewName: 'workSpace' | 'header', optionName: string, value: T): void {
+    if (viewName === 'header') {
+      this.header?.option(optionName, value);
+    } else {
+      this._workSpace?.option(optionName, value);
+    }
   }
 
-  _refreshWorkSpace(): void {
-    this._cleanWorkspace();
+  private refreshWorkSpace(): void {
+    this.cleanWorkspace();
 
     delete this._workSpace;
 
-    this._renderWorkSpace();
+    this.renderWorkSpace();
 
-    if (this._readyToRenderAppointments) {
+    if (this.readyToRenderAppointments) {
       this._appointments.option({
         fixedContainer: this._workSpace.getFixedContainer(),
         allDayContainer: this._workSpace.getAllDayContainer(),
       });
-      this._waitAsyncTemplate(() => this._workSpaceRecalculation.resolve());
+      this.waitAsyncTemplate(() => this.workSpaceRecalculation.resolve());
     }
   }
 
-  _cleanWorkspace() {
+  private cleanWorkspace() {
     this._appointments.$element().detach();
     this._workSpace._dispose();
     this._workSpace.$element().remove();
@@ -1465,11 +1469,11 @@ class Scheduler extends SchedulerOptionsBaseWidget {
   }
 
   getHeader() {
-    return this._header;
+    return this.header;
   }
 
-  _cleanPopup() {
-    this._appointmentPopup?.dispose();
+  private cleanPopup() {
+    this.appointmentPopup?.dispose();
   }
 
   _checkRecurringAppointment(
@@ -1484,7 +1488,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
   ) {
     const recurrenceRule = this._dataAccessors.get('recurrenceRule', rawAppointment);
 
-    if (!validateRRule(recurrenceRule) || !this._editing.allowUpdating) {
+    if (!validateRRule(recurrenceRule) || !this.editing.allowUpdating) {
       callback();
       return;
     }
@@ -1495,18 +1499,18 @@ class Scheduler extends SchedulerOptionsBaseWidget {
         callback();
         break;
       case 'occurrence':
-        this._excludeAppointmentFromSeries(rawAppointment, singleAppointment, exceptionDate, isDeleted, isPopupEditing, dragEvent);
+        this.excludeAppointmentFromSeries(rawAppointment, singleAppointment, exceptionDate, isDeleted, isPopupEditing, dragEvent);
         break;
       default:
         if (dragEvent) {
           // @ts-expect-error
           dragEvent.cancel = new Deferred();
         }
-        this._showRecurrenceChangeConfirm(isDeleted)
+        this.showRecurrenceChangeConfirm(isDeleted)
           .done((editingMode) => {
             editingMode === RECURRENCE_EDITING_MODE.SERIES && callback();
 
-            editingMode === RECURRENCE_EDITING_MODE.OCCURRENCE && this._excludeAppointmentFromSeries(
+            editingMode === RECURRENCE_EDITING_MODE.OCCURRENCE && this.excludeAppointmentFromSeries(
               rawAppointment,
               singleAppointment,
               exceptionDate,
@@ -1519,7 +1523,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     }
   }
 
-  _excludeAppointmentFromSeries(rawAppointment, newRawAppointment, exceptionDate, isDeleted, isPopupEditing, dragEvent) {
+  private excludeAppointmentFromSeries(rawAppointment, newRawAppointment, exceptionDate, isDeleted, isPopupEditing, dragEvent) {
     const appointment = excludeFromRecurrence(
       rawAppointment,
       exceptionDate,
@@ -1541,7 +1545,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     }
 
     if (isPopupEditing) {
-      this._appointmentPopup.show(singleRawAppointment, {
+      this.appointmentPopup.show(singleRawAppointment, {
         isToolbarVisible: true, // TODO: remove when legacyForm is deleted
         action: ACTION_TO_APPOINTMENT.EXCLUDE_FROM_SERIES,
         excludeInfo: {
@@ -1549,7 +1553,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
           updatedAppointment: appointment.source,
         },
       });
-      this._editAppointmentData = rawAppointment;
+      this.editAppointmentData = rawAppointment;
     } else {
       this._updateAppointment(rawAppointment, appointment.source, () => {
         this._appointments.moveAppointmentBack(dragEvent);
@@ -1557,18 +1561,18 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     }
   }
 
-  _createRecurrenceException(appointment, exceptionDate) {
+  private createRecurrenceException(appointment, exceptionDate) {
     const result: any[] = [];
 
     if (appointment.recurrenceException) {
       result.push(appointment.recurrenceException);
     }
-    result.push(this._getSerializedDate(exceptionDate, appointment.startDate, appointment.allDay));
+    result.push(this.getSerializedDate(exceptionDate, appointment.startDate, appointment.allDay));
 
     return result.join();
   }
 
-  _getSerializedDate(date, startDate, isAllDay) {
+  private getSerializedDate(date, startDate, isAllDay) {
     isAllDay && date.setHours(
       startDate.getHours(),
       startDate.getMinutes(),
@@ -1579,13 +1583,13 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     return dateSerialization.serializeDate(date, UTC_FULL_DATE_FORMAT);
   }
 
-  _showRecurrenceChangeConfirm(isDeleted) {
+  private showRecurrenceChangeConfirm(isDeleted) {
     const title = messageLocalization.format(isDeleted ? 'dxScheduler-confirmRecurrenceDeleteTitle' : 'dxScheduler-confirmRecurrenceEditTitle');
     const message = messageLocalization.format(isDeleted ? 'dxScheduler-confirmRecurrenceDeleteMessage' : 'dxScheduler-confirmRecurrenceEditMessage');
     const seriesText = messageLocalization.format(isDeleted ? 'dxScheduler-confirmRecurrenceDeleteSeries' : 'dxScheduler-confirmRecurrenceEditSeries');
     const occurrenceText = messageLocalization.format(isDeleted ? 'dxScheduler-confirmRecurrenceDeleteOccurrence' : 'dxScheduler-confirmRecurrenceEditOccurrence');
 
-    this._recurrenceDialog = customDialog({
+    this.recurrenceDialog = customDialog({
       title,
       messageHtml: message,
       showCloseButton: true,
@@ -1602,7 +1606,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       },
     } as any);
 
-    return this._recurrenceDialog.show();
+    return this.recurrenceDialog.show();
   }
 
   _getUpdatedData(rawAppointment) {
@@ -1702,14 +1706,14 @@ class Scheduler extends SchedulerOptionsBaseWidget {
   }
 
   subscribe(subject, action) {
-    this._subscribes[subject] = subscribes[subject] = action;
+    this.subscribes[subject] = subscribes[subject] = action;
   }
 
   fire<Subject extends SubscribeKey>(
     subject: Subject,
     ...args: Parameters<SubscribeMethods[Subject]>
   ): ReturnType<SubscribeMethods[Subject]> {
-    const callback = this._subscribes[subject];
+    const callback = this.subscribes[subject];
 
     if (!isFunction(callback)) {
       throw errors.Error('E1031', subject);
@@ -1739,7 +1743,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       }
     }.bind(this);
 
-    this._actions[StoreEventNames.UPDATING](updatingOptions);
+    this.actions[StoreEventNames.UPDATING](updatingOptions);
 
     if (dragEvent && !isDeferred(dragEvent.cancel)) {
       // @ts-expect-error
@@ -1747,15 +1751,15 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     }
 
     if (isPromise(updatingOptions.cancel) && dragEvent) {
-      this._updatingAppointments.add(target);
+      this.updatingAppointments.add(target);
     }
 
-    return this._processActionResult(updatingOptions, function (canceled) {
+    return this.processActionResult(updatingOptions, function (canceled) {
       // @ts-expect-error
       let deferred = new Deferred();
 
       if (!canceled) {
-        this._expandAllDayPanel(rawAppointment);
+        this.expandAllDayPanel(rawAppointment);
 
         try {
           deferred = this.appointmentDataSource
@@ -1764,18 +1768,18 @@ class Scheduler extends SchedulerOptionsBaseWidget {
               dragEvent?.cancel.resolve(false);
             })
             .always((storeAppointment) => {
-              this._updatingAppointments.delete(target);
-              this._onDataPromiseCompleted(StoreEventNames.UPDATED, storeAppointment);
+              this.updatingAppointments.delete(target);
+              this.onDataPromiseCompleted(StoreEventNames.UPDATED, storeAppointment);
             })
             .fail(() => performFailAction());
         } catch (err) {
           performFailAction(err);
-          this._updatingAppointments.delete(target);
+          this.updatingAppointments.delete(target);
           deferred.resolve();
         }
       } else {
         performFailAction();
-        this._updatingAppointments.delete(target);
+        this.updatingAppointments.delete(target);
         deferred.resolve();
       }
 
@@ -1783,7 +1787,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     });
   }
 
-  _processActionResult(actionOptions, callback) {
+  private processActionResult(actionOptions, callback) {
     // @ts-expect-error
     const deferred = new Deferred();
     const resolveCallback = (callbackResult) => {
@@ -1805,29 +1809,29 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     return deferred.promise();
   }
 
-  _expandAllDayPanel(appointment) {
-    if (!this._isAllDayExpanded() && this.appointmentTakesAllDay(appointment)) {
-      this._updateOption('workSpace', 'allDayExpanded', true);
+  private expandAllDayPanel(appointment) {
+    if (!this.isAllDayExpanded() && this.appointmentTakesAllDay(appointment)) {
+      this.updateOption('workSpace', 'allDayExpanded', true);
     }
   }
 
-  _onDataPromiseCompleted(handlerName, storeAppointment, appointment?: any) {
+  private onDataPromiseCompleted(handlerName, storeAppointment, appointment?: any) {
     const args: any = { appointmentData: appointment || storeAppointment };
 
     if (storeAppointment instanceof Error) {
       args.error = storeAppointment;
     } else {
-      this._appointmentPopup.visible && this._appointmentPopup.hide();
+      this.appointmentPopup.visible && this.appointmentPopup.hide();
     }
 
-    this._actions[handlerName](args);
+    this.actions[handlerName](args);
     this._fireContentReadyAction();
   }
 
   /// #DEBUG
   // TODO: remove when legacyForm is deleted
   getAppointmentDetailsForm() { // for tests
-    return this._appointmentForm.form;
+    return this.appointmentForm.form;
   }
   /// #ENDDEBUG
 
@@ -1840,7 +1844,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
   }
 
   getActions() {
-    return this._actions;
+    return this.actions;
   }
 
   appointmentTakesAllDay(rawAppointment) {
@@ -1921,8 +1925,8 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     }
 
     if (isCreateAppointment) {
-      delete this._editAppointmentData; // TODO
-      this._editing.allowAdding && this._appointmentPopup.show(rawAppointment, {
+      delete this.editAppointmentData; // TODO
+      this.editing.allowAdding && this.appointmentPopup.show(rawAppointment, {
         isToolbarVisible: true, // TODO: remove when legacyForm is deleted
         action: ACTION_TO_APPOINTMENT.CREATE,
       });
@@ -1930,10 +1934,10 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       const startDate = this._dataAccessors.get('startDate', newRawTargetedAppointment || rawAppointment);
 
       this._checkRecurringAppointment(rawAppointment, newTargetedAppointment, startDate, () => {
-        this._editAppointmentData = rawAppointment; // TODO
+        this.editAppointmentData = rawAppointment; // TODO
 
-        this._appointmentPopup.show(rawAppointment, {
-          isToolbarVisible: this._editing.allowUpdating, // TODO: remove when legacyForm is deleted
+        this.appointmentPopup.show(rawAppointment, {
+          isToolbarVisible: this.editing.allowUpdating, // TODO: remove when legacyForm is deleted
           action: ACTION_TO_APPOINTMENT.UPDATE,
         });
       }, false, true);
@@ -1954,9 +1958,9 @@ class Scheduler extends SchedulerOptionsBaseWidget {
   }
 
   hideAppointmentPopup(saveChanges?: any) {
-    if (this._appointmentPopup?.visible) {
-      saveChanges && this._appointmentPopup.saveChangesAsync();
-      this._appointmentPopup.hide();
+    if (this.appointmentPopup?.visible) {
+      saveChanges && this.appointmentPopup.saveChangesAsync();
+      this.appointmentPopup.hide();
     }
   }
 
@@ -1996,12 +2000,12 @@ class Scheduler extends SchedulerOptionsBaseWidget {
 
     this._createActionByOption('onAppointmentTooltipShowing')(arg);
 
-    if (this._appointmentTooltip.isAlreadyShown(target)) {
+    if (this.appointmentTooltip.isAlreadyShown(target)) {
       this.hideAppointmentTooltip();
     } else {
-      this._processActionResult(arg, (canceled) => {
-        !canceled && this._appointmentTooltip.show(target, data, {
-          ...this._getExtraAppointmentTooltipOptions(),
+      this.processActionResult(arg, (canceled) => {
+        !canceled && this.appointmentTooltip.show(target, data, {
+          ...this.getExtraAppointmentTooltipOptions(),
           ...options,
         });
       });
@@ -2009,7 +2013,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
   }
 
   hideAppointmentTooltip() {
-    this._appointmentTooltip?.hide();
+    this.appointmentTooltip?.hide();
   }
 
   scrollTo(
@@ -2042,7 +2046,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       && ('align' in options || 'allDay' in options || 'group' in options);
   }
 
-  _isHorizontalVirtualScrolling() {
+  private isHorizontalVirtualScrolling() {
     const scrolling = this.option('scrolling');
     const { orientation, mode } = scrolling;
     const isVirtualScrolling = mode === 'virtual';
@@ -2066,19 +2070,19 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       cancel: false,
     };
 
-    this._actions[StoreEventNames.ADDING](addingOptions);
+    this.actions[StoreEventNames.ADDING](addingOptions);
 
-    return this._processActionResult(addingOptions, (canceled) => {
+    return this.processActionResult(addingOptions, (canceled) => {
       if (canceled) {
         // @ts-expect-error
         return new Deferred().resolve();
       }
 
-      this._expandAllDayPanel(serializedAppointment);
+      this.expandAllDayPanel(serializedAppointment);
 
       return this.appointmentDataSource
         .add(serializedAppointment)
-        .always((storeAppointment) => this._onDataPromiseCompleted(StoreEventNames.ADDED, storeAppointment));
+        .always((storeAppointment) => this.onDataPromiseCompleted(StoreEventNames.ADDED, storeAppointment));
     });
   }
 
@@ -2098,17 +2102,17 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       cancel: false,
     };
 
-    this._actions[StoreEventNames.DELETING](deletingOptions);
+    this.actions[StoreEventNames.DELETING](deletingOptions);
 
     return deletingOptions;
   }
 
   processDeleteAppointment(rawAppointment, deletingOptions) {
-    this._processActionResult(deletingOptions, function (canceled) {
+    this.processActionResult(deletingOptions, function (canceled) {
       if (!canceled) {
         this.appointmentDataSource
           .remove(rawAppointment)
-          .always((storeAppointment) => this._onDataPromiseCompleted(
+          .always((storeAppointment) => this.onDataPromiseCompleted(
             StoreEventNames.DELETED,
             storeAppointment,
             rawAppointment,
@@ -2143,7 +2147,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
   }
 
   focus() {
-    if (this._editAppointmentData) {
+    if (this.editAppointmentData) {
       this._appointments.focus();
     } else {
       this._workSpace.focus();
@@ -2160,7 +2164,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       : dateLocalization.firstDayOfWeekIndex() as FirstDayOfWeek;
   }
 
-  _validateKeyFieldIfAgendaExist() {
+  private validateKeyFieldIfAgendaExist() {
     if (!this.appointmentDataSource.isDataSourceInit) {
       return;
     }
@@ -2178,7 +2182,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
   }
 
   _isAppointmentBeingUpdated(appointmentData: Appointment): boolean {
-    return this._updatingAppointments.has(appointmentData);
+    return this.updatingAppointments.has(appointmentData);
   }
 
   getViewOffsetMs(): number {

--- a/packages/devextreme/js/__internal/scheduler/m_scheduler.ts
+++ b/packages/devextreme/js/__internal/scheduler/m_scheduler.ts
@@ -314,7 +314,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
           items: [],
           allowDrag: this.allowDragging(),
           allowResize: this.allowResizing(),
-          itemTemplate: this._getAppointmentTemplate('appointmentTemplate'),
+          itemTemplate: this.getAppointmentTemplate('appointmentTemplate'),
         });
 
         this.postponeResourceLoading().done(() => {
@@ -1003,7 +1003,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
 
     // @ts-expect-error
     this._appointments = this._createComponent('<div>', AppointmentCollection, this.appointmentsConfig());
-    this._appointments.option('itemTemplate', this._getAppointmentTemplate('appointmentTemplate'));
+    this._appointments.option('itemTemplate', this.getAppointmentTemplate('appointmentTemplate'));
 
     this.appointmentTooltip = new (this.option('adaptivityEnabled')
       ? MobileTooltipStrategy
@@ -1105,7 +1105,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       container: that.$element(),
       getScrollableContainer: that.getWorkSpaceScrollableContainer.bind(that),
       addDefaultTemplates: that._templateManager.addDefaultTemplates.bind(that._templateManager),
-      getAppointmentTemplate: that._getAppointmentTemplate.bind(that),
+      getAppointmentTemplate: that.getAppointmentTemplate.bind(that),
       showAppointmentPopup: that.showAppointmentPopup.bind(that),
       checkAndDeleteAppointment: that.checkAndDeleteAppointment.bind(that),
       isAppointmentInAllDayPanel: that.isAppointmentInAllDayPanel.bind(that),
@@ -1138,7 +1138,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     );
 
     const deletingOptions = this.fireOnAppointmentDeleting(appointment, targetedAdapter);
-    this._checkRecurringAppointment(
+    this.checkRecurringAppointment(
       appointment,
       targetedAppointment,
       targetedAdapter.startDate,
@@ -1415,7 +1415,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     }
   }
 
-  _getAppointmentTemplate(optionName) {
+  getAppointmentTemplate(optionName) {
     if (this.currentView?.[optionName]) {
       return this._getTemplate(this.currentView[optionName]);
     }
@@ -1476,7 +1476,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     this.appointmentPopup?.dispose();
   }
 
-  _checkRecurringAppointment(
+  checkRecurringAppointment(
     rawAppointment,
     singleAppointment,
     exceptionDate,
@@ -1933,7 +1933,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     } else {
       const startDate = this._dataAccessors.get('startDate', newRawTargetedAppointment || rawAppointment);
 
-      this._checkRecurringAppointment(rawAppointment, newTargetedAppointment, startDate, () => {
+      this.checkRecurringAppointment(rawAppointment, newTargetedAppointment, startDate, () => {
         this.editAppointmentData = rawAppointment; // TODO
 
         this.appointmentPopup.show(rawAppointment, {
@@ -2129,7 +2129,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
     if (typeof date === 'string') {
       date = new Date(date);
     }
-    this._checkRecurringAppointment(
+    this.checkRecurringAppointment(
       appointment,
       { },
       date,

--- a/packages/devextreme/js/__internal/scheduler/m_subscribes.ts
+++ b/packages/devextreme/js/__internal/scheduler/m_subscribes.ts
@@ -68,7 +68,7 @@ const subscribes = {
     const { info } = utils.dataAccessors.getAppointmentSettings(options.$appointment) as AppointmentItemViewModel;
     const { startDate } = info.sourceAppointment;
 
-    this._checkRecurringAppointment(options.target, options.data, startDate, () => {
+    this.checkRecurringAppointment(options.target, options.data, startDate, () => {
       this._updateAppointment(options.target, options.data, function () {
         this._appointments.moveAppointmentBack();
       });
@@ -102,7 +102,7 @@ const subscribes = {
     }
 
     if (isDropToSelfScheduler && (!isDropToTheSameCell || isDragAndDropBetweenComponents || isDropBetweenAllDay)) {
-      this._checkRecurringAppointment(rawAppointment, targetedRawAppointment, info.sourceAppointment.startDate, () => {
+      this.checkRecurringAppointment(rawAppointment, targetedRawAppointment, info.sourceAppointment.startDate, () => {
         this._updateAppointment(rawAppointment, targetedRawAppointment, onCancel, event);
       }, undefined, undefined, event);
     } else {

--- a/packages/devextreme/testing/helpers/scheduler/helpers.js
+++ b/packages/devextreme/testing/helpers/scheduler/helpers.js
@@ -591,11 +591,11 @@ export class SchedulerTestWrapper extends ElementWrapper {
 
             getCancelButton: () => this.appointmentPopup.getPopup().find('.dx-popup-cancel'),
             clickCancelButton: () => this.appointmentPopup.getCancelButton().trigger('dxclick'),
-            saveAppointmentData: () => this.instance._appointmentPopup.saveEditDataAsync.call(this.instance._appointmentPopup),
+            saveAppointmentData: () => this.instance.appointmentPopup.saveEditDataAsync.call(this.instance.appointmentPopup),
 
             hasLoadPanel: () => this.appointmentPopup.getPopup().find('.dx-loadpanel').length !== 0,
 
-            getInstance: () => this.instance._appointmentPopup
+            getInstance: () => this.instance.appointmentPopup
         };
 
         this.appointmentForm = {

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/appointment.editing.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/appointment.editing.tests.js
@@ -268,7 +268,7 @@ module('Integration: Appointment editing', {
 
                 $('.dx-scheduler-appointment-popup .dx-popup-done').trigger('dxclick');
 
-                const popup = scheduler.instance._appointmentPopup.popup;
+                const popup = scheduler.instance.appointmentPopup.popup;
             });
 
             test('Add new appointment with delay and an error(T381444)', async function(assert) {
@@ -303,7 +303,7 @@ module('Integration: Appointment editing', {
 
                 $('.dx-scheduler-appointment-popup .dx-popup-done').trigger('dxclick');
 
-                const popup = scheduler.instance._appointmentPopup.popup;
+                const popup = scheduler.instance.appointmentPopup.popup;
             });
 
             // TODO: update editors in popup

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/appointment.monthView.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/appointment.monthView.tests.js
@@ -417,7 +417,7 @@ module('Integration: Appointments in Month view', {
 
                 $('.dx-dialog-buttons .dx-button').eq(0).trigger('dxclick');
 
-                const popup = scheduler.instance._appointmentPopup.popup;
+                const popup = scheduler.instance.appointmentPopup.popup;
                 const $buttonGroup = $(popup.$content()).find('.dx-buttongroup');
 
                 assert.deepEqual($buttonGroup.eq(0).dxButtonGroup('instance').option('selectedItemKeys'), ['MO', 'TH'], 'Right button group select item keys');
@@ -459,7 +459,7 @@ module('Integration: Appointments in Month view', {
 
                 $('.dx-dialog-buttons .dx-button').eq(0).trigger('dxclick');
 
-                const popup = scheduler.instance._appointmentPopup.popup;
+                const popup = scheduler.instance.appointmentPopup.popup;
                 const $buttonGroup = $(popup.$content()).find('.dx-buttongroup');
 
                 $buttonGroup.eq(0).dxButtonGroup('instance').option('selectedItemKeys'), ['MO', 'TH'], 'Right button group select item keys';

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/appointment.tooltip.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/appointment.tooltip.tests.js
@@ -55,7 +55,7 @@ module('Integration: Appointment tooltip', {
                 height: 600
             });
 
-            const getAppointmentDisabled = sinon.spy(scheduler.instance._appointmentTooltip._options, 'getAppointmentDisabled');
+            const getAppointmentDisabled = sinon.spy(scheduler.instance.appointmentTooltip._options, 'getAppointmentDisabled');
 
             const clock = sinon.useFakeTimers();
             await scheduler.appointments.click(0, clock);

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/appointment.week.based.views.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/appointment.week.based.views.tests.js
@@ -230,7 +230,7 @@ module('Integration: Appointment Day, Week views', {
                     height: 1500
                 });
 
-                const spy = sinon.spy(scheduler.instance._appointmentPopup, 'show');
+                const spy = sinon.spy(scheduler.instance.appointmentPopup, 'show');
 
                 const clock = sinon.useFakeTimers();
                 await scheduler.appointments.click(0, clock);
@@ -244,7 +244,7 @@ module('Integration: Appointment Day, Week views', {
 
                     hide();
                 } finally {
-                    scheduler.instance._appointmentPopup.show.restore();
+                    scheduler.instance.appointmentPopup.show.restore();
                 }
             });
 

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/common.events.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/common.events.tests.js
@@ -688,16 +688,16 @@ QUnit.module('Events', {
 
         assert.equal(contentReadyFiresCount, 1, 'contentReadyFiresCount === 1');
 
-        scheduler.instance._workSpaceRecalculation = new Deferred();
+        scheduler.instance.workSpaceRecalculation = new Deferred();
         scheduler.instance._fireContentReadyAction();
 
         assert.equal(contentReadyFiresCount, 1, 'contentReadyFiresCount === 1');
 
-        scheduler.instance._workSpaceRecalculation.resolve();
+        scheduler.instance.workSpaceRecalculation.resolve();
 
         assert.equal(contentReadyFiresCount, 2, 'contentReadyFiresCount === 2');
 
-        scheduler.instance._workSpaceRecalculation = null;
+        scheduler.instance.workSpaceRecalculation = null;
         scheduler.instance._fireContentReadyAction();
 
         assert.equal(contentReadyFiresCount, 3, 'contentReadyFiresCount === 3');

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/common.methods.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/common.methods.tests.js
@@ -498,7 +498,7 @@ QUnit.module('Methods', {
         const appointments = scheduler.instance.getAppointmentsInstance();
         const focusSpy = sinon.spy(appointments, 'focus');
 
-        scheduler.instance._editAppointmentData = tasks[0];
+        scheduler.instance.editAppointmentData = tasks[0];
         scheduler.instance.focus();
 
         assert.ok(focusSpy.calledOnce, 'focus is called');

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/common.methods.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/common.methods.tests.js
@@ -636,46 +636,46 @@ QUnit.module('Methods', {
 
     QUnit.test('showAppointmentTooltipCore, should call show tooltip', async function(assert) {
         const scheduler = await createInstance({});
-        scheduler.instance._appointmentTooltip.isAlreadyShown = sinon.stub().returns(false);
-        scheduler.instance._appointmentTooltip.show = sinon.stub();
-        scheduler.instance._appointmentTooltip.hide = sinon.stub();
+        scheduler.instance.appointmentTooltip.isAlreadyShown = sinon.stub().returns(false);
+        scheduler.instance.appointmentTooltip.show = sinon.stub();
+        scheduler.instance.appointmentTooltip.hide = sinon.stub();
         scheduler.instance.showAppointmentTooltipCore('target', [], 'options');
 
-        assert.ok(!scheduler.instance._appointmentTooltip.hide.called, 'hide tooltip is not called');
-        assert.ok(scheduler.instance._appointmentTooltip.show.called, 'show tooltip is called');
+        assert.ok(!scheduler.instance.appointmentTooltip.hide.called, 'hide tooltip is not called');
+        assert.ok(scheduler.instance.appointmentTooltip.show.called, 'show tooltip is called');
     });
 
     QUnit.test('showAppointmentTooltipCore, should call hide tooltip', async function(assert) {
         const scheduler = await createInstance({});
-        scheduler.instance._appointmentTooltip.isAlreadyShown = sinon.stub().returns(true);
-        scheduler.instance._appointmentTooltip.show = sinon.stub();
-        scheduler.instance._appointmentTooltip.hide = sinon.stub();
+        scheduler.instance.appointmentTooltip.isAlreadyShown = sinon.stub().returns(true);
+        scheduler.instance.appointmentTooltip.show = sinon.stub();
+        scheduler.instance.appointmentTooltip.hide = sinon.stub();
         scheduler.instance.showAppointmentTooltipCore('target', [], 'options');
 
-        assert.ok(scheduler.instance._appointmentTooltip.hide.called, 'hide tooltip is called');
-        assert.ok(!scheduler.instance._appointmentTooltip.show.called, 'show tooltip is not called');
+        assert.ok(scheduler.instance.appointmentTooltip.hide.called, 'hide tooltip is called');
+        assert.ok(!scheduler.instance.appointmentTooltip.show.called, 'show tooltip is not called');
     });
 
     QUnit.test('showAppointmentTooltip, should call show tooltip', async function(assert) {
         const scheduler = await createInstance({});
-        scheduler.instance._appointmentTooltip.isAlreadyShown = sinon.stub().returns(false);
-        scheduler.instance._appointmentTooltip.show = sinon.stub();
-        scheduler.instance._appointmentTooltip.hide = sinon.stub();
+        scheduler.instance.appointmentTooltip.isAlreadyShown = sinon.stub().returns(false);
+        scheduler.instance.appointmentTooltip.show = sinon.stub();
+        scheduler.instance.appointmentTooltip.hide = sinon.stub();
         scheduler.instance.showAppointmentTooltip('appointmentData', 'target', 'currentAppointmentData');
 
-        assert.ok(!scheduler.instance._appointmentTooltip.hide.called, 'hide tooltip is not called');
-        assert.ok(scheduler.instance._appointmentTooltip.show.called, 'show tooltip is called');
+        assert.ok(!scheduler.instance.appointmentTooltip.hide.called, 'hide tooltip is not called');
+        assert.ok(scheduler.instance.appointmentTooltip.show.called, 'show tooltip is called');
     });
 
     QUnit.test('showAppointmentTooltip, should call hide tooltip', async function(assert) {
         const scheduler = await createInstance({});
-        scheduler.instance._appointmentTooltip.isAlreadyShown = sinon.stub().returns(true);
-        scheduler.instance._appointmentTooltip.show = sinon.stub();
-        scheduler.instance._appointmentTooltip.hide = sinon.stub();
+        scheduler.instance.appointmentTooltip.isAlreadyShown = sinon.stub().returns(true);
+        scheduler.instance.appointmentTooltip.show = sinon.stub();
+        scheduler.instance.appointmentTooltip.hide = sinon.stub();
         scheduler.instance.showAppointmentTooltip('appointmentData', 'target', 'currentAppointmentData');
 
-        assert.ok(scheduler.instance._appointmentTooltip.hide.called, 'hide tooltip is called');
-        assert.ok(!scheduler.instance._appointmentTooltip.show.called, 'show tooltip is not called');
+        assert.ok(scheduler.instance.appointmentTooltip.hide.called, 'hide tooltip is called');
+        assert.ok(!scheduler.instance.appointmentTooltip.show.called, 'show tooltip is not called');
     });
 
     QUnit.test('_getUpdatedData for the empty data item (T906240)', async function(assert) {

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/common.options.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/common.options.tests.js
@@ -936,7 +936,7 @@ QUnit.module('Options', () => {
         });
 
         const initMarkupSpy = sinon.spy(scheduler.instance, '_initMarkup');
-        const reloadDataSourceSpy = sinon.spy(scheduler.instance, '_reloadDataSource');
+        const reloadDataSourceSpy = sinon.spy(scheduler.instance, 'reloadDataSource');
         let count = 0;
 
         const nextDataSource = new DataSource({

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/common.options.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/common.options.tests.js
@@ -638,7 +638,7 @@ QUnit.module('Options', () => {
 
         const spyAppointmentPopupForm = sinon.spy(
             scheduler.instance,
-            '_createAppointmentPopupForm'
+            'createAppointmentPopupForm'
         );
 
         scheduler.instance.option('resources', resources);

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/common.options.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/common.options.tests.js
@@ -962,7 +962,7 @@ QUnit.module('Options', () => {
         await waitForAsync(() => count === 2);
 
         assert.equal(initMarkupSpy.callCount, 2, 'Init markup was called on each dataSource changes');
-        assert.equal(reloadDataSourceSpy.callCount, 2, '_reloadDataSource was called on each changes');
+        assert.equal(reloadDataSourceSpy.callCount, 2, 'reloadDataSource was called on each changes');
     });
 
     QUnit.test('It should be possible to change views option when view names are specified (T995794)', async function(assert) {

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/common.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/common.tests.js
@@ -444,7 +444,7 @@ QUnit.module('View with configuration', () => {
         });
 
         assert.equal(scheduler.instance._workSpace.option('firstDayOfWeek'), 0, 'value of the firstDayOfWeek in workSpace');
-        assert.equal(scheduler.instance._header.option('firstDayOfWeek'), 0, 'value of the firstDayOfWeek in header');
+        assert.equal(scheduler.instance.header.option('firstDayOfWeek'), 0, 'value of the firstDayOfWeek in header');
     });
 
     QUnit.test('Scheduler should have specific groups setting of the view', async function(assert) {

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/dataSource.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/dataSource.tests.js
@@ -263,7 +263,7 @@ module('Events', {
                 scheduler.instance.showAppointmentPopup(appointments[0]);
                 $('.dx-scheduler-appointment-popup .dx-popup-done').trigger('dxclick');
 
-                const appointmentForm = scheduler.instance._appointmentPopup.form;
+                const appointmentForm = scheduler.instance.appointmentPopup.form;
 
                 assert.deepEqual(appointmentForm.formData.startDate, new Date(2015, 1, 9, 13), 'Form data is correct');
             } finally {

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentCollector.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentCollector.tests.js
@@ -87,7 +87,7 @@ module('Integration: Appointments Collector Base Tests', baseConfig, () => {
                 }
                 return this.callBase(options);
             },
-            _getAppointmentTemplate(template) {
+            getAppointmentTemplate(template) {
                 return this._getTemplateByOption(template);
             },
             _dataAccessors: mockDataAccessor,

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentTooltip.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/integration.appointmentTooltip.tests.js
@@ -309,7 +309,7 @@ module('Integration: Appointment tooltip', moduleConfig, () => {
         assert.equal(Tooltip.getInstance($('.dx-tooltip')).option('rtlEnabled'), true, 'rtlEnabled for tooltip was set to true');
     });
 
-    test('Click on tooltip-edit button should call scheduler._appointmentPopup and hide tooltip', async function(assert) {
+    test('Click on tooltip-edit button should call scheduler.appointmentPopup and hide tooltip', async function(assert) {
         const data = new DataSource({
             store: getSampleData()
         });
@@ -319,7 +319,7 @@ module('Integration: Appointment tooltip', moduleConfig, () => {
             dataSource: data
         });
 
-        const stub = sinon.stub(scheduler.instance._appointmentPopup, 'show');
+        const stub = sinon.stub(scheduler.instance.appointmentPopup, 'show');
 
         const clock = sinon.useFakeTimers();
         await scheduler.appointments.click(1, clock);

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/integration.dateNavigator.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/integration.dateNavigator.tests.js
@@ -381,13 +381,13 @@ QUnit.module('Integration: Date navigator', moduleConfig, function() {
     QUnit.test('Tasks should be rerendered after click on next/prev button', async function(assert) {
         await this.createInstance({ currentDate: new Date(2015, 1, 24) });
 
-        const spy = sinon.spy(this.instance, '_setRemoteFilterIfNeeded');
+        const spy = sinon.spy(this.instance, 'setRemoteFilterIfNeeded');
 
         try {
             $(this.instance.$element()).find('.dx-scheduler-navigator-previous').trigger('dxclick');
             assert.ok(spy.calledOnce, '_setRemoteFilterIfNeeded is called');
         } finally {
-            this.instance._setRemoteFilterIfNeeded.restore();
+            this.instance.setRemoteFilterIfNeeded.restore();
         }
     });
 

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/integration.dateNavigator.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/integration.dateNavigator.tests.js
@@ -385,7 +385,7 @@ QUnit.module('Integration: Date navigator', moduleConfig, function() {
 
         try {
             $(this.instance.$element()).find('.dx-scheduler-navigator-previous').trigger('dxclick');
-            assert.ok(spy.calledOnce, '_setRemoteFilterIfNeeded is called');
+            assert.ok(spy.calledOnce, 'setRemoteFilterIfNeeded is called');
         } finally {
             this.instance.setRemoteFilterIfNeeded.restore();
         }

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/integration.multiWeekAppointments.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/integration.multiWeekAppointments.tests.js
@@ -15,12 +15,12 @@ const { testStart } = QUnit;
 testStart(() => initTestMarkup());
 
 const mockWorkSpaceRendering = function(schedulerInst, cellSize, bounds) {
-    const base = schedulerInst._renderWorkSpace;
+    const base = schedulerInst.renderWorkSpace;
     const getMaxAllowedPosition = (groupIndex) => {
         return bounds[groupIndex];
     };
 
-    sinon.stub(schedulerInst, '_renderWorkSpace').callsFake(function(groups) {
+    sinon.stub(schedulerInst, 'renderWorkSpace').callsFake(function(groups) {
         base.call(this, groups);
 
         sinon.stub(this._workSpace, 'getCellWidth').returns(cellSize);

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/integration.workSpace.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/integration.workSpace.tests.js
@@ -880,7 +880,7 @@ module('Integration: Work space', { ...moduleConfig }, () => {
             ]
         });
 
-        const refreshStub = sinon.stub(scheduler.instance, '_refreshWorkSpace');
+        const refreshStub = sinon.stub(scheduler.instance, 'refreshWorkSpace');
 
         try {
             scheduler.instance.option('groups', ['resource2']);

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/keyboardNavigation.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/keyboardNavigation.tests.js
@@ -88,13 +88,13 @@ QUnit.module('Keyboard Navigation', {
         });
 
         scheduler.appointments.compact.click();
-        assert.notOk(scheduler.instance._appointmentTooltip._list.option('focusStateEnabled'), 'focusStateEnabled was passed correctly');
+        assert.notOk(scheduler.instance.appointmentTooltip._list.option('focusStateEnabled'), 'focusStateEnabled was passed correctly');
 
-        scheduler.instance._appointmentTooltip.hide();
+        scheduler.instance.appointmentTooltip.hide();
 
         scheduler.instance.option('focusStateEnabled', true);
         scheduler.appointments.compact.click();
-        assert.ok(scheduler.instance._appointmentTooltip._list.option('focusStateEnabled'), 'focusStateEnabled was passed correctly');
+        assert.ok(scheduler.instance.appointmentTooltip._list.option('focusStateEnabled'), 'focusStateEnabled was passed correctly');
     });
 
     QUnit.test('Workspace navigation by arrows should work correctly with opened dropDown appointments', async function(assert) {

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/legacyAppointmentPopup.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.scheduler/legacyAppointmentPopup.tests.js
@@ -34,7 +34,7 @@ const checkFormWithRecurrenceEditor = (assert, instance, visibility) => {
     assert.equal(form.itemOption(APPOINTMENT_FORM_GROUP_NAMES.Main).colSpan, colSpan, 'colSpan of main group is correct');
     assert.equal(form.itemOption(APPOINTMENT_FORM_GROUP_NAMES.Recurrence).colSpan, colSpan, 'colSpan of recurrence group is correct');
 
-    assert.equal(instance._appointmentPopup.popup.option('maxWidth'), width, 'maxWidth of popup is correct');
+    assert.equal(instance.appointmentPopup.popup.option('maxWidth'), width, 'maxWidth of popup is correct');
 };
 
 const createInstance = (options) => {
@@ -168,12 +168,12 @@ QUnit.module('Appointment popup form', moduleConfig, () => {
         scheduler.appointments.dblclick(0);
         scheduler.appointmentPopup.dialog.clickEditSeries();
 
-        const form = scheduler.instance._appointmentPopup.form.form;
+        const form = scheduler.instance.appointmentPopup.form.form;
 
         assert.ok(form.getEditor('repeat').option('value'), 'repeat checkbox should be checked');
         assert.ok(form.option('items')[1].visible, 'recurrence form should be visible');
 
-        scheduler.instance._appointmentPopup.popup.hide();
+        scheduler.instance.appointmentPopup.popup.hide();
         scheduler.instance.showAppointmentPopup();
 
         assert.notOk(form.getEditor('repeat').option('value'), 'repeat checkbox should be unchecked if empty form');
@@ -336,11 +336,11 @@ QUnit.module('Appointment popup form', moduleConfig, () => {
 
             scheduler.appointments.dblclick();
             assert.equal(scheduler.appointmentPopup.isVisible(), expected, text + ' if call from UI');
-            scheduler.instance._appointmentPopup.popup.option('visible', false);
+            scheduler.instance.appointmentPopup.popup.option('visible', false);
 
             scheduler.instance.showAppointmentPopup(data[0]);
             assert.equal(scheduler.appointmentPopup.isVisible(), expected, text + ' if call showAppointmentPopup method');
-            scheduler.instance._appointmentPopup.popup.option('visible', false);
+            scheduler.instance.appointmentPopup.popup.option('visible', false);
         });
     });
 
@@ -682,11 +682,11 @@ if(isDesktopEnvironment()) {
         const scheduler = await createScheduler();
         scheduler.instance.showAppointmentPopup({ startDate: new Date(2018, 5, 18), endDate: Date(2018, 5, 18), text: 'a' });
         checkFormWithRecurrenceEditor(assert, scheduler.instance, false);
-        scheduler.instance._appointmentPopup.popup.hide();
+        scheduler.instance.appointmentPopup.popup.hide();
         scheduler.instance.showAppointmentPopup({ startDate: new Date(2018, 5, 18), endDate: Date(2018, 5, 18), text: 'b', recurrenceRule: 'FREQ=WEEKLY' });
         $('.dx-dialog-buttons .dx-button').eq(0).trigger('dxclick');
         checkFormWithRecurrenceEditor(assert, scheduler.instance, true);
-        scheduler.instance._appointmentPopup.popup.hide();
+        scheduler.instance.appointmentPopup.popup.hide();
 
         scheduler.instance.showAppointmentPopup({ startDate: new Date(2018, 5, 18), endDate: Date(2018, 5, 18), text: 'c' });
         checkFormWithRecurrenceEditor(assert, scheduler.instance, false);
@@ -698,7 +698,7 @@ if(isDesktopEnvironment()) {
 
         const form = scheduler.instance.getAppointmentDetailsForm();
         form.getEditor('visibilityChanged').option('value', true);
-        scheduler.instance._appointmentPopup.popup.hide();
+        scheduler.instance.appointmentPopup.popup.hide();
 
         scheduler.instance.showAppointmentPopup({ startDate: new Date(2018, 5, 18), endDate: Date(2018, 5, 18), text: 'b', recurrenceRule: 'FREQ=WEEKLY' });
         $('.dx-dialog-buttons .dx-button').eq(0).trigger('dxclick');
@@ -720,7 +720,7 @@ if(isDesktopEnvironment()) {
         const form = scheduler.instance.getAppointmentDetailsForm();
 
         assert.ok(!form.getEditor(null), 'Editor is not rendered');
-        assert.equal(scheduler.instance._appointmentPopup.popup.option('maxWidth'), APPOINTMENT_POPUP_WIDTH);
+        assert.equal(scheduler.instance.appointmentPopup.popup.option('maxWidth'), APPOINTMENT_POPUP_WIDTH);
         assert.equal(form.option('items')[0].colSpan, 2, 'colSpan of main group');
 
         scheduler.instance.option('recurrenceRuleExpr', 'recurrenceRule');
@@ -745,7 +745,7 @@ if(isDesktopEnvironment()) {
         const form = scheduler.instance.getAppointmentDetailsForm();
 
         assert.ok(!form.getEditor(null), 'Editor is not rendered');
-        assert.equal(scheduler.instance._appointmentPopup.popup.option('maxWidth'), APPOINTMENT_POPUP_WIDTH);
+        assert.equal(scheduler.instance.appointmentPopup.popup.option('maxWidth'), APPOINTMENT_POPUP_WIDTH);
         assert.equal(form.option('items')[0].colSpan, 2, 'colSpan of main group');
     });
 
@@ -777,7 +777,7 @@ QUnit.module('Appointment Popup Content', moduleOptions, () => {
 
         scheduler.instance.showAppointmentPopup({ startDate: new Date(2015, 1, 1), endDate: new Date(2015, 1, 2) });
 
-        const appointmentPopupOptions = scheduler.instance._appointmentPopup.popup.option();
+        const appointmentPopupOptions = scheduler.instance.appointmentPopup.popup.option();
 
         assert.strictEqual(appointmentPopupOptions.enableBodyScroll, false, 'enable body scroll');
         assert.strictEqual(appointmentPopupOptions.preventScrollEvents, false, 'prevent scroll events');
@@ -893,7 +893,7 @@ QUnit.module('Appointment Popup Content', moduleOptions, () => {
 
         scheduler.instance.showAppointmentPopup({ startDate: new Date(2015, 1, 1), endDate: new Date(2015, 1, 2), text: 'appointment 1' });
 
-        const popup = scheduler.instance._appointmentPopup.popup;
+        const popup = scheduler.instance.appointmentPopup.popup;
 
         assert.equal(popup.option('height'), 'auto', 'popup has correct height');
         assert.equal(popup.option('maxHeight'), '100%', 'popup has correct max-height');
@@ -904,7 +904,7 @@ QUnit.module('Appointment Popup Content', moduleOptions, () => {
 
         scheduler.instance.showAppointmentPopup({ startDate: new Date(2015, 1, 1), endDate: new Date(2015, 1, 2), text: 'appointment 1' });
 
-        const popup = scheduler.instance._appointmentPopup.popup;
+        const popup = scheduler.instance.appointmentPopup.popup;
         let contentReadyCalled = 0;
 
         popup.option('onContentReady', function() {
@@ -1400,7 +1400,7 @@ QUnit.module('Appointment Popup Content', moduleOptions, () => {
     QUnit.test('Done button default configuration should be correct', async function(assert) {
         const scheduler = await createInstance({
             onAppointmentFormOpening: function(e) {
-                const popup = e.component._appointmentPopup.popup;
+                const popup = e.component.appointmentPopup.popup;
                 const buttons = popup.option('toolbarItems');
                 const doneButton = buttons[0];
 
@@ -1422,7 +1422,7 @@ QUnit.module('Appointment Popup Content', moduleOptions, () => {
                 store: this.tasks
             }),
             onAppointmentFormOpening: function(e) {
-                const popup = e.component._appointmentPopup.popup;
+                const popup = e.component.appointmentPopup.popup;
                 const buttons = popup.option('toolbarItems');
                 buttons[0].options = { text: 'Text 1' };
                 popup.option('toolbarItems', buttons);
@@ -1563,7 +1563,7 @@ QUnit.module('Appointment Popup', moduleOptions, () => {
             recurrenceRule: 'FREQ=WEEKLY;BYDAY=MO,TH;COUNT=10'
         });
 
-        const popup = scheduler.instance._appointmentPopup.popup;
+        const popup = scheduler.instance.appointmentPopup.popup;
         const $buttonGroup = $(popup.$content()).find('.dx-buttongroup');
 
         assert.deepEqual($buttonGroup.eq(0).dxButtonGroup('instance').option('selectedItemKeys'), ['MO', 'TH'], 'Right buttons was checked');


### PR DESCRIPTION
Addresses review comments from sjbur on PR #32811.

## Changes
- `_getAppointmentTemplate` → `getAppointmentTemplate` in `m_scheduler.ts`
- `_checkRecurringAppointment` → `checkRecurringAppointment` in `m_scheduler.ts`
- Updated callers in `m_compact_appointments_helper.ts`, `m_subscribes.ts`, and `integration.appointmentCollector.tests.js`

## Related
Part of #32811 (3518-scheduler-core-replace-underscore-v2)