### PR TITLE
fix: fix conflict in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -113,10 +113,7 @@
             ],
             "dependencyDashboardApproval": true,
             "matchPackageNames": [
-                "*",
-                "!cldr-{/,}**",
-                "!chrome{/,}**",
-                "!firefox{/,}**"
+                "*"
             ]
         },
         {


### PR DESCRIPTION
This resolves Renovate's validation error. The earlier rules in the array still control chrome/firefox automerge and CLDR grouping behavior independently.

