### PR TITLE
chore(deps): bump form-data to 4.0.6, tmp to 0.2.7 [security]

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8936,8 +8936,8 @@ packages:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
     engines: {node: '>=10.0.0'}
 
-  engine.io@6.6.8:
-    resolution: {integrity: sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==}
+  engine.io@6.6.9:
+    resolution: {integrity: sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==}
     engines: {node: '>=10.2.0'}
 
   enhanced-resolve@5.24.0:
@@ -14874,8 +14874,8 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
-  socket.io-adapter@2.5.7:
-    resolution: {integrity: sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==}
+  socket.io-adapter@2.5.8:
+    resolution: {integrity: sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==}
 
   socket.io-parser@4.2.6:
     resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
@@ -16807,18 +16807,6 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -27306,7 +27294,7 @@ snapshots:
 
   engine.io-parser@5.2.3: {}
 
-  engine.io@6.6.8:
+  engine.io@6.6.9:
     dependencies:
       '@types/cors': 2.8.19
       '@types/node': 20.12.8
@@ -27317,7 +27305,7 @@ snapshots:
       cors: 2.8.6
       debug: 4.4.3
       engine.io-parser: 5.2.3
-      ws: 8.20.1
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -32497,7 +32485,7 @@ snapshots:
 
   md5.js@1.3.5:
     dependencies:
-      hash-base: 3.1.2
+      hash-base: 3.0.5
       inherits: 2.0.4
       safe-buffer: 5.2.1
 
@@ -35640,10 +35628,10 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  socket.io-adapter@2.5.7:
+  socket.io-adapter@2.5.8:
     dependencies:
       debug: 4.4.3
-      ws: 8.20.1
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -35662,8 +35650,8 @@ snapshots:
       base64id: 2.0.0
       cors: 2.8.6
       debug: 4.4.3
-      engine.io: 6.6.8
-      socket.io-adapter: 2.5.7
+      engine.io: 6.6.9
+      socket.io-adapter: 2.5.8
       socket.io-parser: 4.2.6
     transitivePeerDependencies:
       - bufferutil
@@ -38709,8 +38697,6 @@ snapshots:
       signal-exit: 4.1.0
 
   ws@7.5.11: {}
-
-  ws@8.20.1: {}
 
   ws@8.21.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,50 @@ packages:
   - 'e2e/*'
   - 'packages/*'
   - 'packages/devextreme/artifacts/npm/devextreme-dist'
+  - '!packages/sbom'
+
+linkWorkspacePackages: true
+preferWorkspacePackages: true
+saveWorkspaceProtocol: false
+packageManagerStrict: false
+engineStrict: true
+
+overrides:
+  "basic-ftp@<5.3.1": ">=5.3.1"
+  "rollup@<4.59.0": "^4.59.0"
+  "json5@<1.0.2": ^2.2.3
+  "axios@<1.15.2": ^1.15.2
+  "braces@<3.0.3": ^3.0.3
+  "semver@<5.7.2": ^5.7.2
+  qs: ">=6.15.2"
+  "vite@>=6.0.0 <6.4.1": ^7.3.2
+  "tar@<=7.5.9": ^7.5.10
+  "underscore@<=1.13.7": ^1.13.8
+  "hono@<4.12.18": ">=4.12.18"
+  "minimatch@>=9.0.0 < 9.0.7": 9.0.9
+  "picomatch@>=4.0.0 <4.0.4": 4.0.4
+  "micromatch@<4.0.8": ^4.0.8
+  "esbuild@<0.28.1": ^0.28.1
+  "unrs-resolver@<1.12.2": ^1.12.2
+  "tmp@<0.2.7": "^0.2.7"
+  "ajv@>=7.0.0-alpha.0 <8.18.0": ^8.18.0
+  "@tootallnate/once@<3.0.1": ^3.0.1
+  "ws@>=8.0.0 <8.20.1": ^8.20.1
+  "cookie@<0.7.0": ^0.7.0
+  "glob@>=10.2.0 <10.5.0": ^10.5.0
+  "immutable@>=4.0.0-rc.1 <4.3.8": ^4.3.8
+  "ip-address@<=10.1.0": ">=10.1.1"
+  "lodash@<4.18.1": 4.18.1
+  "minimatch@>=10.0.0 < 10.2.4": 10.2.4
+  "path-to-regexp@0.1.12": 0.1.13
+  "postcss@<8.5.10": 8.5.10
+  "rollup@< 4.59.0": ^4.59.0
+  "serialize-javascript@<=7.0.2": 7.0.5
+  "shell-quote@>=1.1.0 <=1.8.3": ^1.8.4
+  "uuid@<14.0.0": ~14.0.0
+  "webpack-dev-server@<=5.2.3": ^5.2.4
+  "yaml@>=2.0.0 <2.8.3": ^2.8.3
+  "form-data@<4.0.6": "^4.0.6"
 
 catalog:
   axe-core: ^4.11.1


### PR DESCRIPTION
origin PR: https://github.com/DevExpress/DevExtreme/pull/34015