### PR TITLE
T1331376 - DataGrid — Tab Navigation between cells stops working if FocusedRowEnabled is true and editCell is called to focus a cell

### DIFF
--- a/e2e/testcafe-devextreme/tests/dataGrid/common/focus/focus.ts
+++ b/e2e/testcafe-devextreme/tests/dataGrid/common/focus/focus.ts
@@ -1,7 +1,7 @@
 import DataGrid from 'devextreme-testcafe-models/dataGrid';
 import { ClientFunction } from 'testcafe';
 import TextBox from 'devextreme-testcafe-models/textBox';
-import { GridsEditMode } from 'devextreme/artifacts/npm/devextreme/common/grids';
+import { GridsEditMode } from 'devextreme/ui/data_grid';
 import { createWidget } from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
 
@@ -380,7 +380,7 @@ test('Focus method should focus the first data row when focusedRowEnabled = true
 
 (['batch', 'cell'] as GridsEditMode[]).forEach((editMode) => {
   // T1331376
-  test(`Tab should focus the next cell after editing a cell by API when focusedRowEnabled (editing.mode=${editMode})`, async (t) => {
+  test.only(`Tab should focus the next cell after editing a cell by API when focusedRowEnabled (editing.mode=${editMode})`, async (t) => {
     const dataGrid = new DataGrid(GRID_SELECTOR);
     await t.expect(dataGrid.isReady()).ok();
 

--- a/e2e/testcafe-devextreme/tests/dataGrid/common/focus/focus.ts
+++ b/e2e/testcafe-devextreme/tests/dataGrid/common/focus/focus.ts
@@ -380,7 +380,7 @@ test('Focus method should focus the first data row when focusedRowEnabled = true
 
 (['batch', 'cell'] as GridsEditMode[]).forEach((editMode) => {
   // T1331376
-  test.only(`Tab should focus the next cell after editing a cell by API when focusedRowEnabled (editing.mode=${editMode})`, async (t) => {
+  test(`Tab should focus the next cell after editing a cell by API when focusedRowEnabled (editing.mode=${editMode})`, async (t) => {
     const dataGrid = new DataGrid(GRID_SELECTOR);
     await t.expect(dataGrid.isReady()).ok();
 

--- a/e2e/testcafe-devextreme/tests/dataGrid/common/focus/focus.ts
+++ b/e2e/testcafe-devextreme/tests/dataGrid/common/focus/focus.ts
@@ -1,6 +1,7 @@
 import DataGrid from 'devextreme-testcafe-models/dataGrid';
 import { ClientFunction } from 'testcafe';
 import TextBox from 'devextreme-testcafe-models/textBox';
+import { GridsEditMode } from 'devextreme/artifacts/npm/devextreme/common/grids';
 import { createWidget } from '../../../../helpers/createWidget';
 import url from '../../../../helpers/getPageUrl';
 
@@ -376,3 +377,37 @@ test('Focus method should focus the first data row when focusedRowEnabled = true
     },
   ],
 }));
+
+(['batch', 'cell'] as GridsEditMode[]).forEach((editMode) => {
+  // T1331376
+  test(`Tab should focus the next cell after editing a cell by API when focusedRowEnabled (editing.mode=${editMode})`, async (t) => {
+    const dataGrid = new DataGrid(GRID_SELECTOR);
+    await t.expect(dataGrid.isReady()).ok();
+
+    await dataGrid.apiEditCell(0, 0);
+
+    await t
+      .expect(dataGrid.getDataCell(0, 0).getEditor().element.focused)
+      .ok();
+
+    await t.pressKey('tab');
+
+    await t
+      .expect(dataGrid.getDataCell(0, 1).isEditCell)
+      .ok()
+      .expect(dataGrid.getDataCell(0, 1).getEditor().element.focused)
+      .ok();
+  }).before(async () => createWidget('dxDataGrid', {
+    dataSource: [
+      { ID: 1, FirstName: 'John', LastName: 'Heart' },
+      { ID: 2, FirstName: 'Olivia', LastName: 'Peyton' },
+    ],
+    keyExpr: 'ID',
+    focusedRowEnabled: true,
+    editing: {
+      mode: editMode,
+      allowUpdating: true,
+    },
+    columns: ['FirstName', 'LastName'],
+  }));
+});

--- a/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -29,6 +29,7 @@ import type { AdaptiveColumnsController } from '@ts/grids/grid_core/adaptivity/m
 import type { Column } from '@ts/grids/grid_core/columns_controller/types';
 import type { DataController } from '@ts/grids/grid_core/data_controller/m_data_controller';
 import type { EditingController } from '@ts/grids/grid_core/editing/m_editing';
+import type { NormalizedEditCellOptions } from '@ts/grids/grid_core/editing/types';
 import type { RowsView } from '@ts/grids/grid_core/views/m_rows_view';
 import { memoize } from '@ts/utils/memoize';
 
@@ -3081,12 +3082,25 @@ const editing = (Base: ModuleType<EditingController>) => class EditingController
       return false;
     }
 
-    const isCellEditing = super.editCell(rowIndex, columnIndex);
-    if (isCellEditing) {
+    return super.editCell(rowIndex, columnIndex);
+  }
+
+  protected _prepareEditCell(parameters: NormalizedEditCellOptions): boolean {
+    const isPrepared = super._prepareEditCell(parameters);
+
+    if (isPrepared) {
+      this._keyboardNavigationController.setCellFocusType();
       this._keyboardNavigationController.setupFocusedView();
+
+      const rowIndexOffset = this._dataController.getRowIndexOffset();
+      const columnIndexOffset = this._columnsController.getColumnIndexOffset();
+      const globalRowIndex = parameters.rowIndex + rowIndexOffset;
+      const globalColumnIndex = parameters.columnIndex + columnIndexOffset;
+
+      this._keyboardNavigationController.setFocusedCellPosition(globalRowIndex, globalColumnIndex);
     }
 
-    return isCellEditing;
+    return isPrepared;
   }
 
   public editRow(rowIndex) {

--- a/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -29,7 +29,6 @@ import type { AdaptiveColumnsController } from '@ts/grids/grid_core/adaptivity/m
 import type { Column } from '@ts/grids/grid_core/columns_controller/types';
 import type { DataController } from '@ts/grids/grid_core/data_controller/m_data_controller';
 import type { EditingController } from '@ts/grids/grid_core/editing/m_editing';
-import type { NormalizedEditCellOptions } from '@ts/grids/grid_core/editing/types';
 import type { RowsView } from '@ts/grids/grid_core/views/m_rows_view';
 import { memoize } from '@ts/utils/memoize';
 

--- a/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/keyboard_navigation/m_keyboard_navigation.ts
@@ -3082,25 +3082,14 @@ const editing = (Base: ModuleType<EditingController>) => class EditingController
       return false;
     }
 
-    return super.editCell(rowIndex, columnIndex);
-  }
+    const isCellEditing = super.editCell(rowIndex, columnIndex);
 
-  protected _prepareEditCell(parameters: NormalizedEditCellOptions): boolean {
-    const isPrepared = super._prepareEditCell(parameters);
-
-    if (isPrepared) {
-      this._keyboardNavigationController.setCellFocusType();
+    if (isCellEditing) {
       this._keyboardNavigationController.setupFocusedView();
-
-      const rowIndexOffset = this._dataController.getRowIndexOffset();
-      const columnIndexOffset = this._columnsController.getColumnIndexOffset();
-      const globalRowIndex = parameters.rowIndex + rowIndexOffset;
-      const globalColumnIndex = parameters.columnIndex + columnIndexOffset;
-
-      this._keyboardNavigationController.setFocusedCellPosition(globalRowIndex, globalColumnIndex);
+      this._keyboardNavigationController.setCellFocusType();
     }
 
-    return isPrepared;
+    return isCellEditing;
   }
 
   public editRow(rowIndex) {


### PR DESCRIPTION
<!--
Before you submit a pull request, review our contribution guidelines (CONTRIBUTING.md).

If your pull request contains a bug fix, its title should include "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What does the PR change?
2. How did you achieve this?
3. How can we verify these changes?

-->
