### PR TITLE
Form - Smart Paste: Remove the null value from NumberBox

### DIFF
--- a/apps/demos/Demos/Form/SmartPaste/Angular/app/app.component.ts
+++ b/apps/demos/Demos/Form/SmartPaste/Angular/app/app.component.ts
@@ -81,7 +81,7 @@ export class AppComponent {
 
   emailAIOptions = { instruction: 'Do not fill this field if the text contains an invalid email address. A valid email is in the following format: email@example.com' };
 
-  zipEditorOptions = { stylingMode, mode: 'text', value: null };
+  zipEditorOptions = { stylingMode, mode: 'text' };
 
   zipAIOptions = { instruction: 'If the text does not contain a ZIP, determine the ZIP code from the provided address.' };
 

--- a/apps/demos/Demos/Form/SmartPaste/Vue/App.vue
+++ b/apps/demos/Demos/Form/SmartPaste/Vue/App.vue
@@ -204,7 +204,7 @@ const phoneAIOptions = { instruction: 'Format as the following: (000) 000-0000' 
 const emailValidationRules: ValidationRule[] = [{ type: 'email' }];
 const emailAIOptions = { instruction: 'Do not fill this field if the text contains an invalid email address. A valid email is in the following format: email@example.com' };
 
-const zipEditorOptions = { stylingMode, mode: 'text', value: null };
+const zipEditorOptions = { stylingMode, mode: 'text' };
 const zipAIOptions = { instruction: 'If the text does not contain a ZIP, determine the ZIP code from the provided address.' };
 
 const resetButtonOptions: DxButtonTypes.Properties = {

--- a/apps/demos/Demos/Form/SmartPaste/jQuery/index.js
+++ b/apps/demos/Demos/Form/SmartPaste/jQuery/index.js
@@ -188,7 +188,6 @@ $(() => {
         editorOptions: {
           stylingMode,
           mode: 'text',
-          value: null,
         },
         aiOptions: {
           instruction: 'If the text does not contain a ZIP, determine the ZIP code from the provided address.',


### PR DESCRIPTION
Removes the `value: null` option from the NumberBox editor configuration in the Form - Smart Paste demos. 
