### PR TITLE
Potential fix for code scanning alert no. 354: Incomplete string escaping or encoding

### DIFF
--- a/packages/devextreme/eslint-scheduler-allowlist.mjs
+++ b/packages/devextreme/eslint-scheduler-allowlist.mjs
@@ -127,4 +127,4 @@ const schedulerMemberAllowlist = [
 ];
 
 export const schedulerMemberAllowlistRegex =
-    `^(_|__esModule|${schedulerMemberAllowlist.map(s => s.replace(/\$/g, '\\$')).join('|')})$`;
+    `^(_|__esModule|${schedulerMemberAllowlist.map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})$`;


### PR DESCRIPTION
Potential fix for [https://github.com/DevExpress/DevExtreme/security/code-scanning/354](https://github.com/DevExpress/DevExtreme/security/code-scanning/354)

Use complete regex escaping for each allowlist token before joining into an alternation.  
Best fix: replace the `$`-only escape with a standard “escape all regex metacharacters” expression:

- From: `s.replace(/\$/g, '\\$')`
- To: `s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')`

This preserves current behavior for existing names while correctly handling backslashes and all other regex-significant characters.  
Edit only `packages/devextreme/eslint-scheduler-allowlist.mjs` at the export constructing `schedulerMemberAllowlistRegex` (line region around 129–130). No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
