### PR TITLE
Potential fix for code scanning alert no. 350: Server-side request forgery

### DIFF
--- a/packages/devextreme/testing/runner/lib/vectormap.ts
+++ b/packages/devextreme/testing/runner/lib/vectormap.ts
@@ -84,6 +84,33 @@ function wait(timeout: number): Promise<void> {
   });
 }
 
+function sanitizeVectorMapArg(arg: string): string {
+  const trimmed = arg.trim();
+
+  // Reject empty values
+  if (!trimmed) {
+    throw new Error('Vector map argument must not be empty.');
+  }
+
+  // Disallow characters and sequences that can alter the path structure
+  if (trimmed.includes('/') || trimmed.includes('\\') || trimmed.includes('?') || trimmed.includes('#')) {
+    throw new Error('Vector map argument contains invalid characters.');
+  }
+
+  // Prevent simple path traversal attempts
+  if (trimmed.includes('..')) {
+    throw new Error('Vector map argument must not contain path traversal sequences.');
+  }
+
+  // Optionally enforce a reasonable maximum length to avoid resource abuse
+  if (trimmed.length > 256) {
+    throw new Error('Vector map argument is too long.');
+  }
+
+  // Encode as a single safe URL path segment
+  return encodeURIComponent(trimmed);
+}
+
 function httpGetText(targetUrl: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const request = http.get(targetUrl, (response) => {
@@ -205,8 +232,10 @@ export function createVectorMapService({
     arg: string,
     startTime: number,
   ): Promise<string> {
+    const safeArg = sanitizeVectorMapArg(arg);
+
     try {
-      return await httpGetText(`http://127.0.0.1:${vectorMapTesterPort}/${action}/${arg}`);
+      return await httpGetText(`http://127.0.0.1:${vectorMapTesterPort}/${action}/${safeArg}`);
     } catch (error) {
       if (Date.now() - startTime > VECTOR_SERVER_RETRY_TIMEOUT_MS) {
         throw error;


### PR DESCRIPTION
Potential fix for [https://github.com/DevExpress/DevExtreme/security/code-scanning/350](https://github.com/DevExpress/DevExtreme/security/code-scanning/350)

To fix this, we should ensure the user‑controlled `arg` cannot arbitrarily modify the request path sent to the internal vector map node server. In practice, that means (1) validating `arg` against a strict pattern of allowed characters (for example, word characters, dashes, underscores, and dots) and optionally enforcing a maximum length, and (2) encoding `arg` as a path segment (`encodeURIComponent`) when building the URL so that any special characters cannot escape the intended segment or smuggle additional slashes or query parameters.

The single best change, with minimal impact on existing behavior, is to (a) add a small helper in `vectormap.ts` that “sanitizes” the `arg` coming from the external request: it should reject obviously unsafe values (containing `/`, `\`, `?`, `#`, or sequences like `..`) by throwing an error; and for acceptable values, it should return the value encoded for use as a URL segment. Then (b) update `requestWithRetryUntilReady` to call this sanitizer and use the sanitized/encoded value when constructing `targetUrl`. This keeps the same base URL (`http://127.0.0.1:${vectorMapTesterPort}`) and the same `action` behavior, while ensuring untrusted data cannot change the ultimate path beyond the intended segment.

Concretely, in `packages/devextreme/testing/runner/lib/vectormap.ts`:
- Define a new function, e.g. `sanitizeVectorMapArg(arg: string): string`, above `httpGetText`. It should:
  - Trim the input.
  - Reject empty strings.
  - Reject values containing `/`, `\`, `?`, `#`, or `..` (to prevent traversal and extra segments).
  - Optionally limit length (e.g., 256 chars) for robustness.
  - Return `encodeURIComponent(arg)` so the caller can safely interpolate it into a URL.
- Change `requestWithRetryUntilReady` so that:
  - It calls `const safeArg = sanitizeVectorMapArg(arg);`.
  - It uses `safeArg` in the URL: ``http://127.0.0.1:${vectorMapTesterPort}/${action}/${safeArg}``.
No changes are needed in `index.ts` or `utils.ts`; they will still pass `id` strings, but the new sanitizer will guard the internal HTTP request.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
