### PR TITLE
fix(vendor): `bootstrap.*` assets should NOT be `devextreme-dist` content, partial revert (#33987)

### DIFF
--- a/packages/devextreme/project.json
+++ b/packages/devextreme/project.json
@@ -1142,8 +1142,6 @@
           { "from": "./node_modules/devexpress-gantt/dist/dx-gantt.min.js", "to": "./artifacts/js/dx-gantt.min.js" },
           { "from": "./node_modules/devextreme-quill/dist/dx-quill.js", "to": "./artifacts/js/dx-quill.js" },
           { "from": "./node_modules/devextreme-quill/dist/dx-quill.min.js", "to": "./artifacts/js/dx-quill.min.js" },
-          { "from": "../devextreme-themebuilder/node_modules/bootstrap/dist/js/bootstrap.js", "to": "./artifacts/js/bootstrap.js" },
-          { "from": "../devextreme-themebuilder/node_modules/bootstrap/dist/js/bootstrap.min.js", "to": "./artifacts/js/bootstrap.min.js" },
           { "from": "../../apps/demos/node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js", "to": "./artifacts/js/dx.aspnet.data.js" }
         ]
       },
@@ -1172,8 +1170,6 @@
         "{projectRoot}/artifacts/js/dx-gantt.min.js",
         "{projectRoot}/artifacts/js/dx-quill.js",
         "{projectRoot}/artifacts/js/dx-quill.min.js",
-        "{projectRoot}/artifacts/js/bootstrap.js",
-        "{projectRoot}/artifacts/js/bootstrap.min.js",
         "{projectRoot}/artifacts/js/dx.aspnet.data.js"
       ]
     },
@@ -1183,8 +1179,7 @@
       "options": {
         "files": [
           { "from": "./node_modules/devexpress-diagram/dist/dx-{diagram,diagram.min}.css", "to": "./artifacts/css" },
-          { "from": "./node_modules/devexpress-gantt/dist/dx-{gantt,gantt.min}.css", "to": "./artifacts/css" },
-          { "from": "../devextreme-themebuilder/node_modules/bootstrap/dist/css/{bootstrap,bootstrap.min}.css", "to": "./artifacts/css" }
+          { "from": "./node_modules/devexpress-gantt/dist/dx-{gantt,gantt.min}.css", "to": "./artifacts/css" }
         ]
       },
       "inputs": [
@@ -1195,9 +1190,7 @@
         "{projectRoot}/artifacts/css/dx-diagram.css",
         "{projectRoot}/artifacts/css/dx-diagram.min.css",
         "{projectRoot}/artifacts/css/dx-gantt.css",
-        "{projectRoot}/artifacts/css/dx-gantt.min.css",
-        "{projectRoot}/artifacts/css/bootstrap.css",
-        "{projectRoot}/artifacts/css/bootstrap.min.css"
+        "{projectRoot}/artifacts/css/dx-gantt.min.css"
       ]
     },
     "copy:vendor": {

--- a/tools/scripts/build-all.ts
+++ b/tools/scripts/build-all.ts
@@ -1,6 +1,6 @@
 import sh from 'shelljs';
 import path from 'node:path';
-import { ARTIFACTS_DIR, INTERNAL_TOOLS_ARTIFACTS, ROOT_DIR, NPM_DIR, JS_ARTIFACTS, CSS_ARTIFACTS } from './common/paths';
+import { ARTIFACTS_DIR, INTERNAL_TOOLS_ARTIFACTS, ROOT_DIR, NPM_DIR } from './common/paths';
 import { version as devextremeNpmVersion } from '../../packages/devextreme/package.json';
 
 const DEVEXTREME_NPM_DIR = path.join(ROOT_DIR, 'packages/devextreme/artifacts/npm');

--- a/tools/scripts/build-all.ts
+++ b/tools/scripts/build-all.ts
@@ -1,6 +1,6 @@
 import sh from 'shelljs';
 import path from 'node:path';
-import { ARTIFACTS_DIR, INTERNAL_TOOLS_ARTIFACTS, ROOT_DIR, NPM_DIR } from './common/paths';
+import { ARTIFACTS_DIR, INTERNAL_TOOLS_ARTIFACTS, ROOT_DIR, NPM_DIR, JS_ARTIFACTS, CSS_ARTIFACTS } from './common/paths';
 import { version as devextremeNpmVersion } from '../../packages/devextreme/package.json';
 
 const DEVEXTREME_NPM_DIR = path.join(ROOT_DIR, 'packages/devextreme/artifacts/npm');
@@ -55,6 +55,11 @@ sh.exec('pnpm exec nx build devextreme-themebuilder');
 sh.pushd(path.join(ROOT_DIR, 'packages/devextreme/artifacts'));
     sh.cp('-r', ['ts', 'js', 'css'], ARTIFACTS_DIR);
 sh.popd();
+
+// TODO: maybe we should add bootstrap to vendors
+const BOOTSTRAP_DIR = path.join(ROOT_DIR, 'packages', 'devextreme-themebuilder', 'node_modules', 'bootstrap', 'dist');
+sh.cp([path.join(BOOTSTRAP_DIR, 'js', 'bootstrap.js'), path.join(BOOTSTRAP_DIR, 'js', 'bootstrap.min.js')], JS_ARTIFACTS);
+sh.cp([path.join(BOOTSTRAP_DIR, 'css', 'bootstrap.css'), path.join(BOOTSTRAP_DIR, 'css', 'bootstrap.min.css')], CSS_ARTIFACTS);
 
 sh.exec('pnpm run all:pack-and-copy');
 

--- a/tools/scripts/build-all.ts
+++ b/tools/scripts/build-all.ts
@@ -56,11 +56,7 @@ sh.pushd(path.join(ROOT_DIR, 'packages/devextreme/artifacts'));
     sh.cp('-r', ['ts', 'js', 'css'], ARTIFACTS_DIR);
 sh.popd();
 
-// TODO: maybe we should add bootstrap to vendors
-const BOOTSTRAP_DIR = path.join(ROOT_DIR, 'packages', 'devextreme-themebuilder', 'node_modules', 'bootstrap', 'dist');
-sh.cp([path.join(BOOTSTRAP_DIR, 'js', 'bootstrap.js'), path.join(BOOTSTRAP_DIR, 'js', 'bootstrap.min.js')], JS_ARTIFACTS);
-sh.cp([path.join(BOOTSTRAP_DIR, 'css', 'bootstrap.css'), path.join(BOOTSTRAP_DIR, 'css', 'bootstrap.min.css')], CSS_ARTIFACTS);
-
+sh.exec('pnpm exec nx copy:bootstrap workflows');
 sh.exec('pnpm run all:pack-and-copy');
 
 sh.exec('pnpm exec nx pack devextreme-react', { silent: true });


### PR DESCRIPTION
This (partially) reverts:
- #33987
- commit 7cec4ef4ba88d2de59965fe52e0b996bf34693e3

The `bootstrap.*` assets should not be the `devextreme-dist` content