### PR TITLE
Potential fix for code scanning alert no. 353: Missing rate limiting

### DIFF
--- a/apps/demos/package.json
+++ b/apps/demos/package.json
@@ -86,7 +86,8 @@
         "vuex": "4.0.0-beta.4",
         "whatwg-fetch": "2.0.4",
         "yargs": "17.7.2",
-        "zone.js": "0.15.1"
+        "zone.js": "0.15.1",
+        "express-rate-limit": "^8.3.1"
     },
     "devDependencies": {
         "@angular/platform-server": "21.1.6",

--- a/apps/demos/utils/server/csp-server.js
+++ b/apps/demos/utils/server/csp-server.js
@@ -381,8 +381,8 @@ app.use(cookieParser());
 app.use(cspMiddleware);
 
 const demoIndexLimiter = RateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // limit each IP to 100 requests per windowMs for demo index routes
+  windowMs: 15 * 60 * 1000,
+  max: 100,
 });
 
 app.post('/csp-report', cspReportHandler);

--- a/apps/demos/utils/server/csp-server.js
+++ b/apps/demos/utils/server/csp-server.js
@@ -5,6 +5,7 @@ const express = require('express');
 const cookieParser = require('cookie-parser');
 const { join, resolve } = require('path');
 const { readFileSync, readdirSync } = require('fs');
+const RateLimit = require('express-rate-limit');
 
 const root = join(__dirname, '..', '..', '..', '..');
 const indexFileName = 'index.html';
@@ -379,12 +380,17 @@ const app = express();
 app.use(cookieParser());
 app.use(cspMiddleware);
 
+const demoIndexLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs for demo index routes
+});
+
 app.post('/csp-report', cspReportHandler);
 app.get('/csp-violations', cspViolationsHandler);
 app.delete('/csp-violations', cspViolationsClearHandler);
 
-app.get('/apps/demos/Demos/:widget/:name/:approach', demoIndexHandler);
-app.get(`/apps/demos/Demos/:widget/:name/:approach/${indexFileName}`, demoIndexHandler);
+app.get('/apps/demos/Demos/:widget/:name/:approach', demoIndexLimiter, demoIndexHandler);
+app.get(`/apps/demos/Demos/:widget/:name/:approach/${indexFileName}`, demoIndexLimiter, demoIndexHandler);
 
 app.use(express.static(root, { index: [indexFileName] }));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,6 +461,9 @@ importers:
       esbuild-plugin-vue3:
         specifier: 0.3.2
         version: 0.3.2(cheerio@1.0.0-rc.10)(sass@1.97.1)
+      express-rate-limit:
+        specifier: ^8.3.1
+        version: 8.3.1(express@4.22.1)
       file-saver-es:
         specifier: 2.0.5
         version: 2.0.5
@@ -31583,6 +31586,11 @@ snapshots:
       jest-util: 30.2.0
 
   exponential-backoff@3.1.1: {}
+
+  express-rate-limit@8.3.1(express@4.22.1):
+    dependencies:
+      express: 4.22.1
+      ip-address: 10.1.0
 
   express-rate-limit@8.3.1(express@5.2.1):
     dependencies:


### PR DESCRIPTION
Potential fix for [https://github.com/DevExpress/DevExtreme/security/code-scanning/353](https://github.com/DevExpress/DevExtreme/security/code-scanning/353)

To fix this, add rate limiting middleware to the Express app and apply it to the routes that trigger the expensive file-system operations (`demoIndexHandler`). The most straightforward way, consistent with the background example, is to use the well-known `express-rate-limit` package. This keeps existing functionality (same handler logic and routes) while enforcing a maximum number of requests per client in a time window, reducing DOS risk from repeated calls to `readFileSync` and `readdirSync`.

Concretely:
- In `apps/demos/utils/server/csp-server.js`, require `express-rate-limit` near the other `require` calls.
- Configure a limiter instance with a reasonable window and max value; since this is a demo server, a generic configuration (e.g., 100 requests per 15 minutes per IP) is acceptable and mirrors the background example.
- Apply the limiter as middleware specifically for the demo routes, not globally, to avoid changing behavior of unrelated endpoints. For example, define `const demoIndexLimiter = RateLimit({...})` and then change the route definitions to `app.get('/apps/demos/...', demoIndexLimiter, demoIndexHandler);`.
- No changes are needed inside `demoIndexHandler` itself; only the route wiring is updated.

All changes are limited to the shown file and keep existing behavior aside from introducing rate limiting on the risky endpoints.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
