### PR TITLE
PivotGrid - KBN - Open cell context menu from keyboard

### DIFF
--- a/packages/devextreme/js/__internal/grids/pivot_grid/keyboard_navigation/cell_context_menu.test.ts
+++ b/packages/devextreme/js/__internal/grids/pivot_grid/keyboard_navigation/cell_context_menu.test.ts
@@ -1,0 +1,35 @@
+import {
+  describe,
+  expect,
+  it,
+} from '@jest/globals';
+
+import { isContextMenuKeyEvent } from './cell_context_menu';
+
+describe('isContextMenuKeyEvent', () => {
+  it('should detect the ContextMenu key', () => {
+    expect(isContextMenuKeyEvent({ key: 'ContextMenu', shiftKey: false })).toBe(true);
+  });
+
+  it('should detect the ContextMenu key regardless of the Shift state', () => {
+    expect(isContextMenuKeyEvent({ key: 'ContextMenu', shiftKey: true })).toBe(true);
+  });
+
+  it('should detect Shift+F10', () => {
+    expect(isContextMenuKeyEvent({ key: 'F10', shiftKey: true })).toBe(true);
+  });
+
+  it('should ignore F10 without Shift', () => {
+    expect(isContextMenuKeyEvent({ key: 'F10', shiftKey: false })).toBe(false);
+  });
+
+  it('should ignore Shift without F10', () => {
+    expect(isContextMenuKeyEvent({ key: 'Shift', shiftKey: true })).toBe(false);
+  });
+
+  it('should ignore unrelated keys', () => {
+    expect(isContextMenuKeyEvent({ key: 'Enter', shiftKey: false })).toBe(false);
+    expect(isContextMenuKeyEvent({ key: 'ArrowDown', shiftKey: false })).toBe(false);
+    expect(isContextMenuKeyEvent({ key: ' ', shiftKey: false })).toBe(false);
+  });
+});

--- a/packages/devextreme/js/__internal/grids/pivot_grid/keyboard_navigation/cell_context_menu.ts
+++ b/packages/devextreme/js/__internal/grids/pivot_grid/keyboard_navigation/cell_context_menu.ts
@@ -1,0 +1,8 @@
+const F10_KEY = 'F10';
+const CONTEXT_MENU_KEY = 'ContextMenu';
+
+export function isContextMenuKeyEvent(
+  event: Pick<KeyboardEvent, 'key' | 'shiftKey'>,
+): boolean {
+  return event.key === CONTEXT_MENU_KEY || (event.shiftKey && event.key === F10_KEY);
+}


### PR DESCRIPTION
### What
Adds a small **PivotGrid** keyboard-navigation helper that recognizes the open-context-menu keyboard gesture (`Shift+F10` and the dedicated `ContextMenu` key) on header cells

### How
New `isContextMenuKeyEvent` predicate in *cell_context_menu.ts* with jest tests, following the existing `keyboard_navigation` helper style. This is the base-agnostic foundation for opening the cell context menu from the keyboard; the widget wiring lands once header cells become focusable