### PR TITLE
Scheduler - Refactor Appointments Collection - Update tooltip on appointment deletion

### DIFF
--- a/packages/devextreme/js/__internal/scheduler/__tests__/appointments_new.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/__tests__/appointments_new.test.ts
@@ -762,6 +762,29 @@ describe('New Appointments', () => {
 
         expect(POM.tooltip.isVisible()).toBe(false);
       });
+
+      it('should show updated appointment data in the collector tooltip after a hidden appointment is updated', async () => {
+        const dataSource = [
+          { text: 'Appointment 1', startDate: new Date(2015, 1, 9, 8), endDate: new Date(2015, 1, 9, 9) },
+          { text: 'Appointment 2', startDate: new Date(2015, 1, 9, 8), endDate: new Date(2015, 1, 9, 9) },
+          { text: 'Appointment 3', startDate: new Date(2015, 1, 9, 8), endDate: new Date(2015, 1, 9, 9) },
+        ];
+        const { POM, scheduler } = await createScheduler({ ...getConfig(), dataSource });
+
+        await scheduler.updateAppointment(dataSource[1], {
+          ...dataSource[1],
+          endDate: new Date(2015, 1, 9, 8, 30),
+        });
+
+        jest.useFakeTimers();
+        POM.getCollectorButton().click();
+        jest.runAllTimers();
+
+        const updatedItem = POM.tooltip.getAppointmentItems().find(
+          (item) => item.textContent?.includes('Appointment 2'),
+        );
+        expect(updatedItem?.textContent).toContain('8:30');
+      });
     });
   });
 

--- a/packages/devextreme/js/__internal/scheduler/__tests__/appointments_new.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/__tests__/appointments_new.test.ts
@@ -705,6 +705,64 @@ describe('New Appointments', () => {
       expect(POM.tooltip.getAppointmentItem(0).textContent).toContain('Appointment 2');
       expect(POM.tooltip.getAppointmentItem(1).textContent).toContain('Appointment 3');
     });
