### PR TITLE
GridCore: fix focus anchor when leave 1st cell with Shift+Tab (T1329750)

### DIFF
--- a/e2e/testcafe-devextreme/tests/dataGrid/common/keyboardNavigation/keyboardNavigation.functional.ts
+++ b/e2e/testcafe-devextreme/tests/dataGrid/common/keyboardNavigation/keyboardNavigation.functional.ts
@@ -1869,6 +1869,36 @@ test('The expand cell should not lose focus on expanding a master row (T892203)'
     },
     columns: ['a', 'b'],
   }));
+
+  test(`${editMode} mode - Shift+Tab from the first editable cell should move focus to the last header (T1329750)`, async (t) => {
+    const dataGrid = new DataGrid('#container') as any;
+    const cell00 = dataGrid.getDataCell(0, 0);
+    const editor00 = cell00.getEditor();
+    const lastHeaderCell = dataGrid.getHeaders().getHeaderRow(0).getHeaderCell(1);
+
+    await t.expect(dataGrid.isReady()).ok();
+
+    await t
+      .click(cell00.element)
+
+      .expect(cell00.isFocused).ok()
+      .expect(editor00.element.focused)
+      .ok()
+
+      .pressKey('shift+tab')
+
+      .expect(cell00.isFocused)
+      .notOk()
+      .expect(lastHeaderCell.element.focused)
+      .ok();
+  }).before(async () => createWidget('dxDataGrid', {
+    dataSource: [{ a: '1', b: '2' }],
+    editing: {
+      mode: editMode.toLowerCase() as any,
+      allowUpdating: true,
+    },
+    columns: ['a', 'b'],
+  }));
 });
 
 test('Horizontal moving by keydown if scrolling.columnRenderingMode: virtual', async (t) => {

--- a/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -508,6 +508,9 @@ export class KeyboardNavigationController extends KeyboardNavigationControllerCo
     this._editorFactory.loseFocus();
 
     if (this._editingController.isEditing() && !this.isRowEditMode()) {
+      // Focus the cell before closing the editor on native Tab-out,
+      // so the browser's native Shift+Tab leaves from a stable anchor.
+      ($cell.get(0) as HTMLElement | undefined)?.focus({ preventScroll: true });
       this._resetFocusedCell(true);
       this._resetFocusedView();
       this._closeEditCell();


### PR DESCRIPTION
<!--
Before you submit a pull request, review our contribution guidelines (CONTRIBUTING.md).

If your pull request contains a bug fix, its title should include "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What does the PR change?
2. How did you achieve this?
3. How can we verify these changes?

-->
