### PR TITLE
PivotGrid A11y and KBN - Scrollable region must have keyboard access (axe issue) (KBN)

### DIFF
--- a/packages/devextreme/js/__internal/grids/pivot_grid/data_area/m_data_area.test.ts
+++ b/packages/devextreme/js/__internal/grids/pivot_grid/data_area/m_data_area.test.ts
@@ -1,0 +1,74 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from '@jest/globals';
+import $ from '@js/core/renderer';
+
+import { DataArea } from './m_data_area';
+
+const createComponent = (): unknown => ({
+  option: (optionName?: string) => {
+    if (optionName === undefined) {
+      return {};
+    }
+
+    return {
+      rtlEnabled: false,
+      encodeHtml: false,
+    }[optionName];
+  },
+  _eventsStrategy: { hasEvent: () => false },
+  _defaultActionArgs: () => ({}),
+});
+
+describe('DataArea', () => {
+  let container: HTMLElement = document.createElement('div');
+
+  const cellsData = [
+    [{ text: '1' }, { text: '2' }],
+    [{ text: '3' }, { text: '4' }],
+  ];
+
+  const renderDataArea = (data: unknown[]): DataArea => {
+    const area = new DataArea(createComponent());
+
+    area.render($(container), data);
+
+    return area;
+  };
+
+  const getCellsTabIndexes = (): (string | null)[] => Array.from(container.querySelectorAll('td'))
+    .map((cell) => cell.getAttribute('tabindex'));
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  describe('render', () => {
+    it('should make only the first data cell focusable', () => {
+      renderDataArea(cellsData);
+
+      expect(getCellsTabIndexes()).toEqual(['0', null, null, null]);
+    });
+
+    it('should keep the first data cell focusable after re-render', () => {
+      const area = renderDataArea(cellsData);
+
+      area.render($(container), cellsData);
+
+      expect(getCellsTabIndexes()).toEqual(['0', null, null, null]);
+    });
+
+    it('should not fail when there is no data', () => {
+      expect(() => renderDataArea([])).not.toThrow();
+    });
+  });
+});

--- a/packages/devextreme/js/__internal/grids/pivot_grid/data_area/m_data_area.ts
+++ b/packages/devextreme/js/__internal/grids/pivot_grid/data_area/m_data_area.ts
@@ -24,10 +24,10 @@ class DataArea extends AreaItem {
   }
 
   _makeFirstCellFocusable() {
-    const $firstCell = this.tableElement().find('td').first();
+    const firstCell = this.tableElement().get(0)?.querySelector('td');
 
-    if ($firstCell.length) {
-      setTabIndex(this.component, $firstCell);
+    if (firstCell) {
+      setTabIndex(this.component, $(firstCell));
     }
   }
 

--- a/packages/devextreme/js/__internal/grids/pivot_grid/data_area/m_data_area.ts
+++ b/packages/devextreme/js/__internal/grids/pivot_grid/data_area/m_data_area.ts
@@ -1,5 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import $ from '@js/core/renderer';
+import { setTabIndex } from '@js/ui/shared/accessibility';
 import supportUtils from '@ts/core/utils/m_support';
 
 import { AreaItem } from '../area_item/m_area_item';
@@ -14,6 +15,20 @@ const PIVOTGRID_ROW_TOTAL_CLASS = 'dx-row-total';
 class DataArea extends AreaItem {
   _getAreaName() {
     return 'data';
+  }
+
+  render(rootElement, data) {
+    super.render(rootElement, data);
+
+    this._makeFirstCellFocusable();
+  }
+
+  _makeFirstCellFocusable() {
+    const $firstCell = this.tableElement().find('td').first();
+
+    if ($firstCell.length) {
+      setTabIndex(this.component, $firstCell);
+    }
   }
 
   _createGroupElement() {

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.markup.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.markup.tests.js
@@ -184,7 +184,7 @@ QUnit.module('PivotGrid markup tests', () => {
             assert.ok($dataCell.length > 0, 'data cell exists');
             assert.strictEqual($dataCell.find('.dx-expand-icon-container').length, 0, 'no expand control in a non-expandable cell');
             assert.strictEqual($dataCell.attr('role'), 'gridcell', 'data cell has role="gridcell"');
-            assert.strictEqual($dataCell.attr('tabindex'), undefined, 'data cell is not focusable');
+            assert.strictEqual($dataCell.attr('tabindex'), '0', 'first data cell is focusable to provide keyboard access to the scrollable data area');
         } finally {
             clock.restore();
         }

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.pivotGrid/pivotGrid.tests.js
@@ -5707,7 +5707,7 @@ function getStubComponent(options) {
     options = options || {};
     return {
         option: function() {
-            return options[arguments[0]];
+            return arguments.length === 0 ? options : options[arguments[0]];
         },
         _defaultActionArgs: function() {
             return {};


### PR DESCRIPTION
### What
Fixed the axe accessibility error "Scrollable region must have keyboard access" in **PivotGrid**. The scrollable data area had nothing focusable inside, so keyboard users could not reach or scroll it

### How
The first cell of the data area now gets `tabindex="0"` (set in *m_data_area.ts* via the shared `setTabIndex` utility), so the Tab key can move focus into the scrollable region. The scroll containers themselves stay non-focusable, so screen readers keep announcing meaningful content instead of an unnamed scrollable element