### PR TITLE
DataGrid - AI Assistant: interruption & cancellation e2e tests

### DIFF
--- a/e2e/testcafe-devextreme/tests/dataGrid/common/aiAssistant/interruption.functional.ts
+++ b/e2e/testcafe-devextreme/tests/dataGrid/common/aiAssistant/interruption.functional.ts
@@ -1,0 +1,368 @@
+import { ClientFunction, Selector } from 'testcafe';
+import DataGrid from 'devextreme-testcafe-models/dataGrid';
+import { createWidget } from '../../../../helpers/createWidget';
+import { AI_INTEGRATION_PAGE, formatMessage, GRID_SELECTOR } from './testHelpers';
+
+const disposeGrid = ClientFunction(() => { (window as any).widget.dispose(); });
+
+const abortMessage = (): Promise<string> => formatMessage('dxDataGrid-aiAssistantAbortMessage');
+
+// === §5.2 Popup close mid-request (before any command executes) ===
+
+fixture.disablePageReloads`AI Assistant - Popup Close Mid-Request`
+  .page(AI_INTEGRATION_PAGE);
+
+// 5.2.1
+test('Closing the popup mid-request should abort and leave the grid unchanged', async (t) => {
+  const dataGrid = new DataGrid(GRID_SELECTOR);
+
+  await t.expect(dataGrid.isReady()).ok();
+
+  await t.click(dataGrid.getAIAssistantButton());
+
+  const aiChat = dataGrid.getAIAssistantChat();
+
+  await t
+    .typeText(aiChat.getInput(), 'Sort by name')
+    .pressKey('enter');
+
+  await t.expect(aiChat.getPendingMessages().count).eql(1);
+
+  await t.click(aiChat.getCloseButton().element);
+
+  await t.expect(aiChat.getAbortConfirmDialog().exists).ok();
+
+  await t.click(aiChat.getAbortConfirmYesButton());
+
+  // No command ran: the grid is unchanged.
+  await t.expect(dataGrid.apiColumnOption('name', 'sortOrder')).notOk();
+}).before(async () => createWidget('dxDataGrid', () => ({
+  dataSource: [
+    { id: 1, name: 'Alice', value: 30 },
+    { id: 2, name: 'Bob', value: 20 },
+    { id: 3, name: 'Charlie', value: 10 },
+  ],
+  keyExpr: 'id',
+  columns: ['id', 'name', 'value'],
+  showBorders: true,
+  aiAssistant: {
+    enabled: true,
+    aiIntegration: new (window as any).DevExpress.aiIntegration.AIIntegration({
+      sendRequest() {
+        return {
+          promise: new Promise(() => {}),
+          abort: (): void => {},
+        };
+      },
+    }),
+  },
+})));
+
+// 5.2.2
+test('Re-opening after a mid-request close shows the aborted response and re-enables input', async (t) => {
+  const dataGrid = new DataGrid(GRID_SELECTOR);
+
+  await t.expect(dataGrid.isReady()).ok();
+
+  await t.click(dataGrid.getAIAssistantButton());
+
+  const aiChat = dataGrid.getAIAssistantChat();
+
+  await t
+    .typeText(aiChat.getInput(), 'Sort by name')
+    .pressKey('enter');
+
+  await t.expect(aiChat.getPendingMessages().count).eql(1);
+
+  await t.click(aiChat.getCloseButton().element);
+
+  await t.expect(aiChat.getAbortConfirmDialog().exists).ok();
+
+  await t.click(aiChat.getAbortConfirmYesButton());
+
+  await t.click(dataGrid.getAIAssistantButton());
+
+  await t.expect(aiChat.getMessages().count).eql(2);
+  await t.expect(aiChat.getErrorMessages().count).eql(1);
+  await t.expect(aiChat.getMessageErrorText(0).innerText).eql(await abortMessage());
+  await t.expect(aiChat.isInputDisabled()).notOk();
+}).before(async () => createWidget('dxDataGrid', () => ({
+  dataSource: [
+    { id: 1, name: 'Alice', value: 30 },
+    { id: 2, name: 'Bob', value: 20 },
+    { id: 3, name: 'Charlie', value: 10 },
+  ],
+  keyExpr: 'id',
+  columns: ['id', 'name', 'value'],
+  showBorders: true,
+  aiAssistant: {
+    enabled: true,
+    aiIntegration: new (window as any).DevExpress.aiIntegration.AIIntegration({
+      sendRequest() {
+        return {
+          promise: new Promise(() => {}),
+          abort: (): void => {},
+        };
+      },
+    }),
+  },
+})));
+
+// 5.2.3
+test('Late LLM resolution after abort should be ignored', async (t) => {
+  const dataGrid = new DataGrid(GRID_SELECTOR);
+
+  await t.expect(dataGrid.isReady()).ok();
+
+  await t.click(dataGrid.getAIAssistantButton());
+
+  const aiChat = dataGrid.getAIAssistantChat();
+
+  await t
+    .typeText(aiChat.getInput(), 'Sort by name')
+    .pressKey('enter');
+
+  await t.expect(aiChat.getPendingMessages().count).eql(1);
+
+  await t.click(aiChat.getCloseButton().element);
+
+  await t.expect(aiChat.getAbortConfirmDialog().exists).ok();
+
+  await t.click(aiChat.getAbortConfirmYesButton());
+
+  await t.click(dataGrid.getAIAssistantButton());
+
+  // Wait past the mocked resolution delay: the late result must not run any command.
+  await t.wait(2000);
+
+  await t.expect(dataGrid.apiColumnOption('name', 'sortOrder')).notOk();
+  await t.expect(aiChat.getSuccessMessages().count).eql(0);
+}).before(async () => createWidget('dxDataGrid', () => ({
+  dataSource: [
+    { id: 1, name: 'Alice', value: 30 },
+    { id: 2, name: 'Bob', value: 20 },
+    { id: 3, name: 'Charlie', value: 10 },
+  ],
+  keyExpr: 'id',
+  columns: ['id', 'name', 'value'],
+  showBorders: true,
+  aiAssistant: {
+    enabled: true,
+    aiIntegration: new (window as any).DevExpress.aiIntegration.AIIntegration({
+      sendRequest() {
+        return {
+          promise: new Promise((resolve) => {
+            setTimeout(() => resolve({
+              actions: [{ name: 'sorting', args: { dataField: 'name', sortOrder: 'asc' } }],
+            }), 1500);
+          }),
+          abort: (): void => {},
+        };
+      },
+    }),
+  },
+})));
+
+// === §5.3 / §5.4 are not covered as e2e ===
+// §5.3 (close popup mid-execution) and §5.4 (re-open after a mid-execution close) cannot be
+// reproduced deterministically: the popup cannot be closed while commands execute (issue 4282),
+// and every non-selection command resolves within microtasks, so there is no observable
+// "mid-execution" window to close into. These remain manual-only / unit-test scenarios.
+
+// === §5.5 Grid destroyed (dispose) mid-request / mid-execution ===
+
+fixture.disablePageReloads`AI Assistant - Dispose`
+  .page(AI_INTEGRATION_PAGE);
+
+// 5.5.1
+test('Disposing the grid mid-request should not throw and ignore the late resolution', async (t) => {
+  const dataGrid = new DataGrid(GRID_SELECTOR);
+
+  await t.expect(dataGrid.isReady()).ok();
+
+  await t.click(dataGrid.getAIAssistantButton());
+
+  const aiChat = dataGrid.getAIAssistantChat();
+
+  await t
+    .typeText(aiChat.getInput(), 'Sort by name')
+    .pressKey('enter');
+
+  await t.expect(aiChat.getPendingMessages().count).eql(1);
+
+  await disposeGrid();
+
+  // Allow the mocked resolution to fire after dispose; it must not touch the destroyed grid.
+  await t.wait(2000);
+
+  await t.expect(Selector('#container').find('.dx-datagrid').exists).notOk();
+}).before(async () => createWidget('dxDataGrid', () => ({
+  dataSource: [
+    { id: 1, name: 'Alice', value: 30 },
+    { id: 2, name: 'Bob', value: 20 },
+    { id: 3, name: 'Charlie', value: 10 },
+  ],
+  keyExpr: 'id',
+  columns: ['id', 'name', 'value'],
+  showBorders: true,
+  aiAssistant: {
+    enabled: true,
+    aiIntegration: new (window as any).DevExpress.aiIntegration.AIIntegration({
+      sendRequest() {
+        return {
+          promise: new Promise((resolve) => {
+            setTimeout(() => resolve({
+              actions: [{ name: 'sorting', args: { dataField: 'name', sortOrder: 'asc' } }],
+            }), 1500);
+          }),
+          abort: (): void => {},
+        };
+      },
+    }),
+  },
+})));
+
+// 5.5.2
+test('Disposing the grid mid-execution should not throw', async (t) => {
+  const dataGrid = new DataGrid(GRID_SELECTOR);
+
+  await t.expect(dataGrid.isReady()).ok();
+
+  await t.click(dataGrid.getAIAssistantButton());
+
+  const aiChat = dataGrid.getAIAssistantChat();
+
+  await t
+    .typeText(aiChat.getInput(), 'Select all rows')
+    .pressKey('enter');
+
+  // The selectAll command is awaiting a server key-load that never resolves — mid-execution.
+  await t.expect(aiChat.isInputDisabled()).ok();
+
+  await disposeGrid();
+
+  await t.wait(500);
+
+  await t.expect(Selector('#container').find('.dx-datagrid').exists).notOk();
+}).before(async () => createWidget('dxDataGrid', () => {
+  const data = Array.from({ length: 50 }, (_, i) => ({
+    id: i + 1,
+    name: `Name ${i + 1}`,
+    value: (i + 1) * 10,
+  }));
+
+  const store = new (window as any).DevExpress.data.CustomStore({
+    key: 'id',
+    load(opts: any) {
+      if (opts.take !== undefined) {
+        const skip = opts.skip ?? 0;
+
+        return Promise.resolve({
+          data: data.slice(skip, skip + opts.take),
+          totalCount: data.length,
+        });
+      }
+
+      return new Promise(() => {});
+    },
+    totalCount: () => data.length,
+  });
+
+  return {
+    dataSource: store,
+    remoteOperations: true,
+    columns: ['id', 'name', 'value'],
+    showBorders: true,
+    selection: { mode: 'multiple' },
+    aiAssistant: {
+      enabled: true,
+      aiIntegration: new (window as any).DevExpress.aiIntegration.AIIntegration({
+        sendRequest() {
+          return {
+            promise: Promise.resolve({ actions: [{ name: 'selectAll', args: {} }] }),
+            abort: (): void => {},
+          };
+        },
+      }),
+    },
+  };
+}));
+
+// 5.5.3
+test('Re-creating the grid after a dispose-during-flight yields a usable instance', async (t) => {
+  let dataGrid = new DataGrid(GRID_SELECTOR);
+
+  await t.expect(dataGrid.isReady()).ok();
+
+  await t.click(dataGrid.getAIAssistantButton());
+
+  let aiChat = dataGrid.getAIAssistantChat();
+
+  await t
+    .typeText(aiChat.getInput(), 'Sort by name')
+    .pressKey('enter');
+
+  await t.expect(aiChat.getPendingMessages().count).eql(1);
+
+  await disposeGrid();
+
+  // Re-create a fresh instance in the same container with a normal (resolving) integration.
+  await createWidget('dxDataGrid', () => ({
+    dataSource: [
+      { id: 1, name: 'Alice', value: 30 },
+      { id: 2, name: 'Bob', value: 20 },
+      { id: 3, name: 'Charlie', value: 10 },
+    ],
+    keyExpr: 'id',
+    columns: ['id', 'name', 'value'],
+    showBorders: true,
+    aiAssistant: {
+      enabled: true,
+      aiIntegration: new (window as any).DevExpress.aiIntegration.AIIntegration({
+        sendRequest() {
+          return {
+            promise: Promise.resolve({
+              actions: [{ name: 'sorting', args: { dataField: 'name', sortOrder: 'asc' } }],
+            }),
+            abort: (): void => {},
+          };
+        },
+      }),
+    },
+  }));
+
+  dataGrid = new DataGrid(GRID_SELECTOR);
+
+  await t.expect(dataGrid.isReady()).ok();
+
+  await t.click(dataGrid.getAIAssistantButton());
+
+  aiChat = dataGrid.getAIAssistantChat();
+
+  await t
+    .typeText(aiChat.getInput(), 'Sort by name')
+    .pressKey('enter');
+
+  await t.expect(aiChat.getSuccessMessages().count).eql(1);
+  await t.expect(dataGrid.apiColumnOption('name', 'sortOrder')).eql('asc');
+}).before(async () => createWidget('dxDataGrid', () => ({
+  dataSource: [
+    { id: 1, name: 'Alice', value: 30 },
+    { id: 2, name: 'Bob', value: 20 },
+    { id: 3, name: 'Charlie', value: 10 },
+  ],
+  keyExpr: 'id',
+  columns: ['id', 'name', 'value'],
+  showBorders: true,
+  aiAssistant: {
+    enabled: true,
+    aiIntegration: new (window as any).DevExpress.aiIntegration.AIIntegration({
+      sendRequest() {
+        return {
+          promise: new Promise(() => {}),
+          abort: (): void => {},
+        };
+      },
+    }),
+  },
+})));

