### PR TITLE
Potential fix for code scanning alert no. 357: Missing rate limiting

### DIFF
--- a/apps/demos/utils/shell/server.js
+++ b/apps/demos/utils/shell/server.js
@@ -5,6 +5,7 @@ const serveStatic = require('serve-static');
 const serveIndex = require('serve-index');
 const cookieParser = require('cookie-parser');
 const open = require('open');
+const rateLimit = require('express-rate-limit');
 const { join, normalize } = require('path');
 const { readFileSync, readdirSync } = require('fs');
 
@@ -42,12 +43,17 @@ const demoIndexHandler = (request, response) => {
 const app = express();
 app.use(cookieParser());
 
+const demoLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+});
+
 app.get('/apps/demos', (request, response) => response.redirect('/'));
 app.get(`/apps/demos/${indexFileName}`, (request, response) => response.redirect('/'));
-app.get('/Demos/:widget/:name/:approach', demoIndexHandler);
-app.get(`/Demos/:widget/:name/:approach/${indexFileName}`, demoIndexHandler);
-app.get('/apps/demos/Demos/:widget/:name/:approach', demoIndexHandler);
-app.get(`/apps/demos/Demos/:widget/:name/:approach/${indexFileName}`, demoIndexHandler);
+app.get('/Demos/:widget/:name/:approach', demoLimiter, demoIndexHandler);
+app.get(`/Demos/:widget/:name/:approach/${indexFileName}`, demoLimiter, demoIndexHandler);
+app.get('/apps/demos/Demos/:widget/:name/:approach', demoLimiter, demoIndexHandler);
+app.get(`/apps/demos/Demos/:widget/:name/:approach/${indexFileName}`, demoLimiter, demoIndexHandler);
 app.get('/themes', (request, response) => response.send(getAvailableThemes));
 app.use(
   serveStatic(root, { index: [indexFileName] }),


### PR DESCRIPTION
Potential fix for [https://github.com/DevExpress/DevExtreme/security/code-scanning/357](https://github.com/DevExpress/DevExtreme/security/code-scanning/357)

Add rate-limiting middleware and apply it to the routes that use `demoIndexHandler` (or globally). The best low-risk fix is to use `express-rate-limit`, define a limiter once, and attach it specifically to the four demo routes that invoke `demoIndexHandler`. This preserves existing behavior while preventing unbounded request bursts to the expensive handler.

In `apps/demos/utils/shell/server.js`:
- Add `const rateLimit = require('express-rate-limit');` near the other imports.
- Define a limiter (for example 100 requests per 15 minutes per IP) after app initialization.
- Update the four `app.get(..., demoIndexHandler)` route declarations to `app.get(..., demoLimiter, demoIndexHandler)`.

No functional routing changes are needed; only middleware insertion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
