### PR TITLE
Scheduler: workspace refactor — pass config object instead of workspace for groupedStrategy

### DIFF
--- a/packages/devextreme/js/__internal/scheduler/__tests__/grouped_strategy.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/__tests__/grouped_strategy.test.ts
@@ -1,0 +1,68 @@
+import {
+  describe, expect, it,
+} from '@jest/globals';
+
+import type { WorkspaceGroupedStrategyConfig } from '../workspaces/types';
+import HorizontalGroupedStrategy from '../workspaces/work_space_grouped_strategy_horizontal';
+import VerticalGroupedStrategy from '../workspaces/work_space_grouped_strategy_vertical';
+
+const createConfig = (
+  overrides: Partial<WorkspaceGroupedStrategyConfig> = {},
+): WorkspaceGroupedStrategyConfig => ({
+  isGroupedByDate: () => false,
+  getCellCount: () => 7,
+  getGroupCount: () => 3,
+  getRowCount: () => 48,
+  getCellWidth: () => 75,
+  getCellHeight: () => 50,
+  getAllDayHeight: () => 30,
+  getTimePanelWidth: () => 100,
+  getGroupTableWidth: () => 60,
+  getWorkSpaceWidth: () => 800,
+  getWorkSpaceLeftOffset: () => 160,
+  getIndicatorOffset: () => 10,
+  getIndicationHeight: () => 200,
+  getIndicationWidth: () => 300,
+  getCellIndexByCoordinates: () => 5,
+  supportAllDayRow: () => true,
+  getScrollableScrollTop: () => 0,
+  getScrollableContentElement: () => document.createElement('div'),
+  getElement: () => document.createElement('div'),
+  getHeaderPanelContainerElement: () => document.createElement('div'),
+  isRtlEnabled: () => false,
+  isShowAllDayPanel: () => true,
+  isCrossScrollingEnabled: () => false,
+  getStartDayHour: () => 0,
+  getEndDayHour: () => 24,
+  getHoursInterval: () => 0.5,
+  getHeaderHeight: () => 40,
+  ...overrides,
+});
+
+describe('HorizontalGroupedStrategy with config object', () => {
+  it('should work with config interface instead of workspace', () => {
+    const strategy = new HorizontalGroupedStrategy(
+      createConfig({ getCellCount: () => 5, getGroupCount: () => 4 }),
+    );
+
+    const result = strategy.prepareCellIndexes({ rowIndex: 2, columnIndex: 3 }, 2);
+
+    expect(result.columnIndex).toBe(3 + 2 * 5);
+    expect(result.rowIndex).toBe(2);
+  });
+});
+
+describe('VerticalGroupedStrategy with config object', () => {
+  it('should work with config interface instead of workspace', () => {
+    const strategy = new VerticalGroupedStrategy(createConfig({
+      getRowCount: () => 10,
+      supportAllDayRow: () => true,
+      isShowAllDayPanel: () => true,
+    }));
+
+    const result = strategy.prepareCellIndexes({ rowIndex: 3, columnIndex: 2 }, 2, false);
+
+    expect(result.rowIndex).toBe(3 + 2 * 10 + 2 + 1);
+    expect(result.columnIndex).toBe(2);
+  });
+});

--- a/packages/devextreme/js/__internal/scheduler/workspaces/m_work_space.ts
+++ b/packages/devextreme/js/__internal/scheduler/workspaces/m_work_space.ts
@@ -98,6 +98,7 @@ import {
   getMaxAllowedPosition,
   PositionHelper,
 } from './helpers/position_helper';
+import type { WorkspaceGroupedStrategyConfig } from './types';
 import type { ViewDataProviderOptions } from './view_model/m_types';
 import ViewDataProvider from './view_model/m_view_data_provider';
 import { VirtualScrollingDispatcher, VirtualScrollingRenderer } from './virtual_scrolling';
@@ -922,6 +923,18 @@ class SchedulerWorkSpace extends Widget<WorkspaceOptionsInternal> {
       startDayHour: this.option('startDayHour'),
       endDayHour: this.option('endDayHour'),
     });
