### PR TITLE
Scheduler - Fix incorrect appointment layout on initial Storybook render

### DIFF
--- a/apps/react-storybook/.storybook/themes/themes.tsx
+++ b/apps/react-storybook/.storybook/themes/themes.tsx
@@ -34,12 +34,18 @@ export const compact = [
 
 export const ThemeDecorator: Decorator = (Story, ctx) => {
     const { theme, compact } = ctx.globals;
+    const [cssLoaded, setCssLoaded] = React.useState(false);
     const themeName = theme.split('.').length < 3 ? 'generic' : theme.split('.')[0];
     const cssFileHref = `css/dx.${theme}${compact ? '.compact' : ''}.css`
     return (
-        <div className={`dx-theme-${themeName}-typography storybook-theme-decorator`}>
-            <link rel="stylesheet" href={cssFileHref} />
-            <Story />
+        <div key={cssFileHref} className={`dx-theme-${themeName}-typography storybook-theme-decorator`}>
+            <link
+                rel="stylesheet"
+                href={cssFileHref}
+                onLoad={() => setCssLoaded(true)}
+                onError={() => setCssLoaded(true)}
+            />
+            {cssLoaded && <Story />}
         </div>
     );
 }


### PR DESCRIPTION
Defer story rendering until the DevExtreme CSS stylesheet has loaded. Without this, widgets measure cell dimensions before styles are applied and produce incorrect layout.