### PR TITLE
fix async rule ts error

### DIFF
--- a/apps/demos/Demos/Form/Validation/Angular/app/app.component.html
+++ b/apps/demos/Demos/Form/Validation/Angular/app/app.component.html
@@ -14,12 +14,11 @@
         </dxi-form-validation-rule>
         <dxi-form-validation-rule type="email" message="Email is invalid">
         </dxi-form-validation-rule>
-        <dxi-form-validation-rule
-          type="async"
+        <dxi-form-async-rule
           message="Email is already registered"
           [validationCallback]="asyncValidation"
         >
-        </dxi-form-validation-rule>
+        </dxi-form-async-rule>
       </dxi-form-item>
       <dxi-form-item
         dataField="Password"

--- a/apps/demos/Demos/Form/Validation/Angular/app/app.component.ts
+++ b/apps/demos/Demos/Form/Validation/Angular/app/app.component.ts
@@ -13,12 +13,14 @@ import {
 } from 'devextreme-angular';
 import notify from 'devextreme/ui/notify';
 import Validator from 'devextreme/ui/validator';
-import { AsyncRule } from 'devextreme-angular/common';
-import { DxFormModule, DxFormComponent, DxFormTypes } from 'devextreme-angular/ui/form';
-import { DxTextBoxTypes } from 'devextreme-angular/ui/text-box';
-import { DxDateBoxTypes } from 'devextreme-angular/ui/date-box';
-import { DxDateRangeBoxTypes } from 'devextreme-angular/ui/date-range-box';
-import { DxButtonModule, DxButtonTypes } from 'devextreme-angular/ui/button';
+import type { AsyncRule } from 'devextreme-angular/common';
+import { DxFormModule, DxFormComponent } from 'devextreme-angular/ui/form';
+import type { DxFormTypes } from 'devextreme-angular/ui/form';
+import type { DxTextBoxTypes } from 'devextreme-angular/ui/text-box';
+import type { DxDateBoxTypes } from 'devextreme-angular/ui/date-box';
+import type { DxDateRangeBoxTypes } from 'devextreme-angular/ui/date-range-box';
+import { DxButtonModule } from 'devextreme-angular/ui/button';
+import type { DxButtonTypes } from 'devextreme-angular/ui/button';
 import { Customer, Service } from './app.service';
 
 type EditorOptions = DxTextBoxTypes.Properties;

--- a/apps/demos/Demos/Validation/Overview/Angular/app/app.component.html
+++ b/apps/demos/Demos/Validation/Overview/Angular/app/app.component.html
@@ -14,11 +14,10 @@
               type="email"
               message="Email is invalid"
             ></dxi-validator-validation-rule>
-            <dxi-validator-validation-rule
-              type="async"
+            <dxi-validator-async-rule
               message="Email is already registered"
               [validationCallback]="asyncValidation"
-            ></dxi-validator-validation-rule>
+            ></dxi-validator-async-rule>
           </dx-validator>
         </dx-text-box>
       </div>

--- a/apps/demos/Demos/Validation/Overview/Angular/app/app.component.ts
+++ b/apps/demos/Demos/Validation/Overview/Angular/app/app.component.ts
@@ -14,9 +14,9 @@ import {
   DxValidationSummaryModule,
 } from 'devextreme-angular';
 import notify from 'devextreme/ui/notify';
-import { DxButtonTypes } from 'devextreme-angular/ui/button';
-import { DxTextBoxTypes } from 'devextreme-angular/ui/text-box';
-import { ValidationCallbackData } from 'devextreme-angular/common';
+import type { DxButtonTypes } from 'devextreme-angular/ui/button';
+import type { DxTextBoxTypes } from 'devextreme-angular/ui/text-box';
+import type { ValidationCallbackData } from 'devextreme-angular/common';
 import { Service } from './app.service';
 
 if (!/localhost/.test(document.location.host)) {


### PR DESCRIPTION
Fix ngc ts errors in Angular demos

Change Form/Validation and Validation/Overview to `async` specific validation rules. To test run 
> pnpm exec ngc --noEmit --project Demos/COMPONENT/DEMO/Angular/tsconfig.typecheck.json
command for the relevant demos
