### PR TITLE
devextreme-aspnet-data: use from /apps/demos/, remove from /packages/devextreme/, arrange vendor files (with bootstrap)

### DIFF
--- a/packages/devextreme/package.json
+++ b/packages/devextreme/package.json
@@ -112,7 +112,6 @@
     "cssom": "0.5.0",
     "csstype": "3.2.3",
     "del": "2.2.2",
-    "devextreme-aspnet-data": "5.1.0",
     "devextreme-cldr-data": "1.0.3",
     "devextreme-exceljs-fork": "catalog:",
     "devextreme-screenshot-comparer": "2.0.17",

--- a/packages/devextreme/project.json
+++ b/packages/devextreme/project.json
@@ -1135,7 +1135,9 @@
           { "from": "./node_modules/devexpress-gantt/dist/dx-gantt.min.js", "to": "./artifacts/js/dx-gantt.min.js" },
           { "from": "./node_modules/devextreme-quill/dist/dx-quill.js", "to": "./artifacts/js/dx-quill.js" },
           { "from": "./node_modules/devextreme-quill/dist/dx-quill.min.js", "to": "./artifacts/js/dx-quill.min.js" },
-          { "from": "./node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js", "to": "./artifacts/js/dx.aspnet.data.js" }
+          { "from": "../devextreme-themebuilder/node_modules/bootstrap/dist/js/bootstrap.js", "to": "./artifacts/js/bootstrap.js" },
+          { "from": "../devextreme-themebuilder/node_modules/bootstrap/dist/js/bootstrap.min.js", "to": "./artifacts/js/bootstrap.min.js" },
+          { "from": "../../apps/demos/node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js", "to": "./artifacts/js/dx.aspnet.data.js" }
         ]
       },
       "inputs": [
@@ -1163,6 +1165,8 @@
         "{projectRoot}/artifacts/js/dx-gantt.min.js",
         "{projectRoot}/artifacts/js/dx-quill.js",
         "{projectRoot}/artifacts/js/dx-quill.min.js",
+        "{projectRoot}/artifacts/js/bootstrap.js",
+        "{projectRoot}/artifacts/js/bootstrap.min.js",
         "{projectRoot}/artifacts/js/dx.aspnet.data.js"
       ]
     },
@@ -1171,7 +1175,8 @@
       "options": {
         "files": [
           { "from": "./node_modules/devexpress-diagram/dist/dx-{diagram,diagram.min}.css", "to": "./artifacts/css" },
-          { "from": "./node_modules/devexpress-gantt/dist/dx-{gantt,gantt.min}.css", "to": "./artifacts/css" }
+          { "from": "./node_modules/devexpress-gantt/dist/dx-{gantt,gantt.min}.css", "to": "./artifacts/css" },
+          { "from": "../devextreme-themebuilder/node_modules/bootstrap/dist/css/{bootstrap,bootstrap.min}.css", "to": "./artifacts/css" }
         ]
       },
       "inputs": [
@@ -1182,7 +1187,9 @@
         "{projectRoot}/artifacts/css/dx-diagram.css",
         "{projectRoot}/artifacts/css/dx-diagram.min.css",
         "{projectRoot}/artifacts/css/dx-gantt.css",
-        "{projectRoot}/artifacts/css/dx-gantt.min.css"
+        "{projectRoot}/artifacts/css/dx-gantt.min.css",
+        "{projectRoot}/artifacts/css/bootstrap.css",
+        "{projectRoot}/artifacts/css/bootstrap.min.css"
       ]
     },
     "copy:vendor": {

--- a/packages/workflows/project.json
+++ b/packages/workflows/project.json
@@ -26,6 +26,14 @@
         ]
       }
     },
+    "copy:devextreme-aspnet-data": {
+      "executor": "devextreme-nx-infra-plugin:copy-files",
+      "options": {
+        "files": [
+          { "from": "../../apps/demos/node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js", "to": "../../artifacts/js/dx.aspnet.data.js" }
+        ]
+      }
+    },
     "copy:npm-tgz": {
       "executor": "devextreme-nx-infra-plugin:copy-files",
       "options": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1534,9 +1534,6 @@ importers:
       del:
         specifier: 2.2.2
         version: 2.2.2
-      devextreme-aspnet-data:
-        specifier: 5.1.0
-        version: 5.1.0(devextreme@packages+devextreme+artifacts+npm+devextreme)
       devextreme-cldr-data:
         specifier: 1.0.3
         version: 1.0.3

--- a/tools/scripts/build-all.ts
+++ b/tools/scripts/build-all.ts
@@ -1,6 +1,6 @@
 import sh from 'shelljs';
 import path from 'node:path';
-import { ARTIFACTS_DIR, INTERNAL_TOOLS_ARTIFACTS, ROOT_DIR, NPM_DIR, JS_ARTIFACTS, CSS_ARTIFACTS } from './common/paths';
+import { ARTIFACTS_DIR, INTERNAL_TOOLS_ARTIFACTS, ROOT_DIR, NPM_DIR } from './common/paths';
 import { version as devextremeNpmVersion } from '../../packages/devextreme/package.json';
 
 const DEVEXTREME_NPM_DIR = path.join(ROOT_DIR, 'packages/devextreme/artifacts/npm');
@@ -55,11 +55,6 @@ sh.exec('pnpm exec nx build devextreme-themebuilder --skipNxCache');
 sh.pushd(path.join(ROOT_DIR, 'packages/devextreme/artifacts'));
     sh.cp('-r', ['ts', 'js', 'css'], ARTIFACTS_DIR);
 sh.popd();
-
-// TODO: maybe we should add bootstrap to vendors
-const BOOTSTRAP_DIR = path.join(ROOT_DIR, 'packages', 'devextreme-themebuilder', 'node_modules', 'bootstrap', 'dist');
-sh.cp([path.join(BOOTSTRAP_DIR, 'js', 'bootstrap.js'), path.join(BOOTSTRAP_DIR, 'js', 'bootstrap.min.js')], JS_ARTIFACTS);
-sh.cp([path.join(BOOTSTRAP_DIR, 'css', 'bootstrap.css'), path.join(BOOTSTRAP_DIR, 'css', 'bootstrap.min.css')], CSS_ARTIFACTS);
 
 sh.exec('pnpm run all:pack-and-copy');
 


### PR DESCRIPTION
Patched at:
- #34158

TODO:

Comments suppressed due to low confidence (2)

**packages/devextreme/project.json:1146**
* This target now copies vendor files from other workspace projects' node_modules (apps/demos and devextreme-themebuilder), but the Nx inputs only include this package.json and the lockfile. Adding the referenced projects' package.json files helps Nx correctly invalidate the cache when those dependencies/peer ranges change.
```
      "inputs": [
        "{projectRoot}/package.json",
        "{workspaceRoot}/pnpm-lock.yaml"
      ],
```
**packages/devextreme/project.json:1185**
* Same as for copy:vendor:js: since this target reads bootstrap CSS from devextreme-themebuilder's node_modules, include that project's package.json (and apps/demos for aspnet-data parity) in the inputs so Nx cache invalidation reflects those upstream dependency changes.
```
      "inputs": [
        "{projectRoot}/package.json",
        "{workspaceRoot}/pnpm-lock.yaml"
      ],
```

