### PR TITLE
Potential fix for code scanning alert no. 359: Incomplete multi-character sanitization

### DIFF
--- a/apps/demos/utils/server/csp-bundle.js
+++ b/apps/demos/utils/server/csp-bundle.js
@@ -216,7 +216,12 @@ function extractDemoBodyInner(srcDir) {
     const html = fs.readFileSync(path.join(srcDir, 'index.html'), 'utf8');
     const bodyMatch = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
     if (!bodyMatch) return null;
-    const withoutScripts = bodyMatch[1].replace(/<script\b[\s\S]*?<\/script>/gi, '');
+    let withoutScripts = bodyMatch[1];
+    let previous;
+    do {
+      previous = withoutScripts;
+      withoutScripts = withoutScripts.replace(/<script\b[\s\S]*?<\/script>/gi, '');
+    } while (withoutScripts !== previous);
     const trimmed = withoutScripts.trim();
     return trimmed || null;
   } catch {


### PR DESCRIPTION
Potential fix for [https://github.com/DevExpress/DevExtreme/security/code-scanning/359](https://github.com/DevExpress/DevExtreme/security/code-scanning/359)

Use a stable sanitization strategy that cannot leave `<script` behind after one pass.  
Best minimal fix (without changing intended behavior) is to repeatedly apply the existing script-removal regex until the string no longer changes.

**Change required in `apps/demos/utils/server/csp-bundle.js`:**
- In `extractDemoBodyInner`, replace the single `.replace(/<script...<\/script>/gi, '')` call with a small loop:
  - initialize `withoutScripts` from `bodyMatch[1]`
  - repeatedly apply the same regex replacement until no change
- Keep the rest of logic (`trim`, fallback behavior) unchanged.
- No new imports or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
