### PR TITLE
devextreme-angular: clean:src-metadata on regenerate

### DIFF
--- a/packages/devextreme-angular/project.json
+++ b/packages/devextreme-angular/project.json
@@ -168,7 +168,7 @@
         "!{projectRoot}/src/ui/popup/index.ts",
         "{projectRoot}/src/index.ts",
         "{projectRoot}/src/common/index.ts",
-        "{projectRoot}/metadata/generated/**/*"
+        "{projectRoot}/src/metadata/generated/**/*"
       ]
     },
     "regenerate": {
@@ -190,7 +190,7 @@
         "!{projectRoot}/src/ui/popup/index.ts",
         "{projectRoot}/src/index.ts",
         "{projectRoot}/src/common/index.ts",
-        "{projectRoot}/metadata/generated/**/*"
+        "{projectRoot}/src/metadata/generated/**/*"
       ],
       "inputs": [
         "default"

--- a/packages/devextreme-angular/project.json
+++ b/packages/devextreme-angular/project.json
@@ -7,6 +7,12 @@
     "devextreme"
   ],
   "targets": {
+    "clean:src-metadata": {
+      "executor": "devextreme-nx-infra-plugin:clean",
+      "options": {
+        "targetDirectory": "./src/metadata"
+      }
+    },
     "clean:src-ui": {
       "executor": "devextreme-nx-infra-plugin:clean",
       "options": {
@@ -172,6 +178,7 @@
       ],
       "options": {
         "commands": [
+          "pnpm --workspace-root nx clean:src-metadata devextreme-angular",
           "pnpm --workspace-root nx clean:src-ui devextreme-angular",
           "pnpm --workspace-root nx generate-components devextreme-angular"
         ],


### PR DESCRIPTION
### Cherry-picks
- #33409

Patch for:
- #32006

Fixes a subj for a new (after NX) folders / files structure, where:

```
\devextreme-angular\
  - \src\
    -- \metadata\ (<<-- src sub)
```

Before NX it was:

```
\devextreme-angular\
  - \metadata\ (<<-- src sibling)
  - \src\
```

https://github.com/DevExpress/DevExtreme/blob/25_1/packages/devextreme-angular/gulpfile.js#L30-L39
https://github.com/DevExpress/DevExtreme/blob/25_1/packages/devextreme-angular/build.config.js#L3-L12