### PR TITLE
Lookup: Fix deprecation warning for function width/height in dropDownOptions (T1330990)

### DIFF
--- a/packages/devextreme/js/__internal/ui/lookup.ts
+++ b/packages/devextreme/js/__internal/ui/lookup.ts
@@ -150,6 +150,7 @@ class Lookup extends DropDownList<LookupProperties> {
       showDropDownButton: false,
       focusStateEnabled: false,
       dropDownOptions: {
+        _ignoreFunctionValueDeprecation: true,
         showTitle: true,
         // @ts-expect-error The width cannot be a static value due to the mechanism of size updates
         width: () => getSize('width'),
@@ -233,7 +234,6 @@ class Lookup extends DropDownList<LookupProperties> {
           dropDownCentered: true,
           _scrollToSelectedItemEnabled: true,
           dropDownOptions: {
-            _ignoreFunctionValueDeprecation: true,
             shading: false,
             showTitle: false,
             // The height cannot be a static value due to the mechanism of size updates

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.editors/lookup.tests.js
@@ -2555,6 +2555,23 @@ QUnit.module('popup options', {
             }
         });
     });
+
+    QUnit.test('should not log W0017 deprecation warning on popup open for function-valued width/height (T1330990)', function(assert) {
+        const logStub = sinon.stub(errors, 'log');
+
+        try {
+            $('#lookup').dxLookup({
+                items: [1, 2, 3],
+                opened: true,
+            });
+
+            const warningCalls = logStub.args.filter(args => args[0] === 'W0017');
+
+            assert.strictEqual(warningCalls.length, 0, 'no W0017 warnings should be logged when opening the popup');
+        } finally {
+            logStub.restore();
+        }
+    });
 });
 
 QUnit.module('list options', {


### PR DESCRIPTION

<!--
Before you submit a pull request, review our contribution guidelines (CONTRIBUTING.md).

If your pull request contains a bug fix, its title should include "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What does the PR change?
2. How did you achieve this?
3. How can we verify these changes?

-->
