### PR TITLE
Scheduler: current_time_shader refactor — pass config object instead of whole workspace

### DIFF
--- a/packages/devextreme/js/__internal/scheduler/shaders/current_time_shader.ts
+++ b/packages/devextreme/js/__internal/scheduler/shaders/current_time_shader.ts
@@ -1,18 +1,21 @@
 import type { dxElementWrapper } from '@js/core/renderer';
 import $ from '@js/core/renderer';
 
-import type SchedulerWorkSpace from '../workspaces/m_work_space';
+export interface CurrentTimeShaderConfig {
+  $container: dxElementWrapper;
+}
 
 const DATE_TIME_SHADER_CLASS = 'dx-scheduler-date-time-shader';
 
 class CurrentTimeShader {
-  protected $container = this.workSpace.getScrollable().$content();
+  protected readonly $container: dxElementWrapper;
 
   protected shader!: dxElementWrapper[];
 
   protected $shader!: dxElementWrapper;
 
-  constructor(protected workSpace: SchedulerWorkSpace) {
+  constructor(config: CurrentTimeShaderConfig) {
+    this.$container = config.$container;
   }
 
   render(isHorizontalGroupedWorkSpace: boolean, groupCount: number, cellCount: number): void {

--- a/packages/devextreme/js/__internal/scheduler/shaders/current_time_shader_horizontal.ts
+++ b/packages/devextreme/js/__internal/scheduler/shaders/current_time_shader_horizontal.ts
@@ -2,9 +2,14 @@ import type { dxElementWrapper } from '@js/core/renderer';
 import { getBoundingRect } from '@js/core/utils/position';
 import { setWidth } from '@js/core/utils/size';
 
+import type SchedulerWorkSpace from '../workspaces/m_work_space';
 import CurrentTimeShader from './current_time_shader';
 
 class HorizontalCurrentTimeShader extends CurrentTimeShader {
+  constructor(protected readonly workSpace: SchedulerWorkSpace) {
+    super({ $container: workSpace.getScrollable().$content() });
+  }
+
   renderShader(isHorizontalGroupedWorkSpace: boolean, groupCount: number, cellCount: number): void {
     const effectiveGroupCount = isHorizontalGroupedWorkSpace ? groupCount : 1;
 

--- a/packages/devextreme/js/__internal/scheduler/shaders/current_time_shader_vertical.ts
+++ b/packages/devextreme/js/__internal/scheduler/shaders/current_time_shader_vertical.ts
@@ -1,6 +1,7 @@
 import $, { type dxElementWrapper } from '@js/core/renderer';
 import { setHeight, setWidth } from '@js/core/utils/size';
 
+import type SchedulerWorkSpace from '../workspaces/m_work_space';
 import CurrentTimeShader from './current_time_shader';
 
 const DATE_TIME_SHADER_ALL_DAY_CLASS = 'dx-scheduler-date-time-shader-all-day';
@@ -16,6 +17,10 @@ class VerticalCurrentTimeShader extends CurrentTimeShader {
   private $bottomShader!: dxElementWrapper;
 
   private $allDayIndicator!: dxElementWrapper;
+
+  constructor(protected readonly workSpace: SchedulerWorkSpace) {
+    super({ $container: workSpace.getScrollable().$content() });
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   renderShader(isHorizontalGroupedWorkSpace: boolean, groupCount: number, cellCount: number): void {


### PR DESCRIPTION
## What:
Base `CurrentTimeShader` no longer depends on the entire workspace. It receives only the `$container` element it actually uses

## How:
Subclasses now own the `workSpace` reference and pass `workSpace.getScrollable().$content()` to `super()`