+  }
+
+  protected getIndicatorOffset(): number {
+    return 0;
+  }
+
+  protected getIndicationHeight(): number {
+    return 0;
+  }
+
+  protected getIndicationWidth(): number {
+    return 0;
   }
 
   private isVirtualModeOn() {
@@ -2625,7 +2638,37 @@ class SchedulerWorkSpace extends Widget<WorkspaceOptionsInternal> {
       ? VerticalGroupedStrategy
       : HorizontalGroupedStrategy;
 
-    this.groupedStrategy = new Strategy(this);
+    const config: WorkspaceGroupedStrategyConfig = {
+      isGroupedByDate: this.isGroupedByDate.bind(this),
+      getCellCount: this.getCellCount.bind(this),
+      getGroupCount: this.getGroupCount.bind(this),
+      getRowCount: this.getRowCount.bind(this),
+      getCellWidth: this.getCellWidth.bind(this),
+      getCellHeight: this.getCellHeight.bind(this),
+      getAllDayHeight: this.getAllDayHeight.bind(this),
+      getTimePanelWidth: this.getTimePanelWidth.bind(this),
+      getGroupTableWidth: this.getGroupTableWidth.bind(this),
+      getWorkSpaceWidth: this.getWorkSpaceWidth.bind(this),
+      getWorkSpaceLeftOffset: this.getWorkSpaceLeftOffset.bind(this),
+      getIndicatorOffset: () => this.getIndicatorOffset(),
+      getIndicationHeight: () => this.getIndicationHeight(),
+      getIndicationWidth: () => this.getIndicationWidth(),
+      getCellIndexByCoordinates: this.getCellIndexByCoordinates.bind(this),
+      supportAllDayRow: this.supportAllDayRow.bind(this),
+      getScrollableScrollTop: () => this.getScrollable().scrollTop(),
+      getScrollableContentElement: () => this.getScrollable().$content().get(0) as HTMLElement,
+      getElement: () => (this.$element() as any).get(0) as HTMLElement,
+      getHeaderPanelContainerElement: () => this.$headerPanelContainer.get(0) as HTMLElement,
+      isRtlEnabled: () => this.option('rtlEnabled'),
+      isShowAllDayPanel: () => this.option('showAllDayPanel'),
+      isCrossScrollingEnabled: () => this.option('crossScrollingEnabled'),
+      getStartDayHour: () => this.option('startDayHour'),
+      getEndDayHour: () => this.option('endDayHour'),
+      getHoursInterval: () => this.option('hoursInterval'),
+      getHeaderHeight: () => this.option('getHeaderHeight')(),
+    };
+
+    this.groupedStrategy = new Strategy(config);
   }
 
   protected getDefaultGroupStrategy() {

--- a/packages/devextreme/js/__internal/scheduler/workspaces/types.ts
+++ b/packages/devextreme/js/__internal/scheduler/workspaces/types.ts
@@ -1,0 +1,32 @@
+export interface WorkspaceGroupedStrategyConfig {
+  isGroupedByDate: () => boolean;
+  getCellCount: () => number;
+  getGroupCount: () => number;
+  getRowCount: () => number;
+  getCellWidth: () => number;
+  getCellHeight: () => number;
+  getAllDayHeight: () => number;
+  getTimePanelWidth: () => number;
+  getGroupTableWidth: () => number;
+  getWorkSpaceWidth: () => number;
+  getWorkSpaceLeftOffset: () => number;
+  getIndicatorOffset: () => number;
+  getIndicationHeight: () => number;
+  getIndicationWidth: () => number;
+  getCellIndexByCoordinates: (
+    coordinates: { top: number; left: number },
+    allDay?: boolean,
+  ) => number;
+  supportAllDayRow: () => boolean;
+  getScrollableScrollTop: () => number;
+  getScrollableContentElement: () => HTMLElement;
+  getElement: () => HTMLElement;
+  getHeaderPanelContainerElement: () => HTMLElement;
+  isRtlEnabled: () => boolean;
+  isShowAllDayPanel: () => boolean;
+  isCrossScrollingEnabled: () => boolean;
+  getStartDayHour: () => number;
+  getEndDayHour: () => number;
+  getHoursInterval: () => number;
+  getHeaderHeight: () => number;
+}

--- a/packages/devextreme/js/__internal/scheduler/workspaces/work_space_grouped_strategy_horizontal.ts
+++ b/packages/devextreme/js/__internal/scheduler/workspaces/work_space_grouped_strategy_horizontal.ts
@@ -6,13 +6,13 @@ import type {
   GroupBoundsOffset,
 } from '@ts/scheduler/types';
 import { WORK_SPACE_BORDER_PX } from '@ts/scheduler/workspaces/const';
-import type SchedulerWorkSpace from '@ts/scheduler/workspaces/m_work_space';
 
 import { FIRST_GROUP_CELL_CLASS, LAST_GROUP_CELL_CLASS } from '../classes';
 import type { ResourceLoader } from '../utils/loader/resource_loader';
+import type { WorkspaceGroupedStrategyConfig } from './types';
 
 class HorizontalGroupedStrategy {
-  constructor(private readonly workspace: SchedulerWorkSpace) {}
+  constructor(private readonly config: WorkspaceGroupedStrategyConfig) {}
 
   prepareCellIndexes(
     cellCoordinates: CellPositionData,
@@ -20,37 +20,32 @@ class HorizontalGroupedStrategy {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     inAllDay?: boolean,
   ): CellPositionData {
-    const groupByDay = this.workspace.isGroupedByDate();
+    const groupByDay = this.config.isGroupedByDate();
 
     if (!groupByDay) {
       return {
         rowIndex: cellCoordinates.rowIndex,
-        // @ts-expect-error
-        columnIndex: cellCoordinates.columnIndex + groupIndex * this.workspace.getCellCount(),
+        columnIndex: cellCoordinates.columnIndex + groupIndex * this.config.getCellCount(),
       };
     }
     return {
       rowIndex: cellCoordinates.rowIndex,
-      // @ts-expect-error
-      columnIndex: cellCoordinates.columnIndex * this.workspace.getGroupCount() + groupIndex,
+      columnIndex: cellCoordinates.columnIndex * this.config.getGroupCount() + groupIndex,
     };
   }
 
   getGroupIndex(rowIndex: number, columnIndex: number): number {
-    const groupByDay = this.workspace.isGroupedByDate();
-    // @ts-expect-error
-    const groupCount = this.workspace.getGroupCount();
+    const groupByDay = this.config.isGroupedByDate();
+    const groupCount = this.config.getGroupCount();
 
     if (groupByDay) {
       return columnIndex % groupCount;
     }
-    // @ts-expect-error
-    return Math.floor(columnIndex / this.workspace.getCellCount());
+    return Math.floor(columnIndex / this.config.getCellCount());
   }
 
   calculateHeaderCellRepeatCount(): number {
-    // @ts-expect-error
-    return this.workspace.getGroupCount() || 1;
+    return this.config.getGroupCount() || 1;
   }
 
   insertAllDayRowsIntoDateTable(): boolean {
@@ -60,13 +55,11 @@ class HorizontalGroupedStrategy {
   getTotalCellCount(groupCount: number): number {
     const effectiveGroupCount = groupCount || 1;
 
-    // @ts-expect-error
-    return this.workspace.getCellCount() * effectiveGroupCount;
+    return this.config.getCellCount() * effectiveGroupCount;
   }
 
   getTotalRowCount(): number {
-    // @ts-expect-error
-    return this.workspace.getRowCount();
+    return this.config.getRowCount();
   }
 
   calculateTimeCellRepeatCount(): number {
@@ -74,14 +67,16 @@ class HorizontalGroupedStrategy {
   }
 
   getWorkSpaceMinWidth(): number {
-    const workSpaceElementWidth = getBoundingRect(this.workspace.$element().get(0)).width;
+    const workSpaceElementWidth = getBoundingRect(
+      this.config.getElement(),
+    ).width;
     return workSpaceElementWidth
-      - this.workspace.getTimePanelWidth()
+      - this.config.getTimePanelWidth()
       - 2 * WORK_SPACE_BORDER_PX;
   }
 
   getAllDayOffset(): number {
-    return this.workspace.getAllDayHeight();
+    return this.config.getAllDayHeight();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -90,7 +85,7 @@ class HorizontalGroupedStrategy {
   }
 
   getLeftOffset(): number {
-    return this.workspace.getTimePanelWidth();
+    return this.config.getTimePanelWidth();
   }
 
   private createGroupBoundOffset(
@@ -130,11 +125,11 @@ class HorizontalGroupedStrategy {
     coordinates: { top: number; left: number; groupIndex?: number },
     groupedDataMap: { dateTableGroupedMap: CellInfo[][][] },
   ): GroupBoundsOffset {
-    if (this.workspace.isGroupedByDate()) {
+    if (this.config.isGroupedByDate()) {
       return this.getGroupedByDateBoundOffset($cells, cellWidth);
     }
 
-    const cellIndex = this.workspace.getCellIndexByCoordinates(coordinates);
+    const cellIndex = this.config.getCellIndexByCoordinates(coordinates);
     const groupIndex = coordinates.groupIndex ?? Math.floor(cellIndex / cellCount);
 
     const currentCellGroup = groupedDataMap.dateTableGroupedMap[groupIndex];
@@ -168,7 +163,7 @@ class HorizontalGroupedStrategy {
   }
 
   private getIndicatorOffset(groupIndex: number): number {
-    const groupByDay = this.workspace.isGroupedByDate();
+    const groupByDay = this.config.isGroupedByDate();
 
     return groupByDay
       ? this.calculateGroupByDateOffset(groupIndex)
@@ -176,29 +171,25 @@ class HorizontalGroupedStrategy {
   }
 
   private calculateOffset(groupIndex: number): number {
-    // @ts-expect-error
-    const indicatorStartPosition = this.workspace.getIndicatorOffset(groupIndex) as number;
-    // @ts-expect-error
-    const offset = this.workspace.getCellCount() * this.workspace.getCellWidth() * groupIndex;
+    const indicatorStartPosition = this.config.getIndicatorOffset();
+    const offset = this.config.getCellCount() * this.config.getCellWidth() * groupIndex;
 
     return indicatorStartPosition + offset;
   }
 
   private calculateGroupByDateOffset(groupIndex: number): number {
-    // @ts-expect-error
-    return this.workspace.getIndicatorOffset(0) * this.workspace.getGroupCount()
-      + this.workspace.getCellWidth() * groupIndex;
+    return this.config.getIndicatorOffset() * this.config.getGroupCount()
+      + this.config.getCellWidth() * groupIndex;
   }
 
   getShaderOffset(i: number, width: number): number {
-    // @ts-expect-error
-    const offset = this.workspace.getCellCount() * this.workspace.getCellWidth() * i;
+    const offset = this.config.getCellCount() * this.config.getCellWidth() * i;
 
-    if (this.workspace.option('rtlEnabled')) {
+    if (this.config.isRtlEnabled()) {
       const containerWidth = getBoundingRect(
-        this.workspace.getScrollable().$content().get(0),
+        this.config.getScrollableContentElement(),
       ).width;
-      return containerWidth - offset - this.workspace.getTimePanelWidth() - width;
+      return containerWidth - offset - this.config.getTimePanelWidth() - width;
     }
 
     return offset;
@@ -209,21 +200,21 @@ class HorizontalGroupedStrategy {
   }
 
   getShaderHeight(): number {
-    // @ts-expect-error
-    return this.workspace.getIndicationHeight() as number;
+    return this.config.getIndicationHeight();
   }
 
   getShaderMaxHeight(): number {
-    return (getBoundingRect(this.workspace.getScrollable().$content().get(0)) as DOMRect).height;
+    return (getBoundingRect(
+      this.config.getScrollableContentElement(),
+    ) as DOMRect).height;
   }
 
   getShaderWidth(): number {
-    // @ts-expect-error
-    return this.workspace.getIndicationWidth() as number;
+    return this.config.getIndicationWidth();
   }
 
   getScrollableScrollTop(allDay: boolean): number {
-    return !allDay ? this.workspace.getScrollable().scrollTop() : 0;
+    return !allDay ? this.config.getScrollableScrollTop() : 0;
   }
 
   // ---------------
@@ -251,15 +242,13 @@ class HorizontalGroupedStrategy {
       return `${cellClass} ${LAST_GROUP_CELL_CLASS}`;
     }
 
-    const groupByDate = this.workspace.isGroupedByDate();
+    const groupByDate = this.config.isGroupedByDate();
 
     if (groupByDate) {
-      // @ts-expect-error
-      if (index % this.workspace.getGroupCount() === 0) {
+      if (index % this.config.getGroupCount() === 0) {
         return `${cellClass} ${LAST_GROUP_CELL_CLASS}`;
       }
-      // @ts-expect-error
-    } else if (index % this.workspace.getCellCount() === 0) {
+    } else if (index % this.config.getCellCount() === 0) {
       return `${cellClass} ${LAST_GROUP_CELL_CLASS}`;
     }
 
@@ -275,15 +264,13 @@ class HorizontalGroupedStrategy {
       return `${cellClass} ${FIRST_GROUP_CELL_CLASS}`;
     }
 
-    const groupByDate = this.workspace.isGroupedByDate();
+    const groupByDate = this.config.isGroupedByDate();
 
     if (groupByDate) {
-      // @ts-expect-error
-      if ((index - 1) % this.workspace.getGroupCount() === 0) {
+      if ((index - 1) % this.config.getGroupCount() === 0) {
         return `${cellClass} ${FIRST_GROUP_CELL_CLASS}`;
       }
-      // @ts-expect-error
-    } else if ((index - 1) % this.workspace.getCellCount() === 0) {
+    } else if ((index - 1) % this.config.getCellCount() === 0) {
       return `${cellClass} ${FIRST_GROUP_CELL_CLASS}`;
     }
 

--- a/packages/devextreme/js/__internal/scheduler/workspaces/work_space_grouped_strategy_vertical.ts
+++ b/packages/devextreme/js/__internal/scheduler/workspaces/work_space_grouped_strategy_vertical.ts
@@ -8,21 +8,20 @@ import { WORK_SPACE_BORDER_PX } from '@ts/scheduler/workspaces/const';
 import { FIRST_GROUP_CELL_CLASS, LAST_GROUP_CELL_CLASS } from '../classes';
 import { Cache } from '../global_cache';
 import type { ResourceLoader } from '../utils/loader/resource_loader';
-import type SchedulerWorkSpace from './m_work_space';
+import type { WorkspaceGroupedStrategyConfig } from './types';
 
 class VerticalGroupedStrategy {
   cache = new Cache();
 
   private groupBoundsOffset!: GroupBoundsOffset;
 
-  constructor(private readonly workspace: SchedulerWorkSpace) {}
+  constructor(private readonly config: WorkspaceGroupedStrategyConfig) {}
 
   prepareCellIndexes(cellCoordinates: CellPositionData, groupIndex: number, inAllDayRow: boolean)
   : CellPositionData {
-    // @ts-expect-error
-    let rowIndex = cellCoordinates.rowIndex + groupIndex * this.workspace.getRowCount();
+    let rowIndex = cellCoordinates.rowIndex + groupIndex * this.config.getRowCount();
 
-    if (this.workspace.supportAllDayRow() && this.workspace.option('showAllDayPanel')) {
+    if (this.config.supportAllDayRow() && this.config.isShowAllDayPanel()) {
       rowIndex += groupIndex;
 
       if (!inAllDayRow) {
@@ -37,8 +36,7 @@ class VerticalGroupedStrategy {
   }
 
   getGroupIndex(rowIndex: number): number {
-    // @ts-expect-error
-    return Math.floor(rowIndex / this.workspace.getRowCount());
+    return Math.floor(rowIndex / this.config.getRowCount());
   }
 
   calculateHeaderCellRepeatCount(): number {
@@ -46,31 +44,29 @@ class VerticalGroupedStrategy {
   }
 
   insertAllDayRowsIntoDateTable(): boolean {
-    return this.workspace.option('showAllDayPanel');
+    return this.config.isShowAllDayPanel();
   }
 
   getTotalCellCount(): number {
-    // @ts-expect-error
-    return this.workspace.getCellCount();
+    return this.config.getCellCount();
   }
 
   getTotalRowCount(): number {
-    // @ts-expect-error
-    return this.workspace.getRowCount() * this.workspace.getGroupCount();
+    return this.config.getRowCount() * this.config.getGroupCount();
   }
 
   calculateTimeCellRepeatCount(): number {
-    // @ts-expect-error
-    return this.workspace.getGroupCount() || 1;
+    return this.config.getGroupCount() || 1;
   }
 
   getWorkSpaceMinWidth(): number {
-    // @ts-expect-error
-    let minWidth = this.workspace.getWorkSpaceWidth();
-    const workSpaceElementWidth = getBoundingRect(this.workspace.$element().get(0)).width;
+    let minWidth = this.config.getWorkSpaceWidth();
+    const workSpaceElementWidth = getBoundingRect(
+      this.config.getElement(),
+    ).width;
     const workspaceContainerWidth = workSpaceElementWidth
-      - this.workspace.getTimePanelWidth()
-      - this.workspace.getGroupTableWidth()
+      - this.config.getTimePanelWidth()
+      - this.config.getGroupTableWidth()
       - 2 * WORK_SPACE_BORDER_PX;
 
     if (minWidth < workspaceContainerWidth) {
@@ -89,26 +85,28 @@ class VerticalGroupedStrategy {
   }
 
   getLeftOffset(): number {
-    return this.workspace.getTimePanelWidth() + this.workspace.getGroupTableWidth();
+    return this.config.getTimePanelWidth() + this.config.getGroupTableWidth();
   }
 
   getGroupBoundsOffset(groupIndex: number, [$firstCell, $lastCell]: [DxElement, DxElement])
   : GroupBoundsOffset {
     return this.cache.memo(`groupBoundsOffset${groupIndex}`, () => {
-      const startDayHour = this.workspace.option('startDayHour');
-      const endDayHour = this.workspace.option('endDayHour');
-      const hoursInterval = this.workspace.option('hoursInterval');
+      const startDayHour = this.config.getStartDayHour();
+      const endDayHour = this.config.getEndDayHour();
+      const hoursInterval = this.config.getHoursInterval();
 
       const dayHeight = (calculateDayDuration(startDayHour, endDayHour) / hoursInterval)
-       * this.workspace.getCellHeight();
+       * this.config.getCellHeight();
       const scrollTop = this.getScrollableScrollTop();
-      // @ts-expect-error
-      const headerRowHeight = getBoundingRect(this.workspace.$headerPanelContainer.get(0)).height;
+      const headerRowHeight = getBoundingRect(
+        this.config.getHeaderPanelContainerElement(),
+      ).height;
 
-      let topOffset = groupIndex * dayHeight + headerRowHeight + this.workspace.option('getHeaderHeight')() - scrollTop;
+      let topOffset = groupIndex * dayHeight + headerRowHeight
+        + this.config.getHeaderHeight() - scrollTop;
 
-      if (this.workspace.option('showAllDayPanel') && this.workspace.supportAllDayRow()) {
-        topOffset += this.workspace.getCellHeight() * (groupIndex + 1);
+      if (this.config.isShowAllDayPanel() && this.config.supportAllDayRow()) {
+        topOffset += this.config.getCellHeight() * (groupIndex + 1);
       }
 
       const bottomOffset = topOffset + dayHeight;
@@ -127,15 +125,15 @@ class VerticalGroupedStrategy {
   }
 
   shiftIndicator($indicator: dxElementWrapper, height: number, rtlOffset: number, i: number): void {
-    // @ts-expect-error
-    const offset = this.workspace.getIndicatorOffset(0);
-    const tableOffset = this.workspace.option('crossScrollingEnabled') ? 0 : this.workspace.getGroupTableWidth();
+    const offset = this.config.getIndicatorOffset();
+    const tableOffset = this.config.isCrossScrollingEnabled()
+      ? 0
+      : this.config.getGroupTableWidth();
     const horizontalOffset = rtlOffset ? rtlOffset - offset : offset;
-    // @ts-expect-error
-    let verticalOffset = this.workspace.getRowCount() * this.workspace.getCellHeight() * i;
+    let verticalOffset = this.config.getRowCount() * this.config.getCellHeight() * i;
 
-    if (this.workspace.supportAllDayRow() && this.workspace.option('showAllDayPanel')) {
-      verticalOffset += this.workspace.getAllDayHeight() * (i + 1);
+    if (this.config.supportAllDayRow() && this.config.isShowAllDayPanel()) {
+      verticalOffset += this.config.getAllDayHeight() * (i + 1);
     }
 
     $indicator.css('left', horizontalOffset + tableOffset);
@@ -143,13 +141,13 @@ class VerticalGroupedStrategy {
   }
 
   getShaderOffset(i: number, width: number): number {
-    const offset = this.workspace.option('crossScrollingEnabled') ? 0 : this.workspace.getGroupTableWidth();
+    const offset = this.config.isCrossScrollingEnabled() ? 0 : this.config.getGroupTableWidth();
 
-    if (this.workspace.option('rtlEnabled')) {
+    if (this.config.isRtlEnabled()) {
       const containerWidth = getBoundingRect(
-        this.workspace.getScrollable().$content().get(0),
+        this.config.getScrollableContentElement(),
       ).width;
-      return containerWidth - offset - this.workspace.getWorkSpaceLeftOffset() - width;
+      return containerWidth - offset - this.config.getWorkSpaceLeftOffset() - width;
     }
 
     return offset;
@@ -161,34 +159,31 @@ class VerticalGroupedStrategy {
   }
 
   getShaderHeight(): number {
-    // @ts-expect-error
-    let height = this.workspace.getIndicationHeight() as number;
+    let height = this.config.getIndicationHeight();
 
-    if (this.workspace.supportAllDayRow() && this.workspace.option('showAllDayPanel')) {
-      height += this.workspace.getCellHeight();
+    if (this.config.supportAllDayRow() && this.config.isShowAllDayPanel()) {
+      height += this.config.getCellHeight();
     }
 
     return height;
   }
 
   getShaderMaxHeight(): number {
-    // @ts-expect-error
-    let height = this.workspace.getRowCount() * this.workspace.getCellHeight();
+    let height = this.config.getRowCount() * this.config.getCellHeight();
 
-    if (this.workspace.supportAllDayRow() && this.workspace.option('showAllDayPanel')) {
-      height += this.workspace.getCellHeight();
+    if (this.config.supportAllDayRow() && this.config.isShowAllDayPanel()) {
+      height += this.config.getCellHeight();
     }
 
     return height;
   }
 
   getShaderWidth(): number {
-    // @ts-expect-error
-    return this.workspace.getIndicationWidth() as number;
+    return this.config.getIndicationWidth();
   }
 
   getScrollableScrollTop(): number {
-    return this.workspace.getScrollable().scrollTop();
+    return this.config.getScrollableScrollTop();
   }
 
   // ------------
@@ -203,8 +198,7 @@ class VerticalGroupedStrategy {
   }
 
   private addLastGroupCellClass(cellClass: string, index: number): string {
-    // @ts-expect-error
-    if (index % this.workspace.getRowCount() === 0) {
+    if (index % this.config.getRowCount() === 0) {
       return `${cellClass} ${LAST_GROUP_CELL_CLASS}`;
     }
 
@@ -212,8 +206,7 @@ class VerticalGroupedStrategy {
   }
 
   private addFirstGroupCellClass(cellClass: string, index: number): string {
-    // @ts-expect-error
-    if ((index - 1) % this.workspace.getRowCount() === 0) {
+    if ((index - 1) % this.config.getRowCount() === 0) {
       return `${cellClass} ${FIRST_GROUP_CELL_CLASS}`;
     }
 


### PR DESCRIPTION
## What:
Grouped strategies now receive a typed config object instead of the entire workspace.

## How:
- New `WorkspaceGroupedStrategyConfig` interface with only needed callbacks
- `initGroupedStrategy()` builds the config from workspace methods
- All `@ts-expect-error` removed from both strategy files