+
+    describe('Update on deletion', () => {
+      const getConfig = (): Properties => ({
+        dataSource: [
+          { text: 'Appointment 1', startDate: new Date(2015, 1, 9, 8), endDate: new Date(2015, 1, 9, 9) },
+          { text: 'Appointment 2', startDate: new Date(2015, 1, 9, 8), endDate: new Date(2015, 1, 9, 9) },
+          { text: 'Appointment 3', startDate: new Date(2015, 1, 9, 8), endDate: new Date(2015, 1, 9, 9) },
+        ],
+        maxAppointmentsPerCell: 1,
+        currentView: 'day',
+        currentDate: new Date(2015, 1, 9, 8),
+        editing: true,
+      });
+
+      it('should keep tooltip open and update items after deleting an appointment from the collector tooltip', async () => {
+        const { POM } = await createScheduler(getConfig());
+
+        jest.useFakeTimers();
+        POM.getCollectorButton().click();
+        jest.runAllTimers();
+
+        POM.tooltip.getDeleteButton(0).click();
+        jest.runAllTimers();
+
+        expect(POM.tooltip.isVisible()).toBe(true);
+        expect(POM.tooltip.getAppointmentItems().length).toBe(1);
+        expect(POM.tooltip.getAppointmentItem(0).textContent).toContain('Appointment 3');
+        expect(POM.tooltip.target?.isConnected).toBe(true);
+      });
+
+      it('should close tooltip after deleting all appointments from the collector tooltip', async () => {
+        const { POM } = await createScheduler(getConfig());
+
+        jest.useFakeTimers();
+        POM.getCollectorButton().click();
+        jest.runAllTimers();
+
+        POM.tooltip.getDeleteButton(0).click();
+        jest.runAllTimers();
+        POM.tooltip.getDeleteButton(0).click();
+        jest.runAllTimers();
+
+        expect(POM.tooltip.isVisible()).toBe(false);
+      });
+
+      it('should close tooltip when the appointment it is shown for is deleted', async () => {
+        const { POM } = await createScheduler(getConfig());
+
+        jest.useFakeTimers();
+        POM.getAppointments()[0].element.click();
+        jest.runAllTimers();
+
+        POM.tooltip.getDeleteButton(0).click();
+        jest.runAllTimers();
+
+        expect(POM.tooltip.isVisible()).toBe(false);
+      });
+    });
   });
 
   describe('Appointment Popup', () => {

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.test.ts
@@ -1,6 +1,7 @@
 import {
   afterEach, beforeEach, describe, expect, it, jest,
 } from '@jest/globals';
+import type { dxElementWrapper } from '@js/core/renderer';
 import $ from '@js/core/renderer';
 import { fireEvent } from '@testing-library/dom';
 
@@ -14,6 +15,7 @@ import {
   mockAppointmentCollectorViewModel,
   mockGridViewModel,
 } from './__mock__/appointment_view_model';
+import type { AppointmentCollector } from './appointment_collector';
 import type { AppointmentsProperties } from './appointments';
 import { Appointments } from './appointments';
 import {
@@ -53,6 +55,9 @@ const getProperties = (options: {
   getDataAccessor: () => mockAppointmentDataAccessor,
 
   showAppointmentTooltip: (): void => {},
+  isTooltipShownForTarget: () => false,
+  updateAppointmentTooltip: (): void => {},
+  hideAppointmentTooltip: (): void => {},
   showEditAppointmentPopup: (): void => {},
   allowDelete: false,
   onDeleteKeyPress: (): void => {},
@@ -363,6 +368,44 @@ describe('Appointments', () => {
       expect(instance.getViewItemBySortedIndex(2)?.$element().get(0)).not.toBe(element2);
     });
 
+    it('should rerender only the collector when its items count changes', () => {
+      const dataA = { ...defaultAppointmentData };
+      const dataB = { ...defaultAppointmentData, text: 'Appointment B' };
+      const dataC = { ...defaultAppointmentData, text: 'Appointment C' };
+
+      const instance = createAppointments(getProperties());
+      instance.option('viewModel', [
+        mockGridViewModel(dataA, { sortedIndex: 0 }),
+        mockAppointmentCollectorViewModel(dataB, {
+          sortedIndex: 1,
+          items: [mockGridViewModel(dataB), mockGridViewModel(dataC)],
+        }),
+      ]);
+
+      const viewItemA = instance.getViewItemBySortedIndex(0);
+      const collector = instance.getViewItemBySortedIndex(1);
+      const elementA = viewItemA?.$element().get(0);
+      const collectorElement = collector?.$element().get(0);
+
+      instance.option('viewModel', [
+        mockGridViewModel(dataA, { sortedIndex: 0 }),
+        mockAppointmentCollectorViewModel(dataB, {
+          sortedIndex: 1,
+          items: [mockGridViewModel(dataB)],
+        }),
+      ]);
+
+      const newCollector = instance.getViewItemBySortedIndex(1);
+
+      expect(instance.$element().find(`.${APPOINTMENT_COLLECTOR_CLASSES.CONTAINER}`).length).toBe(1);
+      expect(instance.getViewItemBySortedIndex(0)).toBe(viewItemA);
+      expect(instance.getViewItemBySortedIndex(0)?.$element().get(0)).toBe(elementA);
+      expect(newCollector).not.toBe(collector);
+      expect(newCollector?.$element().get(0)).not.toBe(collectorElement);
+      expect(collectorElement?.isConnected).toBe(false);
+      expect((newCollector as AppointmentCollector).option().items.length).toBe(1);
+    });
+
     it('should only resize view item if its size changed', () => {
       const dataA = { ...defaultAppointmentData };
       const dataB = { ...defaultAppointmentData, text: 'Appointment B' };
@@ -428,6 +471,150 @@ describe('Appointments', () => {
       expect($element.css('width')).toBe('100px');
       expect($element.css('top')).toBe('10px');
       expect($element.css('left')).toBe('20px');
+    });
+  });
+
+  describe('Tooltip update on rerender', () => {
+    const collectorViewModel = (
+      data: Record<string, unknown>,
+      items: Record<string, unknown>[],
+    ): AppointmentCollectorViewModel => mockAppointmentCollectorViewModel(data, {
+      sortedIndex: 1,
+      items: items.map((itemData) => mockGridViewModel(itemData)),
+    });
+
+    it('should update tooltip target and items when a collector with shown tooltip is rerendered', () => {
+      const dataA = { ...defaultAppointmentData };
+      const dataB = { ...defaultAppointmentData, text: 'Appointment B' };
+      const dataC = { ...defaultAppointmentData, text: 'Appointment C' };
+      const updateAppointmentTooltip = jest.fn();
+
+      const instance = createAppointments({
+        ...getProperties(),
+        updateAppointmentTooltip,
+      });
+      instance.option('viewModel', [
+        mockGridViewModel(dataA, { sortedIndex: 0 }),
+        collectorViewModel(dataB, [dataB, dataC]),
+      ]);
+      const tooltipTarget = instance.getViewItemBySortedIndex(1)?.$element().get(0);
+      instance.option(
+        'isTooltipShownForTarget',
+        ($target: dxElementWrapper) => $target.get(0) === tooltipTarget,
+      );
+
+      instance.option('viewModel', [
+        mockGridViewModel(dataA, { sortedIndex: 0 }),
+        collectorViewModel(dataB, [dataB]),
+      ]);
+
+      const newCollectorElement = instance.getViewItemBySortedIndex(1)?.$element().get(0);
+      expect(updateAppointmentTooltip).toHaveBeenCalledTimes(1);
+
+      const [$target, tooltipItems] = updateAppointmentTooltip.mock.calls[0] as [
+        dxElementWrapper,
+        { appointment: Record<string, unknown> }[],
+      ];
+      expect($target.get(0)).toBe(newCollectorElement);
+      expect(tooltipItems).toHaveLength(1);
+      expect(tooltipItems[0].appointment).toBe(dataB);
+    });
+
+    it('should not update tooltip when it is not shown for the rerendered collector', () => {
+      const dataA = { ...defaultAppointmentData };
+      const dataB = { ...defaultAppointmentData, text: 'Appointment B' };
+      const dataC = { ...defaultAppointmentData, text: 'Appointment C' };
+      const updateAppointmentTooltip = jest.fn();
+
+      const instance = createAppointments({
+        ...getProperties(),
+        isTooltipShownForTarget: () => false,
+        updateAppointmentTooltip,
+      });
+      instance.option('viewModel', [
+        mockGridViewModel(dataA, { sortedIndex: 0 }),
+        collectorViewModel(dataB, [dataB, dataC]),
+      ]);
+
+      instance.option('viewModel', [
+        mockGridViewModel(dataA, { sortedIndex: 0 }),
+        collectorViewModel(dataB, [dataB]),
+      ]);
+
+      expect(updateAppointmentTooltip).not.toHaveBeenCalled();
+    });
+
+    it('should hide tooltip when the appointment it is shown for is removed', () => {
+      const dataA = { ...defaultAppointmentData };
+      const dataB = { ...defaultAppointmentData, text: 'Appointment B' };
+      const hideAppointmentTooltip = jest.fn();
+
+      const instance = createAppointments({
+        ...getProperties(),
+        hideAppointmentTooltip,
+      });
+      instance.option('viewModel', [
+        mockGridViewModel(dataA, { sortedIndex: 0 }),
+        mockGridViewModel(dataB, { sortedIndex: 1 }),
+      ]);
+      const tooltipTarget = instance.getViewItemBySortedIndex(1)?.$element().get(0);
+      instance.option(
+        'isTooltipShownForTarget',
+        ($target: dxElementWrapper) => $target.get(0) === tooltipTarget,
+      );
+
+      instance.option('viewModel', [
+        mockGridViewModel(dataA, { sortedIndex: 0 }),
+      ]);
+
+      expect(hideAppointmentTooltip).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not hide tooltip when removed appointments are not its target', () => {
+      const dataA = { ...defaultAppointmentData };
+      const dataB = { ...defaultAppointmentData, text: 'Appointment B' };
+      const hideAppointmentTooltip = jest.fn();
+
+      const instance = createAppointments({
+        ...getProperties(),
+        isTooltipShownForTarget: () => false,
+        hideAppointmentTooltip,
+      });
+      instance.option('viewModel', [
+        mockGridViewModel(dataA, { sortedIndex: 0 }),
+        mockGridViewModel(dataB, { sortedIndex: 1 }),
+      ]);
+
+      instance.option('viewModel', [
+        mockGridViewModel(dataA, { sortedIndex: 0 }),
+      ]);
+
+      expect(hideAppointmentTooltip).not.toHaveBeenCalled();
+    });
+
+    it('should hide tooltip on full rerender when it is shown for a view item', () => {
+      const dataA = { ...defaultAppointmentData };
+      const dataB = { ...defaultAppointmentData, text: 'Appointment B' };
+      const hideAppointmentTooltip = jest.fn();
+
+      const instance = createAppointments({
+        ...getProperties(),
+        hideAppointmentTooltip,
+      });
+      instance.option('viewModel', [
+        mockGridViewModel(dataA, { sortedIndex: 0 }),
+      ]);
+      const tooltipTarget = instance.getViewItemBySortedIndex(0)?.$element().get(0);
+      instance.option(
+        'isTooltipShownForTarget',
+        ($target: dxElementWrapper) => $target.get(0) === tooltipTarget,
+      );
+
+      instance.option('viewModel', [
+        mockGridViewModel(dataB, { sortedIndex: 0 }),
+      ]);
+
+      expect(hideAppointmentTooltip).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/appointments.ts
@@ -76,6 +76,12 @@ export interface AppointmentsProperties extends DOMComponentProperties<Appointme
     data: AppointmentTooltipItem[],
     options?: AppointmentTooltipExtraOptions,
   ) => void;
+  isTooltipShownForTarget: (target: dxElementWrapper) => boolean;
+  updateAppointmentTooltip: (
+    target: dxElementWrapper,
+    data: AppointmentTooltipItem[],
+  ) => void;
+  hideAppointmentTooltip: () => void;
   showEditAppointmentPopup: (
     appointmentData: SafeAppointment,
     targetedAppointmentData: TargetedAppointment,
@@ -208,6 +214,9 @@ export class Appointments extends DOMComponent<Appointments, AppointmentsPropert
       onAppointmentClick: noop,
       onAppointmentDblClick: noop,
       onAppointmentContextMenu: noop,
+      isTooltipShownForTarget: () => false,
+      updateAppointmentTooltip: noop,
+      hideAppointmentTooltip: noop,
       allowDelete: false,
       onDeleteKeyPress: noop,
       focusFallbackAfterDelete: noop,
@@ -293,6 +302,8 @@ export class Appointments extends DOMComponent<Appointments, AppointmentsPropert
     const allDayFragment = domAdapter.createDocumentFragment();
     const commonFragment = domAdapter.createDocumentFragment();
 
+    this.hideTooltipShownForViewItems();
+
     this.viewItemBySortedIndex = {};
     this.$allDayContainer?.empty();
     this.$commonContainer.empty();
@@ -328,6 +339,10 @@ export class Appointments extends DOMComponent<Appointments, AppointmentsPropert
 
       switch (true) {
         case diffItem.needToRemove: {
+          if (this.option().isTooltipShownForTarget(viewItem.$element())) {
+            this.option().hideAppointmentTooltip();
+          }
+
           viewItem.$element().remove();
           break;
         }
@@ -337,6 +352,20 @@ export class Appointments extends DOMComponent<Appointments, AppointmentsPropert
 
           const fragment = allDay ? allDayFragment : commonFragment;
           fragment.appendChild(newViewItem.$element().get(0));
+          break;
+        }
+        case diffItem.needToUpdateItems: {
+          const newViewItem = this.renderViewItem(diffItem.item, index);
+          newViewItemBySortedIndex[sortedIndex] = newViewItem;
+
+          viewItem.$element().replaceWith(newViewItem.$element());
+
+          if (this.option().isTooltipShownForTarget(viewItem.$element())) {
+            this.option().updateAppointmentTooltip(
+              newViewItem.$element(),
+              this.getTooltipItems(newViewItem),
+            );
+          }
           break;
         }
         default:
@@ -453,6 +482,16 @@ export class Appointments extends DOMComponent<Appointments, AppointmentsPropert
 
   public renderDragClone(appointmentViewModel: AppointmentViewModelPlain): dxElementWrapper {
     return this.renderViewItem(appointmentViewModel, this.viewItems.length).$element();
+  }
+
+  private hideTooltipShownForViewItems(): void {
+    const isTooltipShownForViewItem = this.viewItems.some(
+      (viewItem) => this.option().isTooltipShownForTarget(viewItem.$element()),
+    );
+
+    if (isTooltipShownForViewItem) {
+      this.option().hideAppointmentTooltip();
+    }
   }
 
   private findViewItemByElement($element: dxElementWrapper): ViewItem | undefined {

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/utils/get_view_model_diff.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/utils/get_view_model_diff.test.ts
@@ -295,6 +295,43 @@ describe('getViewModelDiff', () => {
       expect(diff).toEqual([{ item: b[0], needToUpdateItems: true, oldSortedIndex: 0 }]);
     });
 
+    it('should mark needToUpdateItems for a collector when a hidden appointment data changed', () => {
+      const data1: ItemData = {};
+      const data2: ItemData = {};
+      const a = [mockAppointmentCollectorViewModel(data1, {
+        sortedIndex: 0,
+        items: [mockGridViewModel(data1), mockGridViewModel(data2)],
+      })];
+      const b = [mockAppointmentCollectorViewModel(data1, {
+        sortedIndex: 0,
+        items: [mockGridViewModel(data1), mockGridViewModel(data2)],
+      })];
+      const dataSource = createMockDataSource(data2);
+
+      const diff = getViewModelDiff(a, b, dataSource);
+
+      expect(getOperations(diff)).toBe('u');
+      expect(diff).toEqual([{ item: b[0], needToUpdateItems: true, oldSortedIndex: 0 }]);
+    });
+
+    it('should mark needToUpdateItems for a collector when its item matches an updatedAppointmentKey', () => {
+      const data1: ItemData = { id: 1 };
+      const data2: ItemData = { id: 2 };
+      const a = [mockAppointmentCollectorViewModel(data1, {
+        sortedIndex: 0,
+        items: [mockGridViewModel(data1), mockGridViewModel(data2)],
+      })];
+      const b = [mockAppointmentCollectorViewModel(data1, {
+        sortedIndex: 0,
+        items: [mockGridViewModel(data1), mockGridViewModel(data2)],
+      })];
+      const dataSource = createMockDataSource(null, [{ key: 'id', value: 2 }]);
+
+      const diff = getViewModelDiff(a, b, dataSource);
+
+      expect(getOperations(diff)).toBe('u');
+    });
+
     it('should match collector by position and mark needToUpdateItems even when its itemData changed', () => {
       const data1: ItemData = {};
       const data2: ItemData = {};

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/utils/get_view_model_diff.test.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/utils/get_view_model_diff.test.ts
@@ -3,7 +3,7 @@ import {
 } from '@jest/globals';
 
 import type { AppointmentDataSource } from '../../view_model/m_appointment_data_source';
-import { mockGridViewModel } from '../__mock__/appointment_view_model';
+import { mockAppointmentCollectorViewModel, mockGridViewModel } from '../__mock__/appointment_view_model';
 import { getViewModelDiff } from './get_view_model_diff';
 
 type ItemData = Record<string, unknown>;
@@ -25,6 +25,7 @@ const getOperations = (items: ReturnType<typeof getViewModelDiff>): string => it
     if (item.needToAdd) return '+';
     if (item.needToRemove) return '-';
     if (item.needToResize) return 'r';
+    if (item.needToUpdateItems) return 'u';
     return '=';
   })
   .join('');
@@ -272,6 +273,110 @@ describe('getViewModelDiff', () => {
         { item: b[1], needToResize: true, oldSortedIndex: 1 },
         { item: b[2], oldSortedIndex: 2 },
       ]);
+    });
+  });
+
+  describe('needToUpdateItems', () => {
+    it('should mark needToUpdateItems for a collector at the same position with changed items count', () => {
+      const data1: ItemData = {};
+      const data2: ItemData = {};
+      const a = [mockAppointmentCollectorViewModel(data1, {
+        sortedIndex: 0,
+        items: [mockGridViewModel(data1), mockGridViewModel(data2)],
+      })];
+      const b = [mockAppointmentCollectorViewModel(data1, {
+        sortedIndex: 0,
+        items: [mockGridViewModel(data1)],
+      })];
+
+      const diff = getViewModelDiff(a, b, defaultDataSource);
+
+      expect(getOperations(diff)).toBe('u');
+      expect(diff).toEqual([{ item: b[0], needToUpdateItems: true, oldSortedIndex: 0 }]);
+    });
+
+    it('should match collector by position and mark needToUpdateItems even when its itemData changed', () => {
+      const data1: ItemData = {};
+      const data2: ItemData = {};
+      const a = [mockAppointmentCollectorViewModel(data1, {
+        sortedIndex: 0,
+        items: [mockGridViewModel(data1), mockGridViewModel(data2)],
+      })];
+      const b = [mockAppointmentCollectorViewModel(data2, {
+        sortedIndex: 0,
+        items: [mockGridViewModel(data2)],
+      })];
+
+      const diff = getViewModelDiff(a, b, defaultDataSource);
+
+      expect(getOperations(diff)).toBe('u');
+    });
+
+    it('should mark no changes for a collector with the same items count and geometry', () => {
+      const data1: ItemData = {};
+      const data2: ItemData = {};
+      const a = [mockAppointmentCollectorViewModel(data1, {
+        sortedIndex: 0,
+        items: [mockGridViewModel(data1), mockGridViewModel(data2)],
+      })];
+      const b = [mockAppointmentCollectorViewModel(data1, {
+        sortedIndex: 0,
+        items: [mockGridViewModel(data1), mockGridViewModel(data2)],
+      })];
+
+      const diff = getViewModelDiff(a, b, defaultDataSource);
+
+      expect(getOperations(diff)).toBe('=');
+      expect(diff).toEqual([{ item: b[0], oldSortedIndex: 0 }]);
+    });
+
+    it('should mark remove and add for a collector moved to another position', () => {
+      const data1: ItemData = {};
+      const a = [mockAppointmentCollectorViewModel(data1, { sortedIndex: 0, top: 0, left: 0 })];
+      const b = [mockAppointmentCollectorViewModel(data1, { sortedIndex: 0, top: 100, left: 50 })];
+
+      const diff = getViewModelDiff(a, b, defaultDataSource);
+
+      expect(getOperations(diff)).toBe('+-');
+    });
+
+    it('should mark needToResize for a collector with the same items count and changed size', () => {
+      const data1: ItemData = {};
+      const a = [mockAppointmentCollectorViewModel(data1, {
+        sortedIndex: 0, height: 20, width: 20,
+      })];
+      const b = [mockAppointmentCollectorViewModel(data1, {
+        sortedIndex: 0, height: 40, width: 40,
+      })];
+
+      const diff = getViewModelDiff(a, b, defaultDataSource);
+
+      expect(getOperations(diff)).toBe('r');
+    });
+
+    it('should mix needToUpdateItems with operations on regular appointments', () => {
+      const data1: ItemData = {};
+      const data2: ItemData = {};
+      const data3: ItemData = {};
+      const a = [
+        makeItem(data1, { sortedIndex: 0 }),
+        mockAppointmentCollectorViewModel(data2, {
+          sortedIndex: 1,
+          items: [mockGridViewModel(data2), mockGridViewModel(data3)],
+        }),
+        makeItem(data3, { sortedIndex: 2 }),
+      ];
+      const b = [
+        makeItem(data1, { sortedIndex: 0 }),
+        mockAppointmentCollectorViewModel(data2, {
+          sortedIndex: 1,
+          items: [mockGridViewModel(data2)],
+        }),
+      ];
+
+      const diff = getViewModelDiff(a, b, defaultDataSource);
+
+      expect(getOperations(diff)).toBe('=u-');
     });
   });
 

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/utils/get_view_model_diff.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/utils/get_view_model_diff.ts
@@ -67,10 +67,10 @@ function getArraysDiff(options: {
   match: (x: Item, y: Item) => boolean;
   equal: (x: Item, y: Item) => boolean;
   canResize: (x: Item, y: Item) => boolean;
-  itemsLengthEqual: (x: Item, y: Item) => boolean;
+  itemsEqual: (x: Item, y: Item) => boolean;
 }): DiffItem[] {
   const {
-    a, b, match, equal, canResize, itemsLengthEqual,
+    a, b, match, equal, canResize, itemsEqual,
   } = options;
   const n = a.length;
   const m = b.length;
@@ -96,7 +96,7 @@ function getArraysDiff(options: {
 
     if (match(ai, bj)) {
       switch (true) {
-        case !itemsLengthEqual(ai, bj):
+        case !itemsEqual(ai, bj):
           result.push({ item: bj, needToUpdateItems: true, oldSortedIndex: ai.sortedIndex });
           break;
         case equal(ai, bj):
@@ -158,9 +158,14 @@ export const getViewModelDiff = (
     // eslint-disable-next-line @stylistic/implicit-arrow-linebreak
     equalByValue(getObjectToCompare(a, false), getObjectToCompare(b, false));
 
-  const itemsLengthEqual = (a: Item, b: Item): boolean => !isCollectorViewModel(a)
-    || !isCollectorViewModel(b)
-    || a.items.length === b.items.length;
+  const itemsEqual = (a: Item, b: Item): boolean => {
+    if (!isCollectorViewModel(a) || !isCollectorViewModel(b)) {
+      return true;
+    }
+
+    return a.items.length === b.items.length
+      && !b.items.some((item) => isAppointmentDataChanged(item.itemData, appointmentDataSource));
+  };
 
   const result = getArraysDiff({
     a: oldViewModel,
@@ -168,7 +173,7 @@ export const getViewModelDiff = (
     match,
     equal,
     canResize,
-    itemsLengthEqual,
+    itemsEqual,
   });
 
   return result;

--- a/packages/devextreme/js/__internal/scheduler/appointments_new/utils/get_view_model_diff.ts
+++ b/packages/devextreme/js/__internal/scheduler/appointments_new/utils/get_view_model_diff.ts
@@ -11,6 +11,7 @@ export interface DiffItem {
   needToAdd?: boolean;
   needToRemove?: boolean;
   needToResize?: boolean;
+  needToUpdateItems?: boolean;
   item: AppointmentItemViewModel | AppointmentCollectorViewModel;
   oldSortedIndex?: number;
 }
@@ -20,7 +21,8 @@ const getObjectToCompare = (item: Item, includeDimensions: boolean): object => {
     ? {
       allDay: item.allDay,
       groupIndex: item.groupIndex,
-      items: item.items.length,
+      top: item.top,
+      left: item.left,
     }
     : {
       allDay: item.allDay,
@@ -65,9 +67,10 @@ function getArraysDiff(options: {
   match: (x: Item, y: Item) => boolean;
   equal: (x: Item, y: Item) => boolean;
   canResize: (x: Item, y: Item) => boolean;
+  itemsLengthEqual: (x: Item, y: Item) => boolean;
 }): DiffItem[] {
   const {
-    a, b, match, equal, canResize,
+    a, b, match, equal, canResize, itemsLengthEqual,
   } = options;
   const n = a.length;
   const m = b.length;
@@ -92,13 +95,19 @@ function getArraysDiff(options: {
     const bj = b[j - 1];
 
     if (match(ai, bj)) {
-      if (equal(ai, bj)) {
-        result.push({ item: bj, oldSortedIndex: ai.sortedIndex });
-      } else if (canResize(ai, bj)) {
-        result.push({ item: bj, needToResize: true, oldSortedIndex: ai.sortedIndex });
-      } else {
-        result.push({ item: ai, needToRemove: true });
-        result.push({ item: bj, needToAdd: true });
+      switch (true) {
+        case !itemsLengthEqual(ai, bj):
+          result.push({ item: bj, needToUpdateItems: true, oldSortedIndex: ai.sortedIndex });
+          break;
+        case equal(ai, bj):
+          result.push({ item: bj, oldSortedIndex: ai.sortedIndex });
+          break;
+        case canResize(ai, bj):
+          result.push({ item: bj, needToResize: true, oldSortedIndex: ai.sortedIndex });
+          break;
+        default:
+          result.push({ item: ai, needToRemove: true });
+          result.push({ item: bj, needToAdd: true });
       }
 
       i -= 1;
@@ -130,9 +139,16 @@ export const getViewModelDiff = (
   newViewModel: Item[],
   appointmentDataSource: AppointmentDataSource,
 ): DiffItem[] => {
-  const match = (a: Item, b: Item): boolean =>
-    // eslint-disable-next-line @stylistic/implicit-arrow-linebreak
-    a.itemData === b.itemData && !isAppointmentDataChanged(b.itemData, appointmentDataSource);
+  const match = (a: Item, b: Item): boolean => {
+    if (isCollectorViewModel(a) || isCollectorViewModel(b)) {
+      return isCollectorViewModel(a)
+        && isCollectorViewModel(b)
+        && equalByValue(getObjectToCompare(a, false), getObjectToCompare(b, false));
+    }
+
+    return a.itemData === b.itemData
+    && !isAppointmentDataChanged(b.itemData, appointmentDataSource);
+  };
 
   const equal = (a: Item, b: Item): boolean =>
     // eslint-disable-next-line @stylistic/implicit-arrow-linebreak
@@ -142,12 +158,17 @@ export const getViewModelDiff = (
     // eslint-disable-next-line @stylistic/implicit-arrow-linebreak
     equalByValue(getObjectToCompare(a, false), getObjectToCompare(b, false));
 
+  const itemsLengthEqual = (a: Item, b: Item): boolean => !isCollectorViewModel(a)
+    || !isCollectorViewModel(b)
+    || a.items.length === b.items.length;
+
   const result = getArraysDiff({
     a: oldViewModel,
     b: newViewModel,
     match,
     equal,
     canResize,
+    itemsLengthEqual,
   });
 
   return result;

--- a/packages/devextreme/js/__internal/scheduler/scheduler.ts
+++ b/packages/devextreme/js/__internal/scheduler/scheduler.ts
@@ -1392,6 +1392,12 @@ class Scheduler extends SchedulerOptionsBaseWidget {
 
         scrollTo: this.scrollTo.bind(this),
         showAppointmentTooltip: this.showAppointmentTooltipCore.bind(this),
+        isTooltipShownForTarget: (target) => this.appointmentTooltip.isShownForTarget(target),
+        updateAppointmentTooltip: (target, data) => {
+          this.appointmentTooltip.setTarget(target);
+          this.appointmentTooltip.setListItems(data);
+        },
+        hideAppointmentTooltip: () => this.hideAppointmentTooltip(),
         showEditAppointmentPopup: (
           appointmentData: SafeAppointment,
           targetedAppointmentData: TargetedAppointment,


### PR DESCRIPTION
### What
Updates the appointment tooltip in the new **Scheduler** appointments collection (behind the `_newAppointments` flag) when appointments are deleted from it: the item list refreshes after each deletion, the tooltip stays open while items remain and closes when the last item is deleted or the appointment it points to is removed

### How
The view model diff in *get_view_model_diff.ts* now matches collectors by position and marks them with `needToUpdateItems` when their item count changes. The collection rerenders such collectors in place and syncs the tooltip through three new callbacks (`isTooltipShownForTarget`, `updateAppointmentTooltip`, `hideAppointmentTooltip`) that the **Scheduler** wires to the existing tooltip strategy methods