### PR TITLE
CI: Apply `setName` transformation to devextreme-dist-internal package.json

### DIFF
--- a/packages/devextreme/project.json
+++ b/packages/devextreme/project.json
@@ -869,7 +869,8 @@
       },
       "configurations": {
         "internal": {
-          "distDirectory": "./artifacts/npm/devextreme-dist-internal"
+          "distDirectory": "./artifacts/npm/devextreme-dist-internal",
+          "setName": "devextreme-dist-internal"
         }
       },
       "inputs": [


### PR DESCRIPTION
Follow-up for https://github.com/DevExpress/DevExtreme/pull/33510
devextreme-dist internal counterpart should be renamed by adding `-internal` suffix, otherwise it overwrites original dist package