### PR TITLE
Potential fix for code scanning alert no. 358: DOM text reinterpreted as HTML

### DIFF
--- a/packages/devextreme/playground/jquery.html
+++ b/packages/devextreme/playground/jquery.html
@@ -6,10 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <script type="text/javascript">
-        const currentThemeId = localStorage.getItem("currentThemeId") || "light";
+        const storedThemeId = localStorage.getItem("currentThemeId");
+        const safeThemeId = (storedThemeId && /^[a-z0-9.]+$/.test(storedThemeId)) ? storedThemeId : "light";
 
         const link = document.createElement("link");
-        link.href = `../artifacts/css/dx.${currentThemeId}.css`;
+        link.href = `../artifacts/css/dx.${encodeURIComponent(safeThemeId)}.css`;
         link.type = "text/css";
         link.rel = "stylesheet";
 


### PR DESCRIPTION
Potential fix for [https://github.com/DevExpress/DevExtreme/security/code-scanning/358](https://github.com/DevExpress/DevExtreme/security/code-scanning/358)

The best fix is to **validate and normalize the theme id before using it in `href`**, falling back to a safe default when invalid. Since we should only edit shown snippets and avoid assuming cross-file runtime availability, the safest single-file fix is in `packages/devextreme/playground/jquery.html`:

- Add a strict pattern check for allowed theme id characters (e.g. lowercase letters/digits/dots).
- If the stored value is missing or invalid, use a known safe default (`light` as current behavior).
- Encode the validated value with `encodeURIComponent` before interpolating into the URL path segment.

This preserves functionality (loading persisted theme when valid) while preventing hostile values from being interpreted in a dangerous way.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