--- a/e2e/testcafe-devextreme/tests/dataGrid/common/aiAssistant/interruption.functional.ts
+++ b/e2e/testcafe-devextreme/tests/dataGrid/common/aiAssistant/interruption.functional.ts
@@ -155,11 +155,198 @@ test('Late LLM resolution after abort should be ignored', async (t) => {
   options: gridOptions, mode: 'delayed', actions: sortNameAsc, delay: 1500,
 }));
 
-// === §5.3 / §5.4 are not covered as e2e ===
-// §5.3 (close popup mid-execution) and §5.4 (re-open after a mid-execution close) cannot be
-// reproduced deterministically: the popup cannot be closed while commands execute (issue 4282),
-// and every non-selection command resolves within microtasks, so there is no observable
-// "mid-execution" window to close into. These remain manual-only / unit-test scenarios.
+// === §5.3 Popup close mid-execution / §5.4 Re-open after a mid-execution close ===
+
+const releaseSelectAll = ClientFunction(() => { (window as any).__resolveSelectAll(); });
+const selectAllStarted = ClientFunction(() => (window as any).__selectAllStarted === true);
+
+fixture`AI Assistant - Popup Close Mid-Execution`
+  .page(AI_INTEGRATION_PAGE);
+
+// 5.3.1 / 5.3.4 / 5.3.5 / 5.4.1 / 5.4.2
+test('Closing the popup mid-execution aborts the remaining commands and keeps the completed ones', async (t) => {
+  const dataGrid = new DataGrid(GRID_SELECTOR);
+
+  await t.expect(dataGrid.isReady()).ok();
+
+  await t.click(dataGrid.getAIAssistantButton());
+
+  const aiChat = dataGrid.getAIAssistantChat();
+
+  await t
+    .typeText(aiChat.getInput(), 'Sort by name, select all, then sort by value')
+    .pressKey('enter');
+
+  // Command #1 (sort by name) has applied; command #2 (selectAll) is now in flight and gated.
+  await t.expect(selectAllStarted()).ok();
+  await t.expect(aiChat.isInputDisabled()).ok();
+
+  // Close the popup mid-execution → confirm dialog → abort.
+  await closeAndConfirmAbort(t, aiChat);
+
+  // Let the gated selectAll resolve; the loop then sees the abort flag and stops before #3.
+  await releaseSelectAll();
+
+  // Re-open to inspect the resulting response.
+  await t.click(dataGrid.getAIAssistantButton());
+
+  // An aborted command makes the whole message a failure: 2 successes + 1 aborted entry.
+  await t.expect(aiChat.getErrorMessages().count).eql(1);
+  await t.expect(aiChat.getActionItems(0).count).eql(3);
+  await t.expect(aiChat.getSuccessActionItems(0).count).eql(2);
+  await t.expect(aiChat.getAbortedActionItems(0).count).eql(1);
+
+  // the grid reflects only completed commands: #1 applied, #3 (sort by value) skipped.
+  await t.expect(await dataGrid.apiColumnOption('name', 'sortOrder')).eql('asc');
+  await t.expect(await dataGrid.apiColumnOption('value', 'sortOrder')).notOk();
+
+  // no Regenerate button (commands were attempted; the grid was mutated).
+  await t.expect(aiChat.getMessageRegenerateButton(0).count).eql(0);
+
+  // the in-flight lock has been released.
+  await t.expect(aiChat.isInputDisabled()).notOk();
+}).before(async () => createWidget('dxDataGrid', () => {
+  const w = window as any;
+
+  w.__selectAllStarted = false;
+
+  const data = Array.from({ length: 50 }, (_, i) => ({
+    id: i + 1,
+    name: `Name ${i + 1}`,
+    value: (i + 1) * 10,
+  }));
+
+  const store = new w.DevExpress.data.CustomStore({
+    key: 'id',
+    load(opts: any) {
+      if (opts.take !== undefined) {
+        const skip = opts.skip ?? 0;
+
+        return Promise.resolve({
+          data: data.slice(skip, skip + opts.take),
+          totalCount: data.length,
+        });
+      }
+
+      w.__selectAllStarted = true;
+
+      return new Promise((resolve) => {
+        w.__resolveSelectAll = resolve.bind(resolve, data);
+      });
+    },
+    totalCount: () => data.length,
+  });
+
+  return {
+    dataSource: store,
+    remoteOperations: true,
+    columns: ['id', 'name', 'value'],
+    showBorders: true,
+    selection: { mode: 'multiple' },
+    aiAssistant: {
+      enabled: true,
+      aiIntegration: new w.DevExpress.aiIntegration.AIIntegration({
+        sendRequest() {
+          return {
+            promise: Promise.resolve({
+              actions: [
+                { name: 'sorting', args: { dataField: 'name', sortOrder: 'asc' } },
+                { name: 'selectAll', args: {} },
+                { name: 'sorting', args: { dataField: 'value', sortOrder: 'desc' } },
+              ],
+            }),
+            abort: (): void => {},
+          };
+        },
+      }),
+    },
+  };
+}));
+
+// 5.4.3
+test('Customized response title is applied to the partial (aborted) result', async (t) => {
+  const dataGrid = new DataGrid(GRID_SELECTOR);
+
+  await t.expect(dataGrid.isReady()).ok();
+
+  await t.click(dataGrid.getAIAssistantButton());
+
+  const aiChat = dataGrid.getAIAssistantChat();
+
+  await t
+    .typeText(aiChat.getInput(), 'Sort by name, select all, then sort by value')
+    .pressKey('enter');
+
+  await t.expect(selectAllStarted()).ok();
+
+  await closeAndConfirmAbort(t, aiChat);
+
+  await releaseSelectAll();
+
+  await t.click(dataGrid.getAIAssistantButton());
+
+  await t.expect(aiChat.getErrorMessages().count).eql(1);
+  await t.expect(aiChat.getMessageHeader(0).innerText).eql('Stopped before finishing');
+}).before(async () => createWidget('dxDataGrid', () => {
+  const w = window as any;
+
+  w.__selectAllStarted = false;
+
+  const data = Array.from({ length: 50 }, (_, i) => ({
+    id: i + 1,
+    name: `Name ${i + 1}`,
+    value: (i + 1) * 10,
+  }));
+
+  const store = new w.DevExpress.data.CustomStore({
+    key: 'id',
+    load(opts: any) {
+      if (opts.take !== undefined) {
+        const skip = opts.skip ?? 0;
+
+        return Promise.resolve({
+          data: data.slice(skip, skip + opts.take),
+          totalCount: data.length,
+        });
+      }
+
+      w.__selectAllStarted = true;
+
+      return new Promise((resolve) => {
+        w.__resolveSelectAll = resolve.bind(resolve, data);
+      });
+    },
+    totalCount: () => data.length,
+  });
+
+  return {
+    dataSource: store,
+    remoteOperations: true,
+    columns: ['id', 'name', 'value'],
+    showBorders: true,
+    selection: { mode: 'multiple' },
+    aiAssistant: {
+      enabled: true,
+      customizeResponseTitle: (status: string) => (status === 'failure'
+        ? 'Stopped before finishing'
+        : 'All done'),
+      aiIntegration: new w.DevExpress.aiIntegration.AIIntegration({
+        sendRequest() {
+          return {
+            promise: Promise.resolve({
+              actions: [
+                { name: 'sorting', args: { dataField: 'name', sortOrder: 'asc' } },
+                { name: 'selectAll', args: {} },
+                { name: 'sorting', args: { dataField: 'value', sortOrder: 'desc' } },
+              ],
+            }),
+            abort: (): void => {},
+          };
+        },
+      }),
+    },
+  };
+}));
 
 // === §5.5 Grid destroyed (dispose) mid-request / mid-execution ===
 

