### PR TITLE
CI: Run set-timestamp-version as npm script

### DIFF
--- a/.github/workflows/packages_publishing.yml
+++ b/.github/workflows/packages_publishing.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Set timestamp version
         if: ${{ env.SET_TIMESTAMP_VERSION == 'true' }}
-        run: pnpx ts-node tools/scripts/set-timestamp-version
+        run: pnpm run all:set-timestamp-version
 
       - name: Build npm packages
         env:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "regenerate-all": "nx run-many -t regenerate",
     "lint-staged": "lint-staged",
     "prepare": "husky install",
+    "all:set-timestamp-version": "ts-node tools/scripts/set-timestamp-version.ts",
     "all:update-version": "ts-node tools/scripts/update-version.ts",
     "all:build": "ts-node tools/scripts/build-all.ts",
     "all:build-dev": "nx all:build-dev workflows",


### PR DESCRIPTION
Avoid using `pnpx` as is does not respect the lockfile