### PR TITLE
Splitter: prevent cursor misalignment after runtime orientation change (T1327400)

### DIFF
--- a/packages/devextreme/js/__internal/ui/splitter/splitter.ts
+++ b/packages/devextreme/js/__internal/ui/splitter/splitter.ts
@@ -492,9 +492,11 @@ class Splitter extends CollectionWidgetLiveUpdate<Properties> {
         const leftItemIndex = this._getIndexByItem(leftItemData);
         this._activeResizeHandleIndex = leftItemIndex;
 
+        const { orientation: currentOrientation } = this.option();
+
         this._currentOnePxRatio = convertSizeToRatio(
           1,
-          getElementSize($(this.element()), orientation),
+          getElementSize($(this.element()), currentOrientation),
           this._getResizeHandlesSize(),
         );
 

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets/splitter.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets/splitter.tests.js
@@ -2364,6 +2364,20 @@ QUnit.module('Resizing', moduleConfig, () => {
         this.assertLayout(['75', '25']);
     });
 
+    QUnit.test('resize should use current orientation for ratio calculation after orientation runtime change (T1327400)', function(assert) {
+        this.reinit({
+            width: 408, height: 208,
+            items: [{ }, { }],
+        });
+
+        this.instance.option('orientation', 'vertical');
+
+        const pointer = pointerMock(this.getResizeHandles().eq(0));
+        pointer.start().dragStart().drag(0, 50).dragEnd();
+
+        this.assertLayout(['75', '25']);
+    });
+
     QUnit.test('drag resize should work after setting pane size to 0 programmatically', function(assert) {
         this.reinit({
             width: 208, height: 208,


### PR DESCRIPTION
Cherry-pick of #33403 