--- a/e2e/testcafe-devextreme/tests/dataGrid/common/aiAssistant/interruption.functional.ts
+++ b/e2e/testcafe-devextreme/tests/dataGrid/common/aiAssistant/interruption.functional.ts
@@ -76,10 +76,10 @@ const closeAndConfirmAbort = async (t: TestController, aiChat: AIAssistantChat):
   await t.click(aiChat.getAbortConfirmYesButton());
 };
 
-// === §5.2 Popup close mid-request (before any command executes) ===
-
-fixture`AI Assistant - Popup Close Mid-Request`
+fixture`AI Assistant - Interruption`
   .page(AI_INTEGRATION_PAGE);
+
+// === §5.2 Popup close mid-request (before any command executes) ===
 
 // 5.2.1
 test('Closing the popup mid-request should abort and leave the grid unchanged', async (t) => {
@@ -159,9 +159,6 @@ test('Late LLM resolution after abort should be ignored', async (t) => {
 
 const releaseSelectAll = ClientFunction(() => { (window as any).__resolveSelectAll(); });
 const selectAllStarted = ClientFunction(() => (window as any).__selectAllStarted === true);
-
-fixture`AI Assistant - Popup Close Mid-Execution`
-  .page(AI_INTEGRATION_PAGE);
 
 // 5.3.1 / 5.3.4 / 5.3.5 / 5.4.1 / 5.4.2
 test('Closing the popup mid-execution aborts the remaining commands and keeps the completed ones', async (t) => {
@@ -349,9 +346,6 @@ test('Customized response title is applied to the partial (aborted) result', asy
 }));
 
 // === §5.5 Grid destroyed (dispose) mid-request / mid-execution ===
-
-fixture`AI Assistant - Dispose`
-  .page(AI_INTEGRATION_PAGE);
 
 // 5.5.1
 test('Disposing the grid mid-request should not throw and ignore the late resolution', async (t) => {

--- a/e2e/testcafe-devextreme/tests/dataGrid/common/aiAssistant/interruption.functional.ts
+++ b/e2e/testcafe-devextreme/tests/dataGrid/common/aiAssistant/interruption.functional.ts
@@ -87,8 +87,6 @@ const closeAndConfirmAbort = async (t: TestController, aiChat: AIAssistantChat):
 fixture`AI Assistant - Interruption`
   .page(AI_INTEGRATION_PAGE);
 
-// === §5.2 Popup close mid-request (before any command executes) ===
-
 test('Closing the popup mid-request aborts, leaves the grid unchanged, and shows the aborted response on re-open', async (t) => {
   const dataGrid = new DataGrid(GRID_SELECTOR);
 
@@ -117,7 +115,6 @@ test('Closing the popup mid-request aborts, leaves the grid unchanged, and shows
   await t.expect(aiChat.isInputDisabled()).notOk();
 }).before(async () => createGridWithAI({ options: gridOptions, mode: 'never' }));
 
-// 5.2.3
 test('Late LLM resolution after abort should be ignored', async (t) => {
   const dataGrid = new DataGrid(GRID_SELECTOR);
 
@@ -144,12 +141,9 @@ test('Late LLM resolution after abort should be ignored', async (t) => {
   options: gridOptions, mode: 'delayed', actions: sortNameAsc,
 }));
 
-// === §5.3 Popup close mid-execution / §5.4 Re-open after a mid-execution close ===
-
 const resolveSelectAll = ClientFunction(() => { (window as any).__resolveSelectAll(); });
 const selectAllStarted = ClientFunction(() => (window as any).__selectAllStarted === true);
 
-// 5.3.1 / 5.3.4 / 5.3.5 / 5.4.1 / 5.4.2
 test('Closing the popup mid-execution aborts the remaining commands and keeps the completed ones', async (t) => {
   const dataGrid = new DataGrid(GRID_SELECTOR);
 
@@ -247,7 +241,6 @@ test('Closing the popup mid-execution aborts the remaining commands and keeps th
   };
 }));
 
-// 5.4.3
 test('Customized response title is applied to the partial (aborted) result', async (t) => {
   const dataGrid = new DataGrid(GRID_SELECTOR);
 
@@ -332,9 +325,6 @@ test('Customized response title is applied to the partial (aborted) result', asy
   };
 }));
 
-// === §5.5 Grid destroyed (dispose) mid-request / mid-execution ===
-
-// 5.5.1
 test('Disposing the grid mid-request should not throw and ignore the late resolution', async (t) => {
   const dataGrid = new DataGrid(GRID_SELECTOR);
 
@@ -365,7 +355,6 @@ test('Disposing the grid mid-request should not throw and ignore the late resolu
   options: gridOptions, mode: 'delayed', actions: sortNameAsc,
 }));
 
-// 5.5.2
 test('Disposing the grid mid-execution should not throw', async (t) => {
   const dataGrid = new DataGrid(GRID_SELECTOR);
 
@@ -435,7 +424,6 @@ test('Disposing the grid mid-execution should not throw', async (t) => {
   };
 }));
 
-// 5.5.3
 test('Re-creating the grid after a dispose-during-flight yields a usable instance', async (t) => {
   let dataGrid = new DataGrid(GRID_SELECTOR);
 

--- a/e2e/testcafe-devextreme/tests/dataGrid/common/aiAssistant/interruption.functional.ts
+++ b/e2e/testcafe-devextreme/tests/dataGrid/common/aiAssistant/interruption.functional.ts
@@ -1,15 +1,84 @@
+/* eslint-disable no-underscore-dangle */
 import { ClientFunction, Selector } from 'testcafe';
 import DataGrid from 'devextreme-testcafe-models/dataGrid';
+import { AIAssistantChat } from 'devextreme-testcafe-models/dataGrid/aiAssistantChat';
 import { createWidget } from '../../../../helpers/createWidget';
-import { AI_INTEGRATION_PAGE, formatMessage, GRID_SELECTOR } from './testHelpers';
+import { AI_INTEGRATION_PAGE, GRID_SELECTOR } from './testHelpers';
 
-const disposeGrid = ClientFunction(() => { (window as any).widget.dispose(); });
+const gridOptions = {
+  dataSource: [
+    { id: 1, name: 'Alice', value: 30 },
+    { id: 2, name: 'Bob', value: 20 },
+    { id: 3, name: 'Charlie', value: 10 },
+  ],
+  keyExpr: 'id',
+  columns: ['id', 'name', 'value'],
+  showBorders: true,
+};
+
+const sortNameAsc = [{ name: 'sorting', args: { dataField: 'name', sortOrder: 'asc' } }];
+
+const formatMessage = ClientFunction(
+  (key: string) => (window as any).DevExpress.localization.formatMessage(key),
+);
 
 const abortMessage = (): Promise<string> => formatMessage('dxDataGrid-aiAssistantAbortMessage');
 
+const disposeGrid = ClientFunction(() => { (window as any).widget.dispose(); });
+
+const wasAbortCalled = ClientFunction(() => (window as any).__aiAbortCalled === true);
+
+const setupAIState = ClientFunction((config: any) => {
+  (window as any).__aiConfig = config;
+  (window as any).__aiAbortCalled = false;
+});
+
+const aiGridOptions = (): any => {
+  const {
+    options, mode, actions, delay,
+  } = (window as any).__aiConfig;
+
+  const sendRequest = (): any => {
+    const abort = (): void => { (window as any).__aiAbortCalled = true; };
+
+    if (mode === 'never') {
+      return { promise: new Promise(() => {}), abort };
+    }
+
+    if (mode === 'delayed') {
+      return {
+        promise: new Promise((resolve) => { setTimeout(() => resolve({ actions }), delay); }),
+        abort,
+      };
+    }
+
+    return { promise: Promise.resolve({ actions }), abort };
+  };
+
+  return {
+    ...options,
+    aiAssistant: {
+      enabled: true,
+      aiIntegration: new (window as any).DevExpress.aiIntegration.AIIntegration({ sendRequest }),
+    },
+  };
+};
+
+const createGridWithAI = async (config: Record<string, unknown>): Promise<void> => {
+  await setupAIState(config);
+
+  return createWidget('dxDataGrid', aiGridOptions);
+};
+
+const closeAndConfirmAbort = async (t: TestController, aiChat: AIAssistantChat): Promise<void> => {
+  await t.click(aiChat.getCloseButton().element);
+  await t.expect(aiChat.getAbortConfirmDialog().exists).ok();
+  await t.click(aiChat.getAbortConfirmYesButton());
+};
+
 // === §5.2 Popup close mid-request (before any command executes) ===
 
-fixture.disablePageReloads`AI Assistant - Popup Close Mid-Request`
+fixture`AI Assistant - Popup Close Mid-Request`
   .page(AI_INTEGRATION_PAGE);
 
 // 5.2.1
@@ -28,35 +97,11 @@ test('Closing the popup mid-request should abort and leave the grid unchanged', 
 
   await t.expect(aiChat.getPendingMessages().count).eql(1);
 
-  await t.click(aiChat.getCloseButton().element);
+  await closeAndConfirmAbort(t, aiChat);
 
-  await t.expect(aiChat.getAbortConfirmDialog().exists).ok();
-
-  await t.click(aiChat.getAbortConfirmYesButton());
-
-  // No command ran: the grid is unchanged.
-  await t.expect(dataGrid.apiColumnOption('name', 'sortOrder')).notOk();
-}).before(async () => createWidget('dxDataGrid', () => ({
-  dataSource: [
-    { id: 1, name: 'Alice', value: 30 },
-    { id: 2, name: 'Bob', value: 20 },
-    { id: 3, name: 'Charlie', value: 10 },
-  ],
-  keyExpr: 'id',
-  columns: ['id', 'name', 'value'],
-  showBorders: true,
-  aiAssistant: {
-    enabled: true,
-    aiIntegration: new (window as any).DevExpress.aiIntegration.AIIntegration({
-      sendRequest() {
-        return {
-          promise: new Promise(() => {}),
-          abort: (): void => {},
-        };
-      },
-    }),
-  },
-})));
+  await t.expect(wasAbortCalled()).ok();
+  await t.expect(await dataGrid.apiColumnOption('name', 'sortOrder')).notOk();
+}).before(async () => createGridWithAI({ options: gridOptions, mode: 'never' }));
 
 // 5.2.2
 test('Re-opening after a mid-request close shows the aborted response and re-enables input', async (t) => {
@@ -74,11 +119,7 @@ test('Re-opening after a mid-request close shows the aborted response and re-ena
 
   await t.expect(aiChat.getPendingMessages().count).eql(1);
 
-  await t.click(aiChat.getCloseButton().element);
-
-  await t.expect(aiChat.getAbortConfirmDialog().exists).ok();
-
-  await t.click(aiChat.getAbortConfirmYesButton());
+  await closeAndConfirmAbort(t, aiChat);
 
   await t.click(dataGrid.getAIAssistantButton());
 
@@ -86,27 +127,7 @@ test('Re-opening after a mid-request close shows the aborted response and re-ena
   await t.expect(aiChat.getErrorMessages().count).eql(1);
   await t.expect(aiChat.getMessageErrorText(0).innerText).eql(await abortMessage());
   await t.expect(aiChat.isInputDisabled()).notOk();
-}).before(async () => createWidget('dxDataGrid', () => ({
-  dataSource: [
-    { id: 1, name: 'Alice', value: 30 },
-    { id: 2, name: 'Bob', value: 20 },
-    { id: 3, name: 'Charlie', value: 10 },
-  ],
-  keyExpr: 'id',
-  columns: ['id', 'name', 'value'],
-  showBorders: true,
-  aiAssistant: {
-    enabled: true,
-    aiIntegration: new (window as any).DevExpress.aiIntegration.AIIntegration({
-      sendRequest() {
-        return {
-          promise: new Promise(() => {}),
-          abort: (): void => {},
-        };
-      },
-    }),
-  },
-})));
+}).before(async () => createGridWithAI({ options: gridOptions, mode: 'never' }));
 
 // 5.2.3
 test('Late LLM resolution after abort should be ignored', async (t) => {
@@ -124,44 +145,15 @@ test('Late LLM resolution after abort should be ignored', async (t) => {
 
   await t.expect(aiChat.getPendingMessages().count).eql(1);
 
-  await t.click(aiChat.getCloseButton().element);
+  await closeAndConfirmAbort(t, aiChat);
 
-  await t.expect(aiChat.getAbortConfirmDialog().exists).ok();
-
-  await t.click(aiChat.getAbortConfirmYesButton());
-
-  await t.click(dataGrid.getAIAssistantButton());
-
-  // Wait past the mocked resolution delay: the late result must not run any command.
   await t.wait(2000);
 
-  await t.expect(dataGrid.apiColumnOption('name', 'sortOrder')).notOk();
+  await t.expect(await dataGrid.apiColumnOption('name', 'sortOrder')).notOk();
   await t.expect(aiChat.getSuccessMessages().count).eql(0);
-}).before(async () => createWidget('dxDataGrid', () => ({
-  dataSource: [
-    { id: 1, name: 'Alice', value: 30 },
-    { id: 2, name: 'Bob', value: 20 },
-    { id: 3, name: 'Charlie', value: 10 },
-  ],
-  keyExpr: 'id',
-  columns: ['id', 'name', 'value'],
-  showBorders: true,
-  aiAssistant: {
-    enabled: true,
-    aiIntegration: new (window as any).DevExpress.aiIntegration.AIIntegration({
-      sendRequest() {
-        return {
-          promise: new Promise((resolve) => {
-            setTimeout(() => resolve({
-              actions: [{ name: 'sorting', args: { dataField: 'name', sortOrder: 'asc' } }],
-            }), 1500);
-          }),
-          abort: (): void => {},
-        };
-      },
-    }),
-  },
-})));
+}).before(async () => createGridWithAI({
+  options: gridOptions, mode: 'delayed', actions: sortNameAsc, delay: 1500,
+}));
 
 // === §5.3 / §5.4 are not covered as e2e ===
 // §5.3 (close popup mid-execution) and §5.4 (re-open after a mid-execution close) cannot be
@@ -171,7 +163,7 @@ test('Late LLM resolution after abort should be ignored', async (t) => {
 
 // === §5.5 Grid destroyed (dispose) mid-request / mid-execution ===
 
-fixture.disablePageReloads`AI Assistant - Dispose`
+fixture`AI Assistant - Dispose`
   .page(AI_INTEGRATION_PAGE);
 
 // 5.5.1
@@ -192,35 +184,12 @@ test('Disposing the grid mid-request should not throw and ignore the late resolu
 
   await disposeGrid();
 
-  // Allow the mocked resolution to fire after dispose; it must not touch the destroyed grid.
   await t.wait(2000);
 
   await t.expect(Selector('#container').find('.dx-datagrid').exists).notOk();
-}).before(async () => createWidget('dxDataGrid', () => ({
-  dataSource: [
-    { id: 1, name: 'Alice', value: 30 },
-    { id: 2, name: 'Bob', value: 20 },
-    { id: 3, name: 'Charlie', value: 10 },
-  ],
-  keyExpr: 'id',
-  columns: ['id', 'name', 'value'],
-  showBorders: true,
-  aiAssistant: {
-    enabled: true,
-    aiIntegration: new (window as any).DevExpress.aiIntegration.AIIntegration({
-      sendRequest() {
-        return {
-          promise: new Promise((resolve) => {
-            setTimeout(() => resolve({
-              actions: [{ name: 'sorting', args: { dataField: 'name', sortOrder: 'asc' } }],
-            }), 1500);
-          }),
-          abort: (): void => {},
-        };
-      },
-    }),
-  },
-})));
+}).before(async () => createGridWithAI({
+  options: gridOptions, mode: 'delayed', actions: sortNameAsc, delay: 1500,
+}));
 
 // 5.5.2
 test('Disposing the grid mid-execution should not throw', async (t) => {
@@ -236,7 +205,6 @@ test('Disposing the grid mid-execution should not throw', async (t) => {
     .typeText(aiChat.getInput(), 'Select all rows')
     .pressKey('enter');
 
-  // The selectAll command is awaiting a server key-load that never resolves — mid-execution.
   await t.expect(aiChat.isInputDisabled()).ok();
 
   await disposeGrid();
@@ -306,30 +274,7 @@ test('Re-creating the grid after a dispose-during-flight yields a usable instanc
 
   await disposeGrid();
 
-  // Re-create a fresh instance in the same container with a normal (resolving) integration.
-  await createWidget('dxDataGrid', () => ({
-    dataSource: [
-      { id: 1, name: 'Alice', value: 30 },
-      { id: 2, name: 'Bob', value: 20 },
-      { id: 3, name: 'Charlie', value: 10 },
-    ],
-    keyExpr: 'id',
-    columns: ['id', 'name', 'value'],
-    showBorders: true,
-    aiAssistant: {
-      enabled: true,
-      aiIntegration: new (window as any).DevExpress.aiIntegration.AIIntegration({
-        sendRequest() {
-          return {
-            promise: Promise.resolve({
-              actions: [{ name: 'sorting', args: { dataField: 'name', sortOrder: 'asc' } }],
-            }),
-            abort: (): void => {},
-          };
-        },
-      }),
-    },
-  }));
+  await createGridWithAI({ options: gridOptions, mode: 'resolved', actions: sortNameAsc });
 
   dataGrid = new DataGrid(GRID_SELECTOR);
 
@@ -344,25 +289,6 @@ test('Re-creating the grid after a dispose-during-flight yields a usable instanc
     .pressKey('enter');
 
   await t.expect(aiChat.getSuccessMessages().count).eql(1);
-  await t.expect(dataGrid.apiColumnOption('name', 'sortOrder')).eql('asc');
-}).before(async () => createWidget('dxDataGrid', () => ({
-  dataSource: [
-    { id: 1, name: 'Alice', value: 30 },
-    { id: 2, name: 'Bob', value: 20 },
-    { id: 3, name: 'Charlie', value: 10 },
-  ],
-  keyExpr: 'id',
-  columns: ['id', 'name', 'value'],
-  showBorders: true,
-  aiAssistant: {
-    enabled: true,
-    aiIntegration: new (window as any).DevExpress.aiIntegration.AIIntegration({
-      sendRequest() {
-        return {
-          promise: new Promise(() => {}),
-          abort: (): void => {},
-        };
-      },
-    }),
-  },
-})));
+  await t.expect(aiChat.getSuccessActionItems(0).count).eql(1);
+  await t.expect(await dataGrid.apiColumnOption('name', 'sortOrder')).eql('asc');
+}).before(async () => createGridWithAI({ options: gridOptions, mode: 'never' }));

--- a/e2e/testcafe-devextreme/tests/dataGrid/common/aiAssistant/interruption.functional.ts
+++ b/e2e/testcafe-devextreme/tests/dataGrid/common/aiAssistant/interruption.functional.ts
@@ -100,7 +100,7 @@ test('Closing the popup mid-request should abort and leave the grid unchanged', 
   await closeAndConfirmAbort(t, aiChat);
 
   await t.expect(wasAbortCalled()).ok();
-  await t.expect(await dataGrid.apiColumnOption('name', 'sortOrder')).notOk();
+  await t.expect(dataGrid.apiColumnOption('name', 'sortOrder')).notOk();
 }).before(async () => createGridWithAI({ options: gridOptions, mode: 'never' }));
 
 // 5.2.2
@@ -149,7 +149,7 @@ test('Late LLM resolution after abort should be ignored', async (t) => {
 
   await t.wait(2000);
 
-  await t.expect(await dataGrid.apiColumnOption('name', 'sortOrder')).notOk();
+  await t.expect(dataGrid.apiColumnOption('name', 'sortOrder')).notOk();
   await t.expect(aiChat.getSuccessMessages().count).eql(0);
 }).before(async () => createGridWithAI({
   options: gridOptions, mode: 'delayed', actions: sortNameAsc, delay: 1500,
@@ -194,8 +194,8 @@ test('Closing the popup mid-execution aborts the remaining commands and keeps th
   await t.expect(aiChat.getAbortedActionItems(0).count).eql(1);
 
   // the grid reflects only completed commands: #1 applied, #3 (sort by value) skipped.
-  await t.expect(await dataGrid.apiColumnOption('name', 'sortOrder')).eql('asc');
-  await t.expect(await dataGrid.apiColumnOption('value', 'sortOrder')).notOk();
+  await t.expect(dataGrid.apiColumnOption('name', 'sortOrder')).eql('asc');
+  await t.expect(dataGrid.apiColumnOption('value', 'sortOrder')).notOk();
 
   // no Regenerate button (commands were attempted; the grid was mutated).
   await t.expect(aiChat.getMessageRegenerateButton(0).count).eql(0);
@@ -471,5 +471,5 @@ test('Re-creating the grid after a dispose-during-flight yields a usable instanc
 
   await t.expect(aiChat.getSuccessMessages().count).eql(1);
   await t.expect(aiChat.getSuccessActionItems(0).count).eql(1);
-  await t.expect(await dataGrid.apiColumnOption('name', 'sortOrder')).eql('asc');
+  await t.expect(dataGrid.apiColumnOption('name', 'sortOrder')).eql('asc');
 }).before(async () => createGridWithAI({ options: gridOptions, mode: 'never' }));

--- a/e2e/testcafe-devextreme/tests/dataGrid/common/aiAssistant/interruption.functional.ts
+++ b/e2e/testcafe-devextreme/tests/dataGrid/common/aiAssistant/interruption.functional.ts
@@ -28,15 +28,18 @@ const disposeGrid = ClientFunction(() => { (window as any).widget.dispose(); });
 
 const wasAbortCalled = ClientFunction(() => (window as any).__aiAbortCalled === true);
 
+const wasAIRequestResolved = ClientFunction(() => (window as any).__aiRequestResolved === true);
+
+const resolveAIRequest = ClientFunction(() => { (window as any).__resolveAIRequest(); });
+
 const setupAIState = ClientFunction((config: any) => {
   (window as any).__aiConfig = config;
   (window as any).__aiAbortCalled = false;
+  (window as any).__aiRequestResolved = false;
 });
 
 const aiGridOptions = (): any => {
-  const {
-    options, mode, actions, delay,
-  } = (window as any).__aiConfig;
+  const { options, mode, actions } = (window as any).__aiConfig;
 
   const sendRequest = (): any => {
     const abort = (): void => { (window as any).__aiAbortCalled = true; };
@@ -47,7 +50,12 @@ const aiGridOptions = (): any => {
 
     if (mode === 'delayed') {
       return {
-        promise: new Promise((resolve) => { setTimeout(() => resolve({ actions }), delay); }),
+        promise: new Promise((resolve) => {
+          (window as any).__resolveAIRequest = (): void => {
+            (window as any).__aiRequestResolved = true;
+            resolve({ actions });
+          };
+        }),
         abort,
       };
     }
@@ -81,8 +89,7 @@ fixture`AI Assistant - Interruption`
 
 // === §5.2 Popup close mid-request (before any command executes) ===
 
-// 5.2.1
-test('Closing the popup mid-request should abort and leave the grid unchanged', async (t) => {
+test('Closing the popup mid-request aborts, leaves the grid unchanged, and shows the aborted response on re-open', async (t) => {
   const dataGrid = new DataGrid(GRID_SELECTOR);
 
   await t.expect(dataGrid.isReady()).ok();
@@ -101,25 +108,6 @@ test('Closing the popup mid-request should abort and leave the grid unchanged', 
 
   await t.expect(wasAbortCalled()).ok();
   await t.expect(dataGrid.apiColumnOption('name', 'sortOrder')).notOk();
-}).before(async () => createGridWithAI({ options: gridOptions, mode: 'never' }));
-
-// 5.2.2
-test('Re-opening after a mid-request close shows the aborted response and re-enables input', async (t) => {
-  const dataGrid = new DataGrid(GRID_SELECTOR);
-
-  await t.expect(dataGrid.isReady()).ok();
-
-  await t.click(dataGrid.getAIAssistantButton());
-
-  const aiChat = dataGrid.getAIAssistantChat();
-
-  await t
-    .typeText(aiChat.getInput(), 'Sort by name')
-    .pressKey('enter');
-
-  await t.expect(aiChat.getPendingMessages().count).eql(1);
-
-  await closeAndConfirmAbort(t, aiChat);
 
   await t.click(dataGrid.getAIAssistantButton());
 
@@ -147,17 +135,18 @@ test('Late LLM resolution after abort should be ignored', async (t) => {
 
   await closeAndConfirmAbort(t, aiChat);
 
-  await t.wait(2000);
+  await resolveAIRequest();
+  await t.expect(wasAIRequestResolved()).ok();
 
   await t.expect(dataGrid.apiColumnOption('name', 'sortOrder')).notOk();
   await t.expect(aiChat.getSuccessMessages().count).eql(0);
 }).before(async () => createGridWithAI({
-  options: gridOptions, mode: 'delayed', actions: sortNameAsc, delay: 1500,
+  options: gridOptions, mode: 'delayed', actions: sortNameAsc,
 }));
 
 // === §5.3 Popup close mid-execution / §5.4 Re-open after a mid-execution close ===
 
-const releaseSelectAll = ClientFunction(() => { (window as any).__resolveSelectAll(); });
+const resolveSelectAll = ClientFunction(() => { (window as any).__resolveSelectAll(); });
 const selectAllStarted = ClientFunction(() => (window as any).__selectAllStarted === true);
 
 // 5.3.1 / 5.3.4 / 5.3.5 / 5.4.1 / 5.4.2
@@ -174,15 +163,15 @@ test('Closing the popup mid-execution aborts the remaining commands and keeps th
     .typeText(aiChat.getInput(), 'Sort by name, select all, then sort by value')
     .pressKey('enter');
 
-  // Command #1 (sort by name) has applied; command #2 (selectAll) is now in flight and gated.
+  // Command #1 (sort by name) has applied; command #2 (selectAll) is now in flight and delayed.
   await t.expect(selectAllStarted()).ok();
   await t.expect(aiChat.isInputDisabled()).ok();
 
   // Close the popup mid-execution → confirm dialog → abort.
   await closeAndConfirmAbort(t, aiChat);
 
-  // Let the gated selectAll resolve; the loop then sees the abort flag and stops before #3.
-  await releaseSelectAll();
+  // Let the delayed selectAll resolve; the loop then sees the abort flag and stops before #3.
+  await resolveSelectAll();
 
   // Re-open to inspect the resulting response.
   await t.click(dataGrid.getAIAssistantButton());
@@ -193,14 +182,12 @@ test('Closing the popup mid-execution aborts the remaining commands and keeps th
   await t.expect(aiChat.getSuccessActionItems(0).count).eql(2);
   await t.expect(aiChat.getAbortedActionItems(0).count).eql(1);
 
-  // the grid reflects only completed commands: #1 applied, #3 (sort by value) skipped.
   await t.expect(dataGrid.apiColumnOption('name', 'sortOrder')).eql('asc');
   await t.expect(dataGrid.apiColumnOption('value', 'sortOrder')).notOk();
+  await t.expect((await dataGrid.apiGetSelectedRowKeys()).length).eql(50);
 
-  // no Regenerate button (commands were attempted; the grid was mutated).
   await t.expect(aiChat.getMessageRegenerateButton(0).count).eql(0);
 
-  // the in-flight lock has been released.
   await t.expect(aiChat.isInputDisabled()).notOk();
 }).before(async () => createWidget('dxDataGrid', () => {
   const w = window as any;
@@ -278,7 +265,7 @@ test('Customized response title is applied to the partial (aborted) result', asy
 
   await closeAndConfirmAbort(t, aiChat);
 
-  await releaseSelectAll();
+  await resolveSelectAll();
 
   await t.click(dataGrid.getAIAssistantButton());
 
@@ -365,11 +352,17 @@ test('Disposing the grid mid-request should not throw and ignore the late resolu
 
   await disposeGrid();
 
-  await t.wait(2000);
+  await resolveAIRequest();
+  await t.expect(wasAIRequestResolved()).ok();
 
   await t.expect(Selector('#container').find('.dx-datagrid').exists).notOk();
+  await t.expect(dataGrid.getAIAssistantChat().element.exists).notOk();
+
+  const { error } = await t.getBrowserConsoleMessages();
+
+  await t.expect(error).eql([]);
 }).before(async () => createGridWithAI({
-  options: gridOptions, mode: 'delayed', actions: sortNameAsc, delay: 1500,
+  options: gridOptions, mode: 'delayed', actions: sortNameAsc,
 }));
 
 // 5.5.2
@@ -393,6 +386,11 @@ test('Disposing the grid mid-execution should not throw', async (t) => {
   await t.wait(500);
 
   await t.expect(Selector('#container').find('.dx-datagrid').exists).notOk();
+  await t.expect(dataGrid.getAIAssistantChat().element.exists).notOk();
+
+  const { error } = await t.getBrowserConsoleMessages();
+
+  await t.expect(error).eql([]);
 }).before(async () => createWidget('dxDataGrid', () => {
   const data = Array.from({ length: 50 }, (_, i) => ({
     id: i + 1,

--- a/packages/testcafe-models/dataGrid/aiAssistantChat.ts
+++ b/packages/testcafe-models/dataGrid/aiAssistantChat.ts
@@ -23,6 +23,7 @@ const CLASS = {
   actionListItem: 'dx-ai-chat__action-list-item',
   actionListItemSuccess: 'dx-ai-chat__action-list-item--success',
   actionListItemError: 'dx-ai-chat__action-list-item--error',
+  actionListItemAborted: 'dx-ai-chat__action-list-item--aborted',
   actionListItemIcon: 'dx-ai-chat__action-list-item-icon',
   actionListItemText: 'dx-ai-chat__action-list-item-text',
   closeButton: 'dx-closebutton',
@@ -129,6 +130,10 @@ export class AIAssistantChat extends Popup {
 
   getErrorActionItems(messageIndex: number): Selector {
     return this.getAIMessage(messageIndex).find(`.${CLASS.actionListItemError}`);
+  }
+
+  getAbortedActionItems(messageIndex: number): Selector {
+    return this.getAIMessage(messageIndex).find(`.${CLASS.actionListItemAborted}`);
   }
 
   getActionItemText(messageIndex: number, actionIndex: number): Selector {

--- a/packages/testcafe-models/dataGrid/index.ts
+++ b/packages/testcafe-models/dataGrid/index.ts
@@ -786,6 +786,15 @@ export default class DataGrid extends GridCore {
     )();
   }
 
+  apiGetSelectedRowKeys(): Promise<any[]> {
+    const { getInstance } = this;
+
+    return ClientFunction(
+      () => (getInstance() as DataGridInstance).getSelectedRowKeys(),
+      { dependencies: { getInstance } },
+    )();
+  }
+
   moveRow(rowIndex: number, x: number, y: number, isStart = false): Promise<void> {
     const { getInstance } = this;
 


### PR DESCRIPTION
## What does the PR change?

Adds e2e TestCafe tests for the **DataGrid AI Assistant** — interruption and cancellation — closing the popup mid-request (abort, ignored late resolution) and disposing the grid mid-request/mid-execution (plan §5.2, §5.5).

Part of splitting the AI Assistant e2e suite into per-area pull requests.

