### PR TITLE
Scheduler - Refactor Appointments Collection - KBN

### DIFF
--- a/packages/devextreme/js/__internal/scheduler/__tests__/appointments_new.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/__tests__/appointments_new.test.ts
@@ -784,6 +784,7 @@ describe('New Appointments', () => {
           recurrenceRule: 'FREQ=DAILY;COUNT=3',
         }],
         currentDate: new Date(2015, 1, 9),
+        currentView: 'week',
         recurrenceEditMode: 'occurrence',
       });
 

--- a/packages/devextreme/js/__internal/scheduler/__tests__/appointments_new.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/__tests__/appointments_new.test.ts
@@ -392,7 +392,6 @@ describe('New Appointments', () => {
     });
   });
 
-<<<<<<< HEAD
   describe('onAppointmentClick', () => {
     it('should call onAppointmentClick callback', async () => {
       const onAppointmentClick = jest.fn();

--- a/packages/devextreme/js/__internal/scheduler/__tests__/appointments_new.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/__tests__/appointments_new.test.ts
@@ -4,6 +4,7 @@ import {
 import type { dxElementWrapper } from '@js/core/renderer';
 import $ from '@js/core/renderer';
 import type { Properties } from '@js/ui/scheduler';
+import { fireEvent } from '@testing-library/dom';
 
 import { createScheduler as baseCreateScheduler } from './__mock__/create_scheduler';
 import { setupSchedulerTestEnvironment } from './__mock__/m_mock_scheduler';
@@ -391,6 +392,7 @@ describe('New Appointments', () => {
     });
   });
 
+<<<<<<< HEAD
   describe('onAppointmentClick', () => {
     it('should call onAppointmentClick callback', async () => {
       const onAppointmentClick = jest.fn();
@@ -754,6 +756,44 @@ describe('New Appointments', () => {
       expect(onAppointmentUpdated).toHaveBeenCalledTimes(1);
       expect((onAppointmentUpdated.mock.calls[0][0] as any).appointmentData).toBe(appointment);
       expect(appointment.text).toBe('Updated Appointment');
+    });
+  });
+
+  describe('Keyboard navigation', () => {
+    it('should delete appointment by delete key', async () => {
+      const { POM } = await createScheduler({
+        dataSource: [{
+          startDate: new Date(2015, 1, 9, 8),
+          endDate: new Date(2015, 1, 9, 9),
+        }],
+        currentDate: new Date(2015, 1, 9, 8),
+      });
+
+      const appointment = POM.getAppointments()[0];
+      appointment.element.focus();
+      fireEvent.keyDown(appointment.element, { key: 'Delete' });
+
+      expect(POM.getAppointments().length).toBe(0);
+    });
+
+    it('should delete recurring appointment occurrence by delete key', async () => {
+      const { POM } = await createScheduler({
+        dataSource: [{
+          startDate: new Date(2015, 1, 9, 8),
+          endDate: new Date(2015, 1, 9, 9),
+          recurrenceRule: 'FREQ=DAILY;COUNT=3',
+        }],
+        currentDate: new Date(2015, 1, 9),
+        recurrenceEditMode: 'occurrence',
+      });
+
+      expect(POM.getAppointments().length).toBe(3);
+
+      const appointment = POM.getAppointments()[0];
+      appointment.element.focus();
+      fireEvent.keyDown(appointment.element, { key: 'Delete' });
+
+      expect(POM.getAppointments().length).toBe(2);
     });
   });
 });

--- a/packages/devextreme/js/__internal/scheduler/__tests__/appointments_new.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/__tests__/appointments_new.test.ts
@@ -772,6 +772,7 @@ describe('New Appointments', () => {
       const appointment = POM.getAppointments()[0];
       appointment.element.focus();
       fireEvent.keyDown(appointment.element, { key: 'Delete' });
+      await new Promise(process.nextTick);
 
       expect(POM.getAppointments().length).toBe(0);
     });
@@ -793,8 +794,52 @@ describe('New Appointments', () => {
       const appointment = POM.getAppointments()[0];
       appointment.element.focus();
       fireEvent.keyDown(appointment.element, { key: 'Delete' });
+      await new Promise(process.nextTick);
 
       expect(POM.getAppointments().length).toBe(2);
+    });
+
+    it.each([
+      { editing: true },
+      { editing: { allowDeleting: true } },
+      { editing: { allowDeleting: true, allowUpdating: false } },
+    ])('should delete appointment when editing=$editing', async ({ editing }) => {
+      const { POM } = await createScheduler({
+        dataSource: [{
+          startDate: new Date(2015, 1, 9, 8),
+          endDate: new Date(2015, 1, 9, 9),
+        }],
+        currentDate: new Date(2015, 1, 9, 8),
+        editing,
+      });
+
+      const appointment = POM.getAppointments()[0];
+      appointment.element.focus();
+      fireEvent.keyDown(appointment.element, { key: 'Delete' });
+      await new Promise(process.nextTick);
+
+      expect(POM.getAppointments().length).toBe(0);
+    });
+
+    it.each([
+      { editing: { allowDeleting: false } },
+      { editing: false },
+    ])('should NOT delete appointment when editing=$editing', async ({ editing }) => {
+      const { POM } = await createScheduler({
+        dataSource: [{
+          startDate: new Date(2015, 1, 9, 8),
+          endDate: new Date(2015, 1, 9, 9),
+        }],
+        currentDate: new Date(2015, 1, 9, 8),
+        editing,
+      });
+
+      const appointment = POM.getAppointments()[0];
+      appointment.element.focus();
+      fireEvent.keyDown(appointment.element, { key: 'Delete' });
+      await new Promise(process.nextTick);
+
+      expect(POM.getAppointments().length).toBe(1);
     });
   });
 });

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointment/base_appointment.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointment/base_appointment.ts
@@ -38,11 +38,11 @@ export interface BaseAppointmentViewProperties
 export class BaseAppointmentView<
   TProperties extends BaseAppointmentViewProperties = BaseAppointmentViewProperties,
 > extends ViewItem<TProperties> {
-  get targetedAppointmentData(): TargetedAppointment {
+  public get targetedAppointmentData(): TargetedAppointment {
     return this.option().targetedAppointmentData;
   }
 
-  get appointmentData(): SafeAppointment {
+  public get appointmentData(): SafeAppointment {
     return this.option().appointmentData;
   }
 

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.focus_controller.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.focus_controller.ts
@@ -19,7 +19,7 @@ export class AppointmentsFocusController {
 
   private needRestoreFocusIndex = -1;
 
-  private get sortedAppointments(): SortedEntity[] {
+  private get sortedItems(): SortedEntity[] {
     return this.appointments.option().getSortedItems();
   }
 
@@ -110,7 +110,7 @@ export class AppointmentsFocusController {
 
   private handleTabKeyDown(e: KeyboardKeyDownEvent, sortedIndex: number): void {
     const nextIndex = sortedIndex + (e.shift ? -1 : 1);
-    const nextItemData = this.sortedAppointments[nextIndex];
+    const nextItemData = this.sortedItems[nextIndex];
 
     if (!nextItemData) {
       return;
@@ -134,7 +134,7 @@ export class AppointmentsFocusController {
   }
 
   private handleHomeKeyDown(e: KeyboardKeyDownEvent): void {
-    const firstSortedItem = this.sortedAppointments[0];
+    const firstSortedItem = this.sortedItems[0];
     if (firstSortedItem) {
       e.originalEvent.preventDefault();
       this.focusBySortedItem(firstSortedItem);
@@ -142,7 +142,7 @@ export class AppointmentsFocusController {
   }
 
   private handleEndKeyDown(e: KeyboardKeyDownEvent): void {
-    const lastSortedItem = this.sortedAppointments[this.sortedAppointments.length - 1];
+    const lastSortedItem = this.sortedItems[this.sortedItems.length - 1];
     if (lastSortedItem) {
       e.originalEvent.preventDefault();
       this.focusBySortedItem(lastSortedItem);

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.focus_controller.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.focus_controller.ts
@@ -52,6 +52,8 @@ export class AppointmentsFocusController {
   public onViewItemKeyDown(viewItem: ViewItem, e: KeyboardKeyDownEvent): void {
     if (e.key === 'Tab') {
       this.handleTabKeyDown(e, viewItem.option().sortedIndex);
+    } else if (e.key === 'Delete') {
+      this.handleDeleteKeyDown(viewItem.option().sortedIndex);
     }
   }
 
@@ -90,6 +92,15 @@ export class AppointmentsFocusController {
 
     e.originalEvent.preventDefault();
     this.focusByItemData(nextItemData);
+  }
+
+  private handleDeleteKeyDown(sortedIndex: number): void {
+    const { allowDelete, onDeleteKeyPress } = this.appointments.option();
+    if (!allowDelete) { return; }
+
+    const itemData = this.sortedAppointments.find((s) => s.sortedIndex === sortedIndex)?.itemData;
+    if (!itemData) { return; }
+    onDeleteKeyPress({ data: itemData, target: null });
   }
 
   private focusByItemData(itemData: SortedEntity): void {

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.focus_controller.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.focus_controller.ts
@@ -10,6 +10,10 @@ import { AppointmentCollector } from './appointment_collector';
 import type { Appointments } from './appointments';
 import type { ViewItem } from './view_item';
 
+interface AppointmentsFocusControllerHandlers {
+  onAppointmentEnterKeyDown: (appointmentView: BaseAppointmentView, event: DxEvent) => void;
+}
+
 export class AppointmentsFocusController {
   private focusableSortedIndex = 0;
 
@@ -27,7 +31,10 @@ export class AppointmentsFocusController {
     return this.appointments.option().tabIndex;
   }
 
-  constructor(private readonly appointments: Appointments) { }
+  constructor(
+    private readonly appointments: Appointments,
+    private readonly handlers: AppointmentsFocusControllerHandlers,
+  ) { }
 
   public onViewItemClick(viewItem: ViewItem): void {
     this.focusViewItem(viewItem);
@@ -119,12 +126,9 @@ export class AppointmentsFocusController {
     const { allowDelete, onDeleteKeyPress } = this.appointments.option();
     if (!allowDelete) { return; }
 
-    const sortedItem = this.sortedAppointments[viewItem.option().sortedIndex];
-    if (!sortedItem) { return; }
-
     const appointmentViewItem = viewItem as BaseAppointmentView;
     onDeleteKeyPress({
-      appointmentData: sortedItem.itemData,
+      appointmentData: appointmentViewItem.appointmentData,
       targetedAppointmentData: appointmentViewItem.targetedAppointmentData,
     });
   }
@@ -146,15 +150,16 @@ export class AppointmentsFocusController {
   }
 
   private handleEnterKeyDown(viewItem: ViewItem, e: KeyboardKeyDownEvent): void {
-    const { onItemActivate } = this.appointments.option();
-    const sortedItem = this.sortedAppointments[viewItem.option().sortedIndex];
-    if (!sortedItem) { return; }
     e.originalEvent.preventDefault();
-    const appointmentViewItem = viewItem as BaseAppointmentView;
-    onItemActivate({
-      data: sortedItem.itemData,
-      targetedAppointmentData: appointmentViewItem.targetedAppointmentData,
-    });
+
+    if (viewItem instanceof AppointmentCollector) {
+      return;
+    }
+
+    this.handlers.onAppointmentEnterKeyDown(
+      viewItem as BaseAppointmentView,
+      e.originalEvent as DxEvent,
+    );
   }
 
   private focusBySortedItem(sortedItem: SortedEntity): void {

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.focus_controller.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.focus_controller.ts
@@ -5,6 +5,8 @@ import { focus } from '@ts/events/m_short';
 
 import { getRawAppointmentGroupValues } from '../utils/resource_manager/appointment_groups_utils';
 import type { SortedEntity } from '../view_model/types';
+import type { BaseAppointmentView } from './appointment/base_appointment';
+import { AppointmentCollector } from './appointment_collector';
 import type { Appointments } from './appointments';
 import type { ViewItem } from './view_item';
 
@@ -14,7 +16,7 @@ export class AppointmentsFocusController {
   private needRestoreFocusIndex = -1;
 
   private get sortedAppointments(): SortedEntity[] {
-    return this.appointments.option().getSortedAppointments();
+    return this.appointments.option().getSortedItems();
   }
 
   private get isVirtualScrolling(): boolean {
@@ -55,19 +57,19 @@ export class AppointmentsFocusController {
         this.handleTabKeyDown(e, viewItem.option().sortedIndex);
         break;
       case e.key === 'Delete':
-        this.handleDeleteKeyDown(viewItem.option().sortedIndex);
+        this.handleDeleteKeyDown(viewItem);
         break;
       case e.key === 'Home':
-        this.handleHomeKeyDown();
+        this.handleHomeKeyDown(e);
         break;
       case e.key === 'End':
-        this.handleEndKeyDown();
+        this.handleEndKeyDown(e);
         break;
       case e.key === 'Enter':
-        this.handleEnterKeyDown(viewItem.option().sortedIndex);
+        this.handleEnterKeyDown(viewItem, e);
         break;
       case e.key === ' ':
-        this.handleEnterKeyDown(viewItem.option().sortedIndex);
+        this.handleEnterKeyDown(viewItem, e);
         break;
       default:
         break;
@@ -108,49 +110,64 @@ export class AppointmentsFocusController {
     }
 
     e.originalEvent.preventDefault();
-    this.focusByItemData(nextItemData);
+    this.focusBySortedItem(nextItemData);
   }
 
-  private handleDeleteKeyDown(sortedIndex: number): void {
-    const { allowDelete, onDeleteKeyPress, getDataAccessor } = this.appointments.option();
+  private handleDeleteKeyDown(viewItem: ViewItem): void {
+    if (viewItem instanceof AppointmentCollector) { return; }
+
+    const { allowDelete, onDeleteKeyPress } = this.appointments.option();
     if (!allowDelete) { return; }
 
-    const entity = this.sortedAppointments[sortedIndex];
-    if (!entity) { return; }
+    const sortedItem = this.sortedAppointments[viewItem.option().sortedIndex];
+    if (!sortedItem) { return; }
 
-    const occurrence = { ...entity.itemData };
-    getDataAccessor().set('startDate', occurrence, new Date(entity.source.startDate));
-
-    onDeleteKeyPress({ appointment: entity.itemData, occurrence });
+    const appointmentViewItem = viewItem as BaseAppointmentView;
+    onDeleteKeyPress({
+      appointmentData: sortedItem.itemData,
+      targetedAppointmentData: appointmentViewItem.targetedAppointmentData,
+    });
   }
 
-  private handleHomeKeyDown(): void {
-    const firstAppointment = this.sortedAppointments[0];
-    if (firstAppointment) { this.focusByItemData(firstAppointment); }
+  private handleHomeKeyDown(e: KeyboardKeyDownEvent): void {
+    const firstSortedItem = this.sortedAppointments[0];
+    if (firstSortedItem) {
+      e.originalEvent.preventDefault();
+      this.focusBySortedItem(firstSortedItem);
+    }
   }
 
-  private handleEndKeyDown(): void {
-    const lastAppointment = this.sortedAppointments[this.sortedAppointments.length - 1];
-    if (lastAppointment) { this.focusByItemData(lastAppointment); }
+  private handleEndKeyDown(e: KeyboardKeyDownEvent): void {
+    const lastSortedItem = this.sortedAppointments[this.sortedAppointments.length - 1];
+    if (lastSortedItem) {
+      e.originalEvent.preventDefault();
+      this.focusBySortedItem(lastSortedItem);
+    }
   }
 
-  private handleEnterKeyDown(sortedIndex: number): void {
+  private handleEnterKeyDown(viewItem: ViewItem, e: KeyboardKeyDownEvent): void {
     const { onItemActivate } = this.appointments.option();
-    const entity = this.sortedAppointments[sortedIndex];
-    onItemActivate({ data: entity?.itemData, target: null });
+    const sortedItem = this.sortedAppointments[viewItem.option().sortedIndex];
+    if (!sortedItem) { return; }
+    e.originalEvent.preventDefault();
+    const appointmentViewItem = viewItem as BaseAppointmentView;
+    onItemActivate({
+      data: sortedItem.itemData,
+      targetedAppointmentData: appointmentViewItem.targetedAppointmentData,
+    });
   }
 
-  private focusByItemData(itemData: SortedEntity): void {
+  private focusBySortedItem(sortedItem: SortedEntity): void {
     if (this.isVirtualScrolling) {
-      this.scrollToItem(itemData);
+      this.scrollToItem(sortedItem);
     }
 
-    const viewItem = this.appointments.getViewItemBySortedIndex(itemData.sortedIndex);
+    const viewItem = this.appointments.getViewItemBySortedIndex(sortedItem.sortedIndex);
 
     if (viewItem) {
       this.focusViewItem(viewItem);
     } else if (this.isVirtualScrolling) {
-      this.needRestoreFocusIndex = itemData.sortedIndex;
+      this.needRestoreFocusIndex = sortedItem.sortedIndex;
     }
   }
 
@@ -159,19 +176,19 @@ export class AppointmentsFocusController {
     focus.trigger(viewItem?.$element());
   }
 
-  private scrollToItem(itemData: SortedEntity): void {
+  private scrollToItem(sortedItem: SortedEntity): void {
     const { getStartViewDate, getResourceManager, scrollTo } = this.appointments.option();
 
     const date = new Date(Math.max(
       getStartViewDate().getTime(),
-      itemData.source.startDate,
+      sortedItem.source.startDate,
     ));
 
     const group = getRawAppointmentGroupValues(
-      itemData.itemData,
+      sortedItem.itemData,
       getResourceManager().resources,
     );
 
-    scrollTo(date, { group, allDay: itemData.allDay });
+    scrollTo(date, { group, allDay: sortedItem.allDay });
   }
 }

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.focus_controller.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.focus_controller.ts
@@ -50,10 +50,27 @@ export class AppointmentsFocusController {
   }
 
   public onViewItemKeyDown(viewItem: ViewItem, e: KeyboardKeyDownEvent): void {
-    if (e.key === 'Tab') {
-      this.handleTabKeyDown(e, viewItem.option().sortedIndex);
-    } else if (e.key === 'Delete') {
-      this.handleDeleteKeyDown(viewItem.option().sortedIndex);
+    switch (true) {
+      case e.key === 'Tab':
+        this.handleTabKeyDown(e, viewItem.option().sortedIndex);
+        break;
+      case e.key === 'Delete':
+        this.handleDeleteKeyDown(viewItem.option().sortedIndex);
+        break;
+      case e.key === 'Home':
+        this.handleHomeKeyDown();
+        break;
+      case e.key === 'End':
+        this.handleEndKeyDown();
+        break;
+      case e.key === 'Enter':
+        this.handleEnterKeyDown(viewItem.option().sortedIndex);
+        break;
+      case e.key === ' ':
+        this.handleEnterKeyDown(viewItem.option().sortedIndex);
+        break;
+      default:
+        break;
     }
   }
 
@@ -95,12 +112,32 @@ export class AppointmentsFocusController {
   }
 
   private handleDeleteKeyDown(sortedIndex: number): void {
-    const { allowDelete, onDeleteKeyPress } = this.appointments.option();
+    const { allowDelete, onDeleteKeyPress, getDataAccessor } = this.appointments.option();
     if (!allowDelete) { return; }
 
-    const itemData = this.sortedAppointments.find((s) => s.sortedIndex === sortedIndex)?.itemData;
-    if (!itemData) { return; }
-    onDeleteKeyPress({ data: itemData, target: null });
+    const entity = this.sortedAppointments[sortedIndex];
+    if (!entity) { return; }
+
+    const occurrence = { ...entity.itemData };
+    getDataAccessor().set('startDate', occurrence, new Date(entity.source.startDate));
+
+    onDeleteKeyPress({ appointment: entity.itemData, occurrence });
+  }
+
+  private handleHomeKeyDown(): void {
+    const firstAppointment = this.sortedAppointments[0];
+    if (firstAppointment) { this.focusByItemData(firstAppointment); }
+  }
+
+  private handleEndKeyDown(): void {
+    const lastAppointment = this.sortedAppointments[this.sortedAppointments.length - 1];
+    if (lastAppointment) { this.focusByItemData(lastAppointment); }
+  }
+
+  private handleEnterKeyDown(sortedIndex: number): void {
+    const { onItemActivate } = this.appointments.option();
+    const entity = this.sortedAppointments[sortedIndex];
+    onItemActivate({ data: entity?.itemData, target: null });
   }
 
   private focusByItemData(itemData: SortedEntity): void {

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.test.ts
@@ -558,9 +558,7 @@ describe('Appointments', () => {
         const viewItem1 = instance.getViewItemBySortedIndex(1);
 
         (viewItem0?.$element().get(0) as HTMLElement).click();
-        viewItem0?.$element().get(0).dispatchEvent(
-          new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
-        );
+        fireEvent.keyDown(viewItem0?.$element().get(0) as HTMLElement, { key: 'Tab' });
 
         expect(viewItem0?.$element().attr('tabindex')).toBe('-1');
         expect(viewItem1?.$element().attr('tabindex')).toBe('0');
@@ -584,9 +582,7 @@ describe('Appointments', () => {
         const viewItem1 = instance.getViewItemBySortedIndex(1);
 
         (viewItem1?.$element().get(0) as HTMLElement).click();
-        viewItem1?.$element().get(0).dispatchEvent(
-          new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true }),
-        );
+        fireEvent.keyDown(viewItem1?.$element().get(0) as HTMLElement, { key: 'Tab', shiftKey: true });
 
         expect(viewItem0?.$element().attr('tabindex')).toBe('0');
         expect(viewItem1?.$element().attr('tabindex')).toBe('-1');
@@ -658,9 +654,7 @@ describe('Appointments', () => {
 
         const viewItem1 = instance.getViewItemBySortedIndex(0);
         (viewItem1?.$element().get(0) as HTMLElement).click();
-        viewItem1?.$element().get(0).dispatchEvent(
-          new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
-        );
+        fireEvent.keyDown(viewItem1?.$element().get(0) as HTMLElement, { key: 'Tab' });
 
         expect(scrollTo).toHaveBeenCalled();
       });
@@ -683,9 +677,7 @@ describe('Appointments', () => {
         const viewItem2 = instance.getViewItemBySortedIndex(2);
 
         (viewItem1?.$element().get(0) as HTMLElement).click();
-        viewItem1?.$element().get(0).dispatchEvent(
-          new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
-        );
+        fireEvent.keyDown(viewItem1?.$element().get(0) as HTMLElement, { key: 'Tab' });
 
         expect(document.activeElement).toBe(viewItem2?.$element().get(0));
       });
@@ -708,9 +700,7 @@ describe('Appointments', () => {
 
         const viewItem1 = instance.getViewItemBySortedIndex(1);
         (viewItem1?.$element().get(0) as HTMLElement).click();
-        viewItem1?.$element().get(0).dispatchEvent(
-          new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
-        );
+        fireEvent.keyDown(viewItem1?.$element().get(0) as HTMLElement, { key: 'Tab' });
 
         // item2 is not rendered yet, so focus cannot move yet
         expect(instance.getViewItemBySortedIndex(2)).toBeUndefined();
@@ -744,9 +734,7 @@ describe('Appointments', () => {
 
         const viewItem0 = instance.getViewItemBySortedIndex(0);
         (viewItem0?.$element().get(0) as HTMLElement).click();
-        viewItem0?.$element().get(0).dispatchEvent(
-          new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
-        );
+        fireEvent.keyDown(viewItem0?.$element().get(0) as HTMLElement, { key: 'Tab' });
 
         expect(scrollTo).toHaveBeenCalledWith(appointmentStartDate, expect.anything());
       });
@@ -770,9 +758,7 @@ describe('Appointments', () => {
 
         const viewItem0 = instance.getViewItemBySortedIndex(0);
         (viewItem0?.$element().get(0) as HTMLElement).click();
-        viewItem0?.$element().get(0).dispatchEvent(
-          new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
-        );
+        fireEvent.keyDown(viewItem0?.$element().get(0) as HTMLElement, { key: 'Tab' });
 
         expect(scrollTo).toHaveBeenCalledWith(startViewDate, expect.anything());
       });
@@ -781,9 +767,7 @@ describe('Appointments', () => {
     describe('Navigation after partial render', () => {
       const pressTab = (): void => {
         const activeElement = document.activeElement as HTMLElement;
-        activeElement.dispatchEvent(
-          new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
-        );
+        fireEvent.keyDown(activeElement, { key: 'Tab' });
       };
 
       it('should navigate to the last appointment correctly after an appointment is added', () => {

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.test.ts
@@ -944,6 +944,48 @@ describe('Appointments', () => {
         expect(wasDefaultPrevented).toBe(true);
       });
 
+      it('should prevent default browser behavior on Enter key', () => {
+        const viewModel = [
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
+        ];
+
+        const instance = createAppointments({
+          ...getProperties(),
+        });
+        instance.option('viewModel', viewModel);
+
+        const viewItem = instance.getViewItemBySortedIndex(0);
+        (viewItem?.$element().get(0) as HTMLElement).click();
+
+        const wasDefaultPrevented = !fireEvent.keyDown(
+          viewItem?.$element().get(0) as HTMLElement,
+          { key: 'Enter' },
+        );
+
+        expect(wasDefaultPrevented).toBe(true);
+      });
+
+      it('should prevent default browser behavior on Space key', () => {
+        const viewModel = [
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
+        ];
+
+        const instance = createAppointments({
+          ...getProperties(),
+        });
+        instance.option('viewModel', viewModel);
+
+        const viewItem = instance.getViewItemBySortedIndex(0);
+        (viewItem?.$element().get(0) as HTMLElement).click();
+
+        const wasDefaultPrevented = !fireEvent.keyDown(
+          viewItem?.$element().get(0) as HTMLElement,
+          { key: ' ' },
+        );
+
+        expect(wasDefaultPrevented).toBe(true);
+      });
+
       it('should move focus to last appointment on End key', () => {
         const viewModel = [
           mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
@@ -1041,16 +1083,15 @@ describe('Appointments', () => {
         expect(onDeleteKeyPress).not.toHaveBeenCalled();
       });
 
-      it('should call onItemActivate when Enter is pressed', () => {
-        const onItemActivate = jest.fn();
+      it('should show appointment popup when Enter is pressed', () => {
+        const showEditAppointmentPopup = jest.fn();
         const viewModel = [
           mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
         ];
 
         const instance = createAppointments({
           ...getProperties(),
-          onItemActivate,
-          getSortedItems: () => viewModel as unknown as SortedEntity[],
+          showEditAppointmentPopup,
         });
         instance.option('viewModel', viewModel);
 
@@ -1058,21 +1099,44 @@ describe('Appointments', () => {
         (viewItem?.$element().get(0) as HTMLElement).click();
         fireEvent.keyDown(viewItem?.$element().get(0) as HTMLElement, { key: 'Enter' });
 
-        expect(onItemActivate).toHaveBeenCalledTimes(1);
-        expect(onItemActivate).toHaveBeenCalledWith(
-          expect.objectContaining({ data: defaultAppointmentData }),
+        expect(showEditAppointmentPopup).toHaveBeenCalledTimes(1);
+        expect(showEditAppointmentPopup).toHaveBeenCalledWith(
+          defaultAppointmentData,
+          expect.objectContaining({ ...defaultAppointmentData }),
         );
       });
-      it('should call onItemActivate when Space is pressed', () => {
-        const onItemActivate = jest.fn();
+
+      it('should call onAppointmentDblClick when Enter is pressed', () => {
+        const onAppointmentDblClick = jest.fn();
         const viewModel = [
           mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
         ];
 
         const instance = createAppointments({
           ...getProperties(),
-          onItemActivate,
-          getSortedItems: () => viewModel as unknown as SortedEntity[],
+          onAppointmentDblClick,
+        });
+        instance.option('viewModel', viewModel);
+
+        const viewItem = instance.getViewItemBySortedIndex(0);
+        (viewItem?.$element().get(0) as HTMLElement).click();
+        fireEvent.keyDown(viewItem?.$element().get(0) as HTMLElement, { key: 'Enter' });
+
+        expect(onAppointmentDblClick).toHaveBeenCalledTimes(1);
+        expect(onAppointmentDblClick).toHaveBeenCalledWith(
+          expect.objectContaining({ appointmentData: defaultAppointmentData }),
+        );
+      });
+
+      it('should show appointment popup when Space is pressed', () => {
+        const showEditAppointmentPopup = jest.fn();
+        const viewModel = [
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
+        ];
+
+        const instance = createAppointments({
+          ...getProperties(),
+          showEditAppointmentPopup,
         });
         instance.option('viewModel', viewModel);
 
@@ -1080,10 +1144,75 @@ describe('Appointments', () => {
         (viewItem?.$element().get(0) as HTMLElement).click();
         fireEvent.keyDown(viewItem?.$element().get(0) as HTMLElement, { key: ' ' });
 
-        expect(onItemActivate).toHaveBeenCalledTimes(1);
-        expect(onItemActivate).toHaveBeenCalledWith(
-          expect.objectContaining({ data: defaultAppointmentData }),
+        expect(showEditAppointmentPopup).toHaveBeenCalledTimes(1);
+        expect(showEditAppointmentPopup).toHaveBeenCalledWith(
+          defaultAppointmentData,
+          expect.objectContaining({ ...defaultAppointmentData }),
         );
+      });
+
+      it('should call onAppointmentDblClick when Space is pressed', () => {
+        const onAppointmentDblClick = jest.fn();
+        const viewModel = [
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
+        ];
+
+        const instance = createAppointments({
+          ...getProperties(),
+          onAppointmentDblClick,
+        });
+        instance.option('viewModel', viewModel);
+
+        const viewItem = instance.getViewItemBySortedIndex(0);
+        (viewItem?.$element().get(0) as HTMLElement).click();
+        fireEvent.keyDown(viewItem?.$element().get(0) as HTMLElement, { key: ' ' });
+
+        expect(onAppointmentDblClick).toHaveBeenCalledTimes(1);
+        expect(onAppointmentDblClick).toHaveBeenCalledWith(
+          expect.objectContaining({ appointmentData: defaultAppointmentData }),
+        );
+      });
+
+      it('should show tooltip when Enter is pressed on appointment collector', () => {
+        const showTooltipForCollector = jest.fn();
+        const showEditAppointmentPopup = jest.fn();
+        const viewModel = [
+          mockAppointmentCollectorViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
+        ];
+
+        const instance = createAppointments({
+          ...getProperties(),
+          showTooltipForCollector,
+          showEditAppointmentPopup,
+        });
+        instance.option('viewModel', viewModel);
+
+        const viewItem = instance.getViewItemBySortedIndex(0);
+        fireEvent.keyDown(viewItem?.$element().get(0) as HTMLElement, { key: 'Enter' });
+
+        expect(showTooltipForCollector).toHaveBeenCalledTimes(1);
+        expect(showEditAppointmentPopup).not.toHaveBeenCalled();
+      });
+
+      it('should show tooltip when Space is pressed on appointment collector', () => {
+        const showTooltipForCollector = jest.fn();
+        const showEditAppointmentPopup = jest.fn();
+        const viewModel = [
+          mockAppointmentCollectorViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
+        ];
+
+        const instance = createAppointments({
+          ...getProperties(),
+          showTooltipForCollector,
+          showEditAppointmentPopup,
+        });
+        instance.option('viewModel', viewModel);
+
+        const viewItem = instance.getViewItemBySortedIndex(0);
+        fireEvent.keyDown(viewItem?.$element().get(0) as HTMLElement, { key: ' ' });
+
+        expect(showTooltipForCollector).toHaveBeenCalledTimes(1);
+        expect(showEditAppointmentPopup).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.test.ts
@@ -4,7 +4,6 @@ import {
 import $ from '@js/core/renderer';
 import { fireEvent } from '@testing-library/dom';
 
-import fx from '../../../common/core/animation/fx';
 import { mockAppointmentDataAccessor } from '../__mock__/appointment_data_accessor.mock';
 import { getResourceManagerMock } from '../__mock__/resource_manager.mock';
 import type { ResourceConfig } from '../utils/loader/types';
@@ -82,8 +81,6 @@ const dblClick = (element: HTMLElement): void => {
 
 describe('Appointments', () => {
   beforeEach(() => {
-    fx.off = true;
-
     const $container = $('<div>')
       .addClass('container')
       .appendTo(document.body);
@@ -99,8 +96,6 @@ describe('Appointments', () => {
 
   afterEach(() => {
     $('.container').remove();
-    fx.off = false;
-    jest.useRealTimers();
   });
 
   describe('Classes', () => {
@@ -894,6 +889,56 @@ describe('Appointments', () => {
       });
     });
 
+    describe('Home/End navigation', () => {
+      it('should move focus to first appointment on Home key', () => {
+        const viewModel = [
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 1 }),
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 2 }),
+        ];
+
+        const instance = createAppointments({
+          ...getProperties(),
+          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+        });
+        instance.option('viewModel', viewModel);
+
+        const viewItem0 = instance.getViewItemBySortedIndex(0);
+        const viewItem2 = instance.getViewItemBySortedIndex(2);
+
+        (viewItem2?.$element().get(0) as HTMLElement).click();
+        fireEvent.keyDown(viewItem2?.$element().get(0) as HTMLElement, { key: 'Home' });
+
+        expect(viewItem0?.$element().attr('tabindex')).toBe('0');
+        expect(viewItem2?.$element().attr('tabindex')).toBe('-1');
+        expect(document.activeElement).toBe(viewItem0?.$element().get(0));
+      });
+
+      it('should move focus to last appointment on End key', () => {
+        const viewModel = [
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 1 }),
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 2 }),
+        ];
+
+        const instance = createAppointments({
+          ...getProperties(),
+          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+        });
+        instance.option('viewModel', viewModel);
+
+        const viewItem0 = instance.getViewItemBySortedIndex(0);
+        const viewItem2 = instance.getViewItemBySortedIndex(2);
+
+        (viewItem0?.$element().get(0) as HTMLElement).click();
+        fireEvent.keyDown(viewItem0?.$element().get(0) as HTMLElement, { key: 'End' });
+
+        expect(viewItem2?.$element().attr('tabindex')).toBe('0');
+        expect(viewItem0?.$element().attr('tabindex')).toBe('-1');
+        expect(document.activeElement).toBe(viewItem2?.$element().get(0));
+      });
+    });
+
     describe('Keyboard actions', () => {
       it('should call onDeleteKeyPress when Delete is pressed and allowDelete is true', () => {
         const onDeleteKeyPress = jest.fn();
@@ -906,7 +951,11 @@ describe('Appointments', () => {
           ...getProperties(),
           allowDelete: true,
           onDeleteKeyPress,
-          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+          getSortedAppointments: () => [{
+            sortedIndex: 0,
+            itemData: defaultAppointmentData,
+            source: { startDate: 0 },
+          }] as unknown as SortedEntity[],
         });
         instance.option('viewModel', viewModel);
 
@@ -916,7 +965,7 @@ describe('Appointments', () => {
 
         expect(onDeleteKeyPress).toHaveBeenCalledTimes(1);
         expect(onDeleteKeyPress).toHaveBeenCalledWith(
-          expect.objectContaining({ data: defaultAppointmentData }),
+          expect.objectContaining({ appointment: defaultAppointmentData }),
         );
       });
 
@@ -939,6 +988,51 @@ describe('Appointments', () => {
         fireEvent.keyDown(viewItem?.$element().get(0) as HTMLElement, { key: 'Delete' });
 
         expect(onDeleteKeyPress).not.toHaveBeenCalled();
+      });
+
+      it('should call onItemActivate when Enter is pressed', () => {
+        const onItemActivate = jest.fn();
+        const viewModel = [
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
+        ];
+
+        const instance = createAppointments({
+          ...getProperties(),
+          onItemActivate,
+          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+        });
+        instance.option('viewModel', viewModel);
+
+        const viewItem = instance.getViewItemBySortedIndex(0);
+        (viewItem?.$element().get(0) as HTMLElement).click();
+        fireEvent.keyDown(viewItem?.$element().get(0) as HTMLElement, { key: 'Enter' });
+
+        expect(onItemActivate).toHaveBeenCalledTimes(1);
+        expect(onItemActivate).toHaveBeenCalledWith(
+          expect.objectContaining({ data: defaultAppointmentData }),
+        );
+      });
+      it('should call onItemActivate when Space is pressed', () => {
+        const onItemActivate = jest.fn();
+        const viewModel = [
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
+        ];
+
+        const instance = createAppointments({
+          ...getProperties(),
+          onItemActivate,
+          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+        });
+        instance.option('viewModel', viewModel);
+
+        const viewItem = instance.getViewItemBySortedIndex(0);
+        (viewItem?.$element().get(0) as HTMLElement).click();
+        fireEvent.keyDown(viewItem?.$element().get(0) as HTMLElement, { key: ' ' });
+
+        expect(onItemActivate).toHaveBeenCalledTimes(1);
+        expect(onItemActivate).toHaveBeenCalledWith(
+          expect.objectContaining({ data: defaultAppointmentData }),
+        );
       });
     });
   });

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.test.ts
@@ -43,7 +43,7 @@ const getProperties = (options: {
   onAppointmentDblClick: (): void => {},
 
   getStartViewDate: () => new Date(2024, 0, 1),
-  getSortedAppointments: () => [],
+  getSortedItems: () => [],
   isVirtualScrolling: () => false,
   scrollTo: (): void => {},
 
@@ -550,7 +550,7 @@ describe('Appointments', () => {
 
         const instance = createAppointments({
           ...getProperties(),
-          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+          getSortedItems: () => viewModel as unknown as SortedEntity[],
         });
         instance.option('viewModel', viewModel);
 
@@ -574,7 +574,7 @@ describe('Appointments', () => {
 
         const instance = createAppointments({
           ...getProperties(),
-          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+          getSortedItems: () => viewModel as unknown as SortedEntity[],
         });
         instance.option('viewModel', viewModel);
 
@@ -643,7 +643,7 @@ describe('Appointments', () => {
           ...getProperties(),
           isVirtualScrolling: () => true,
           scrollTo,
-          getSortedAppointments: () => [
+          getSortedItems: () => [
             makeSortedEntity(0), makeSortedEntity(1), makeSortedEntity(1),
           ],
         });
@@ -663,7 +663,7 @@ describe('Appointments', () => {
         const instance = createAppointments({
           ...getProperties(),
           isVirtualScrolling: () => true,
-          getSortedAppointments: () => [
+          getSortedItems: () => [
             makeSortedEntity(0), makeSortedEntity(1), makeSortedEntity(2),
           ],
         });
@@ -690,7 +690,7 @@ describe('Appointments', () => {
         const instance = createAppointments({
           ...getProperties(),
           isVirtualScrolling: () => true,
-          getSortedAppointments: () => [
+          getSortedItems: () => [
             makeSortedEntity(0), makeSortedEntity(1), makeSortedEntity(2),
           ],
         });
@@ -724,7 +724,7 @@ describe('Appointments', () => {
           isVirtualScrolling: () => true,
           scrollTo,
           getStartViewDate: () => startViewDate,
-          getSortedAppointments: () => [
+          getSortedItems: () => [
             makeSortedEntity(0), makeSortedEntity(1, appointmentStartDate),
           ],
         });
@@ -752,7 +752,7 @@ describe('Appointments', () => {
           isVirtualScrolling: () => true,
           scrollTo,
           getStartViewDate: () => startViewDate,
-          getSortedAppointments: () => sortedEntities,
+          getSortedItems: () => sortedEntities,
         });
         instance.option('viewModel', viewModel);
 
@@ -783,7 +783,7 @@ describe('Appointments', () => {
 
         const instance = createAppointments({
           ...getProperties(),
-          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+          getSortedItems: () => viewModel as unknown as SortedEntity[],
         });
         instance.option('viewModel', viewModel);
 
@@ -819,7 +819,7 @@ describe('Appointments', () => {
 
         const instance = createAppointments({
           ...getProperties(),
-          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+          getSortedItems: () => viewModel as unknown as SortedEntity[],
         });
         instance.option('viewModel', viewModel);
 
@@ -851,7 +851,7 @@ describe('Appointments', () => {
 
         const instance = createAppointments({
           ...getProperties(),
-          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+          getSortedItems: () => viewModel as unknown as SortedEntity[],
         });
         instance.option('viewModel', viewModel);
 
@@ -883,7 +883,7 @@ describe('Appointments', () => {
 
         const instance = createAppointments({
           ...getProperties(),
-          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+          getSortedItems: () => viewModel as unknown as SortedEntity[],
         });
         instance.option('viewModel', viewModel);
 
@@ -898,6 +898,52 @@ describe('Appointments', () => {
         expect(document.activeElement).toBe(viewItem0?.$element().get(0));
       });
 
+      it('should prevent default browser behavior on Home key', () => {
+        const viewModel = [
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 1 }),
+        ];
+
+        const instance = createAppointments({
+          ...getProperties(),
+          getSortedItems: () => viewModel as unknown as SortedEntity[],
+        });
+        instance.option('viewModel', viewModel);
+
+        const viewItem1 = instance.getViewItemBySortedIndex(1);
+        (viewItem1?.$element().get(0) as HTMLElement).click();
+
+        const wasDefaultPrevented = !fireEvent.keyDown(
+          viewItem1?.$element().get(0) as HTMLElement,
+          { key: 'Home' },
+        );
+
+        expect(wasDefaultPrevented).toBe(true);
+      });
+
+      it('should prevent default browser behavior on End key', () => {
+        const viewModel = [
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 1 }),
+        ];
+
+        const instance = createAppointments({
+          ...getProperties(),
+          getSortedItems: () => viewModel as unknown as SortedEntity[],
+        });
+        instance.option('viewModel', viewModel);
+
+        const viewItem0 = instance.getViewItemBySortedIndex(0);
+        (viewItem0?.$element().get(0) as HTMLElement).click();
+
+        const wasDefaultPrevented = !fireEvent.keyDown(
+          viewItem0?.$element().get(0) as HTMLElement,
+          { key: 'End' },
+        );
+
+        expect(wasDefaultPrevented).toBe(true);
+      });
+
       it('should move focus to last appointment on End key', () => {
         const viewModel = [
           mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
@@ -907,7 +953,7 @@ describe('Appointments', () => {
 
         const instance = createAppointments({
           ...getProperties(),
-          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+          getSortedItems: () => viewModel as unknown as SortedEntity[],
         });
         instance.option('viewModel', viewModel);
 
@@ -935,7 +981,7 @@ describe('Appointments', () => {
           ...getProperties(),
           allowDelete: true,
           onDeleteKeyPress,
-          getSortedAppointments: () => [{
+          getSortedItems: () => [{
             sortedIndex: 0,
             itemData: defaultAppointmentData,
             source: { startDate: 0 },
@@ -949,7 +995,7 @@ describe('Appointments', () => {
 
         expect(onDeleteKeyPress).toHaveBeenCalledTimes(1);
         expect(onDeleteKeyPress).toHaveBeenCalledWith(
-          expect.objectContaining({ appointment: defaultAppointmentData }),
+          expect.objectContaining({ appointmentData: defaultAppointmentData }),
         );
       });
 
@@ -963,7 +1009,28 @@ describe('Appointments', () => {
           ...getProperties(),
           allowDelete: false,
           onDeleteKeyPress,
-          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+          getSortedItems: () => viewModel as unknown as SortedEntity[],
+        });
+        instance.option('viewModel', viewModel);
+
+        const viewItem = instance.getViewItemBySortedIndex(0);
+        (viewItem?.$element().get(0) as HTMLElement).click();
+        fireEvent.keyDown(viewItem?.$element().get(0) as HTMLElement, { key: 'Delete' });
+
+        expect(onDeleteKeyPress).not.toHaveBeenCalled();
+      });
+
+      it('should not call onDeleteKeyPress when Delete is pressed on appointment collector', () => {
+        const onDeleteKeyPress = jest.fn();
+        const viewModel = [
+          mockAppointmentCollectorViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
+        ];
+
+        const instance = createAppointments({
+          ...getProperties(),
+          allowDelete: true,
+          onDeleteKeyPress,
+          getSortedItems: () => viewModel as unknown as SortedEntity[],
         });
         instance.option('viewModel', viewModel);
 
@@ -983,7 +1050,7 @@ describe('Appointments', () => {
         const instance = createAppointments({
           ...getProperties(),
           onItemActivate,
-          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+          getSortedItems: () => viewModel as unknown as SortedEntity[],
         });
         instance.option('viewModel', viewModel);
 
@@ -1005,7 +1072,7 @@ describe('Appointments', () => {
         const instance = createAppointments({
           ...getProperties(),
           onItemActivate,
-          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+          getSortedItems: () => viewModel as unknown as SortedEntity[],
         });
         instance.option('viewModel', viewModel);
 

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.test.ts
@@ -55,6 +55,8 @@ const getProperties = (options: {
   showTooltipForAppointment: (): void => {},
   showTooltipForCollector: (): void => {},
   showEditAppointmentPopup: (): void => {},
+  allowDelete: false,
+  onDeleteKeyPress: (): void => {},
 });
 
 const createAppointments = (
@@ -889,6 +891,54 @@ describe('Appointments', () => {
         const lastViewItem = instance.getViewItemBySortedIndex(2);
         expect(document.activeElement).toBe(lastViewItem?.$element().get(0));
         expect(lastViewItem?.$element().attr('tabindex')).toBe('0');
+      });
+    });
+
+    describe('Keyboard actions', () => {
+      it('should call onDeleteKeyPress when Delete is pressed and allowDelete is true', () => {
+        const onDeleteKeyPress = jest.fn();
+        const viewModel = [
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 1 }),
+        ];
+
+        const instance = createAppointments({
+          ...getProperties(),
+          allowDelete: true,
+          onDeleteKeyPress,
+          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+        });
+        instance.option('viewModel', viewModel);
+
+        const viewItem = instance.getViewItemBySortedIndex(0);
+        (viewItem?.$element().get(0) as HTMLElement).click();
+        fireEvent.keyDown(viewItem?.$element().get(0) as HTMLElement, { key: 'Delete' });
+
+        expect(onDeleteKeyPress).toHaveBeenCalledTimes(1);
+        expect(onDeleteKeyPress).toHaveBeenCalledWith(
+          expect.objectContaining({ data: defaultAppointmentData }),
+        );
+      });
+
+      it('should not call onDeleteKeyPress when Delete is pressed and allowDelete is false', () => {
+        const onDeleteKeyPress = jest.fn();
+        const viewModel = [
+          mockGridViewModel({ ...defaultAppointmentData }, { sortedIndex: 0 }),
+        ];
+
+        const instance = createAppointments({
+          ...getProperties(),
+          allowDelete: false,
+          onDeleteKeyPress,
+          getSortedAppointments: () => viewModel as unknown as SortedEntity[],
+        });
+        instance.option('viewModel', viewModel);
+
+        const viewItem = instance.getViewItemBySortedIndex(0);
+        (viewItem?.$element().get(0) as HTMLElement).click();
+        fireEvent.keyDown(viewItem?.$element().get(0) as HTMLElement, { key: 'Delete' });
+
+        expect(onDeleteKeyPress).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.ts
@@ -84,8 +84,10 @@ export interface AppointmentsProperties extends DOMComponentProperties<Appointme
   ) => void;
 
   allowDelete: boolean;
-  onDeleteKeyPress: (options:
-  { appointmentData: SafeAppointment; targetedAppointmentData: TargetedAppointment }) => void;
+  onDeleteKeyPress: (options: {
+    appointmentData: SafeAppointment;
+    targetedAppointmentData: TargetedAppointment;
+  }) => void;
 }
 
 export class Appointments extends DOMComponent<Appointments, AppointmentsProperties> {

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.ts
@@ -116,7 +116,9 @@ export class Appointments extends DOMComponent<Appointments, AppointmentsPropert
   override _init(): void {
     super._init();
 
-    this.focusController = new AppointmentsFocusController(this);
+    this.focusController = new AppointmentsFocusController(this, {
+      onAppointmentEnterKeyDown: this.onAppointmentDblClick.bind(this),
+    });
 
     this._templateManager.addDefaultTemplates({
       appointment: new EmptyTemplate(),

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.ts
@@ -82,6 +82,10 @@ export interface AppointmentsProperties extends DOMComponentProperties<Appointme
     appointmentData: SafeAppointment,
     targetedAppointmentData: TargetedAppointment,
   ) => void;
+
+  allowDelete: boolean;
+  onDeleteKeyPress: (options:
+  { appointmentData: SafeAppointment; targetedAppointmentData: TargetedAppointment }) => void;
 }
 
 export class Appointments extends DOMComponent<Appointments, AppointmentsProperties> {
@@ -152,6 +156,8 @@ export class Appointments extends DOMComponent<Appointments, AppointmentsPropert
       onAppointmentRendered: noop,
       onAppointmentClick: noop,
       onAppointmentDblClick: noop,
+      allowDelete: false,
+      onDeleteKeyPress: noop,
     };
   }
 

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.ts
@@ -64,7 +64,7 @@ export interface AppointmentsProperties extends DOMComponentProperties<Appointme
   getResourceManager: () => ResourceManager;
   getDataAccessor: () => AppointmentDataAccessor;
   getStartViewDate: () => Date;
-  getSortedAppointments: () => SortedEntity[];
+  getSortedItems: () => SortedEntity[];
   isVirtualScrolling: () => boolean;
 
   scrollTo: (date: Date, options?: ScrollToOptions) => void;

--- a/packages/devextreme/js/__internal/scheduler/m_scheduler.ts
+++ b/packages/devextreme/js/__internal/scheduler/m_scheduler.ts
@@ -1074,12 +1074,16 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       const appointmentsConfig: Partial<AppointmentsProperties> = {
         tabIndex: this.option('tabIndex'),
         currentView: this.option('currentView') as ViewType,
+        allowDelete: this.editing.allowUpdating && this.editing.allowDeleting,
         appointmentTemplate: this.getViewOption('appointmentTemplate'),
         appointmentCollectorTemplate: this.getViewOption('appointmentCollectorTemplate'),
 
         onAppointmentRendered: (...args) => this.actions.onAppointmentRendered(...args),
         onAppointmentClick: (...args) => this.actions.onAppointmentClick(...args),
         onAppointmentDblClick: (...args) => this.actions.onAppointmentDblClick(...args),
+        onDeleteKeyPress: (e) => {
+          this.checkAndDeleteAppointment(e.appointmentData, e.targetedAppointmentData);
+        },
 
         getResourceManager: () => this.resourceManager,
         getAppointmentDataSource: () => this.appointmentDataSource,

--- a/packages/devextreme/js/__internal/scheduler/m_scheduler.ts
+++ b/packages/devextreme/js/__internal/scheduler/m_scheduler.ts
@@ -509,7 +509,11 @@ class Scheduler extends SchedulerOptionsBaseWidget {
         this.initEditing();
         const { editing } = this;
 
-        this.bringEditingModeToAppointments(editing);
+        if (this.option('_newAppointments')) {
+          this._appointments.option('allowDelete', this.editing.allowDeleting);
+        } else {
+          this.bringEditingModeToAppointments(editing);
+        }
 
         this.hideAppointmentTooltip();
         this.createAppointmentPopupForm();
@@ -1074,7 +1078,7 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       const appointmentsConfig: Partial<AppointmentsProperties> = {
         tabIndex: this.option('tabIndex'),
         currentView: this.option('currentView') as ViewType,
-        allowDelete: this.editing.allowUpdating && this.editing.allowDeleting,
+        allowDelete: this.editing.allowDeleting,
         appointmentTemplate: this.getViewOption('appointmentTemplate'),
         appointmentCollectorTemplate: this.getViewOption('appointmentCollectorTemplate'),
 
@@ -1089,7 +1093,8 @@ class Scheduler extends SchedulerOptionsBaseWidget {
         getAppointmentDataSource: () => this.appointmentDataSource,
         getDataAccessor: () => this._dataAccessors,
         getStartViewDate: () => this.getStartViewDate(),
-        getSortedAppointments: () => this._layoutManager.sortedItems,
+        getSortedItems: () => this._layoutManager.sortedItems,
+
         isVirtualScrolling: () => this.isVirtualScrolling(),
 
         scrollTo: this.scrollTo.bind(this),
@@ -1246,7 +1251,6 @@ class Scheduler extends SchedulerOptionsBaseWidget {
       targetedAppointment,
       this._dataAccessors,
     );
-
     const deletingOptions = this.fireOnAppointmentDeleting(appointment, targetedAdapter);
     this.checkRecurringAppointment(
       appointment,


### PR DESCRIPTION
## What
 Keyboard navigation for new `appointments_new/` architecture (Del/Home/End/Enter/Space)
 
 ## How
- New props: `editing.allowDeleting`, `onDeleteKeyPress`, `onItemActivate` on `AppointmentsProperties`
- `focus_controller`: switch(true) per key in `onViewItemKeyDown`
- Del passes correct occurrence `startDate`, recurring delete excludes right instance