### PR TITLE
WG Demos - Update editorType/widget import statements for scheduler-related widget demos

### DIFF
--- a/apps/demos/Demos/Scheduler/Templates/Angular/app/app.component.ts
+++ b/apps/demos/Demos/Scheduler/Templates/Angular/app/app.component.ts
@@ -12,6 +12,7 @@ import { formatDate } from 'devextreme-angular/common/core/localization';
 import { query } from 'devextreme-angular/common/data';
 import { DxSchedulerModule, DxSchedulerComponent } from 'devextreme-angular/ui/scheduler';
 import { DxSelectBoxTypes } from 'devextreme-angular/ui/select-box';
+import 'devextreme/ui/select_box';
 import { DxFormTypes } from 'devextreme-angular/ui/form';
 import { DxPopupTypes } from 'devextreme-angular/ui/popup';
 

--- a/apps/demos/Demos/Scheduler/Templates/React/App.tsx
+++ b/apps/demos/Demos/Scheduler/Templates/React/App.tsx
@@ -9,6 +9,7 @@ import Scheduler, {
 import { query } from 'devextreme-react/common/data';
 import type { SchedulerTypes } from 'devextreme-react/scheduler';
 import type { SelectBoxTypes } from 'devextreme-react/select-box';
+import 'devextreme/ui/select_box';
 import type { FormTypes } from 'devextreme-react/form';
 import type { PopupTypes } from 'devextreme-react/popup';
 import type { ToolbarItem } from 'devextreme/ui/popup';

--- a/apps/demos/Demos/Scheduler/Templates/ReactJs/App.js
+++ b/apps/demos/Demos/Scheduler/Templates/ReactJs/App.js
@@ -7,6 +7,7 @@ import Scheduler, {
   Label,
 } from 'devextreme-react/scheduler';
 import { query } from 'devextreme-react/common/data';
+import 'devextreme/ui/select_box';
 import Appointment from './Appointment.js';
 import AppointmentTooltip from './AppointmentTooltip.js';
 import MovieInfoContainer from './MovieInfoContainer.js';

--- a/apps/demos/Demos/Scheduler/Templates/Vue/App.vue
+++ b/apps/demos/Demos/Scheduler/Templates/Vue/App.vue
@@ -103,6 +103,7 @@ import DxScheduler, {
 } from 'devextreme-vue/scheduler';
 import type { DxFormTypes } from 'devextreme-vue/form';
 import type { DxSelectBoxTypes } from 'devextreme-vue/select-box';
+import 'devextreme/ui/select_box';
 import type { DxPopupTypes } from 'devextreme-vue/popup';
 import { query } from 'devextreme-vue/common/data';
 import type { MovieResource } from './data.ts';

--- a/apps/demos/Demos/Scheduler/Toolbar/Angular/app/app.component.ts
+++ b/apps/demos/Demos/Scheduler/Toolbar/Angular/app/app.component.ts
@@ -1,6 +1,7 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { Component, ViewChild, enableProdMode, provideZoneChangeDetection } from '@angular/core';
-import { DxButtonModule, type DxButtonTypes } from 'devextreme-angular/ui/button';
+import { type DxButtonTypes } from 'devextreme-angular/ui/button';
+import 'devextreme/ui/button';
 import { DxSchedulerModule, DxSchedulerComponent } from 'devextreme-angular/ui/scheduler';
 import { DxSelectBoxModule, type DxSelectBoxTypes } from 'devextreme-angular/ui/select-box';
 import { Service } from './app.service';
@@ -22,7 +23,6 @@ if (window && window.config?.packageConfigPaths) {
   templateUrl: `.${modulePrefix}/app.component.html`,
   providers: [Service],
   imports: [
-    DxButtonModule,
     DxSchedulerModule,
     DxSelectBoxModule,
   ],

--- a/apps/demos/Demos/Scheduler/Toolbar/React/App.tsx
+++ b/apps/demos/Demos/Scheduler/Toolbar/React/App.tsx
@@ -5,6 +5,7 @@ import { SelectBox } from 'devextreme-react/select-box';
 import type { DataSource } from 'devextreme-react/common/data';
 import type { SchedulerRef, SchedulerTypes } from 'devextreme-react/scheduler';
 import type { SelectBoxTypes } from 'devextreme-react/select-box';
+import 'devextreme/ui/button';
 
 import { assignees, data, currentDate } from './data.ts';
 

--- a/apps/demos/Demos/Scheduler/Toolbar/ReactJs/App.js
+++ b/apps/demos/Demos/Scheduler/Toolbar/ReactJs/App.js
@@ -5,6 +5,7 @@ import {
   Scheduler, Resource, Toolbar, Item,
 } from 'devextreme-react/scheduler';
 import { SelectBox } from 'devextreme-react/select-box';
+import 'devextreme/ui/button';
 import { assignees, data, currentDate } from './data.js';
 
 const views = ['day', 'week', 'workWeek', 'month'];

--- a/apps/demos/Demos/Scheduler/Toolbar/Vue/App.vue
+++ b/apps/demos/Demos/Scheduler/Toolbar/Vue/App.vue
@@ -61,6 +61,7 @@ import {
 import type { DxSchedulerTypes } from 'devextreme-vue/scheduler';
 import { DxSelectBox, type DxSelectBoxTypes } from 'devextreme-vue/select-box';
 import type { DataSource } from 'devextreme-vue/common/data';
+import 'devextreme/ui/button';
 import { assignees, currentDate, data } from './data.ts';
 
 const MS_IN_HOUR = 60 * 1000;


### PR DESCRIPTION
**What does the PR change?**

1. Updates the editorType and widget import statements in scheduler-related widget demos to use the correct module references.

**How did you achieve this?**
1. Reviewed the scheduler-related widget demos that use editorType and widget imports.
2. Updated the import statements to align with the current module structure and import conventions.
3. Verified that the affected demos compile and load successfully after the changes.

**How can we verify these changes?**
1. Build and run the WG Demos project.
2. Open the scheduler-related widget demos.
3. Confirm that the demos render correctly without import or module resolution errors.
5. Verify that all scheduler-related widgets function as expected