### PR TITLE
T1332109 - DataGrid throws the "Cannot read properties of null (reading 'remoteOperations')" if multiple data operations are executed and autoNavigateToFocusedRow is true

### DIFF
--- a/packages/devextreme/js/__internal/grids/data_grid/focus/m_focus.ts
+++ b/packages/devextreme/js/__internal/grids/data_grid/focus/m_focus.ts
@@ -88,9 +88,8 @@ const data = (Base: DataControllerBase) => class FocusDataControllerExtender ext
   }
 
   private _calculateGlobalRowIndexByGroupedData(key) {
-    const that = this;
-    const dataSource = that._dataSource;
-    const filter = that._generateFilterByKey(key);
+    const dataSource = this._dataSource;
+    const filter = this._generateFilterByKey(key);
     // @ts-expect-error
     const deferred = new Deferred();
     const isGroupKey = Array.isArray(key);
@@ -101,35 +100,39 @@ const data = (Base: DataControllerBase) => class FocusDataControllerExtender ext
     }
 
     if (!dataSource._grouping._updatePagingOptions) {
-      that._calculateGlobalRowIndexByFlatData(key, null, true)
+      this._calculateGlobalRowIndexByFlatData(key, null, true)
         .done(deferred.resolve)
         .fail(deferred.reject);
       return deferred;
     }
 
     dataSource.load({
-      filter: that._concatWithCombinedFilter(filter),
+      filter: this._concatWithCombinedFilter(filter),
       group,
     }).done((data) => {
       const hasData = isDefined(data) && data.length > 0;
 
-      if (!hasData) {
+      if (this._dataSource !== dataSource || !hasData) {
         return deferred.resolve(-1).promise();
       }
 
-      const groupPath = that._getGroupPath(data, group.length);
+      const groupPath = this._getGroupPath(data, group.length);
 
-      that._expandGroupByPath(that, groupPath, 0).done(() => {
-        that._calculateExpandedRowGlobalIndex(deferred, key, groupPath, group);
+      this._expandGroupByPath(this, groupPath, 0).done(() => {
+        this._calculateExpandedRowGlobalIndex(deferred, key, groupPath, group, dataSource);
       }).fail(deferred.reject);
     }).fail(deferred.reject);
 
     return deferred.promise();
   }
 
-  private _calculateExpandedRowGlobalIndex(deferred, key, groupPath, group) {
+  private _calculateExpandedRowGlobalIndex(deferred, key, groupPath, group, dataSource) {
+    if (this._dataSource !== dataSource) {
+      deferred.resolve(-1);
+      return;
+    }
+
     const groupFilter = createGroupFilter(groupPath, { group });
-    const dataSource = this._dataSource;
     const scrollingMode = this.option('scrolling.mode');
     const isVirtualScrolling = scrollingMode === 'virtual' || scrollingMode === 'infinite';
     const pageSize = dataSource.pageSize();

--- a/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.integration.test.ts
@@ -1,10 +1,13 @@
 import {
   afterEach, beforeEach, describe, expect, it, jest,
 } from '@jest/globals';
+import { CustomStore, query } from '@js/common/data';
+import $ from '@js/core/renderer';
 import type { StoreChange } from '@js/data/store';
+import DataGrid from '@js/ui/data_grid';
 
 import {
-  afterTest, beforeTest, createDataGrid, flushAsync,
+  afterTest, beforeTest, createDataGrid, flushAsync, GRID_CONTAINER_ID,
 } from '../__tests__/__mock__/helpers/utils';
 
 describe('GridCore focus', () => {
@@ -126,4 +129,126 @@ describe('GridCore focus', () => {
       });
     },
   );
+
+  // T1332109
+  describe('when the dataSource is changed while the focused row position lookup is in flight', () => {
+    const data = Array.from({ length: 100 }, (_, index) => ({
+      id: index + 1,
+      name: `Item ${index + 1}`,
+    }));
+
+    let capturedErrors: unknown[] = [];
+    const trackError = (error: unknown): void => {
+      capturedErrors.push(error);
+    };
+
+    beforeEach(() => {
+      jest.useRealTimers();
+      capturedErrors = [];
+      process.on('uncaughtException', trackError);
+      process.on('unhandledRejection', trackError);
+    });
+
+    afterEach(() => {
+      process.off('uncaughtException', trackError);
+      process.off('unhandledRejection', trackError);
+    });
+
+    const wait = async (ms = 0): Promise<void> => new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+
+    const waitFor = async (predicate: () => boolean): Promise<void> => {
+      for (let attempt = 0; attempt < 200 && !predicate(); attempt += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await wait(5);
+      }
+    };
+
+    const createStore = (
+      items: { id: number; name: string }[],
+      holdLookupLoads = false,
+    ) => {
+      const heldLookupLoads: (() => void)[] = [];
+      const store = new CustomStore({
+        key: 'id',
+        load: (loadOptions) => {
+          let dataQuery = query(items);
+          if (loadOptions.filter) {
+            dataQuery = dataQuery.filter(loadOptions.filter);
+          }
+          const filteredItems = dataQuery.toArray();
+          const skip = loadOptions.skip ?? 0;
+          const take = loadOptions.take ?? filteredItems.length;
+          const result = {
+            data: filteredItems.slice(skip, skip + take),
+            totalCount: filteredItems.length,
+          };
+          if (take === 1 && holdLookupLoads) {
+            return new Promise<unknown>((resolve) => {
+              heldLookupLoads.push(() => resolve(result));
+            });
+          }
+          return Promise.resolve(result);
+        },
+      });
+
+      return { store, heldLookupLoads };
+    };
+
+    const createGridWithHeldLookup = async () => {
+      const { store, heldLookupLoads } = createStore(data, true);
+      const $container = $('<div>')
+        .attr('id', GRID_CONTAINER_ID)
+        .appendTo(document.body);
+      const instance = new DataGrid($container.get(0) as HTMLDivElement, {
+        dataSource: store,
+        remoteOperations: true,
+        focusedRowEnabled: true,
+        paging: { pageSize: 10 },
+        columns: ['id', 'name'],
+      });
+      await waitFor(() => instance.getVisibleRows().length === 10);
+
+      expect(instance.getVisibleRows()).toHaveLength(10);
+
+      instance.option('focusedRowKey', 55);
+      await waitFor(() => heldLookupLoads.length === 1);
+
+      expect(heldLookupLoads).toHaveLength(1);
+
+      return {
+        instance,
+        releaseLookupLoads: () => {
+          heldLookupLoads.forEach((release) => release());
+          heldLookupLoads.length = 0;
+        },
+      };
+    };
+
+    it('should not fail when the dataSource is cleared', async () => {
+      const { instance, releaseLookupLoads } = await createGridWithHeldLookup();
+
+      instance.option('dataSource', undefined);
+      releaseLookupLoads();
+      await wait(50);
+
+      expect(capturedErrors).toEqual([]);
+      expect(instance.option('focusedRowIndex')).toBe(-1);
+      expect(instance.getVisibleRows()).toEqual([]);
+    });
+
+    it('should not apply the stale lookup result when the dataSource is replaced', async () => {
+      const { instance, releaseLookupLoads } = await createGridWithHeldLookup();
+
+      instance.option('dataSource', createStore(data.slice(45)).store);
+      await waitFor(() => instance.option('focusedRowIndex') === 9);
+      releaseLookupLoads();
+      await wait(50);
+
+      expect(capturedErrors).toEqual([]);
+      expect(instance.pageIndex()).toBe(0);
+      expect(instance.option('focusedRowIndex')).toBe(9);
+    });
+  });
 });

--- a/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.ts
@@ -677,30 +677,37 @@ const data = (Base: ModuleType<DataController>) => class FocusDataControllerExte
   }
 
   protected _calculateGlobalRowIndexByFlatData(key, groupFilter, useGroup) {
-    const that = this;
     // @ts-expect-error
     const deferred = new Deferred();
-    const dataSource = that._dataSource;
+    const dataSource = this._dataSource;
 
     if (Array.isArray(key) || isNewRowTempKey(key)) {
       return deferred.resolve(-1).promise();
     }
 
-    let filter = that._generateFilterByKey(key);
+    let filter = this._generateFilterByKey(key);
 
     dataSource.load({
-      filter: that._concatWithCombinedFilter(filter),
+      filter: this._concatWithCombinedFilter(filter),
       skip: 0,
       take: 1,
     }).done((data) => {
+      if (this._dataSource !== dataSource) {
+        deferred.resolve(-1);
+        return;
+      }
       if (data.length > 0) {
-        filter = that._generateOperationFilterByKey(key, data[0], useGroup);
+        filter = this._generateOperationFilterByKey(key, data[0], useGroup);
         dataSource.load({
-          filter: that._concatWithCombinedFilter(filter, groupFilter),
+          filter: this._concatWithCombinedFilter(filter, groupFilter),
           skip: 0,
           take: 1,
           requireTotalCount: true,
         }).done((_, extra) => {
+          if (this._dataSource !== dataSource) {
+            deferred.resolve(-1);
+            return;
+          }
           deferred.resolve(extra.totalCount);
         });
       } else {

--- a/packages/devextreme/js/__internal/grids/tree_list/m_focus.ts
+++ b/packages/devextreme/js/__internal/grids/tree_list/m_focus.ts
@@ -98,21 +98,25 @@ const data = (
   }
 
   protected getPageIndexByKey(key) {
-    const that = this;
-    const dataSource = that._dataSource;
+    const dataSource = this._dataSource;
     // @ts-expect-error
     const d = new Deferred();
 
-    that.expandAscendants(key).done(() => {
+    this.expandAscendants(key).done(() => {
       dataSource.load({
         parentIds: [],
       }).done((nodes) => {
-        const offset = findIndex(nodes, (node) => that.keyOf(node.data) === key);
+        if (this._dataSource !== dataSource) {
+          d.resolve(-1);
+          return;
+        }
+
+        const offset = findIndex(nodes, (node) => this.keyOf(node.data) === key);
 
         let pageIndex = -1;
 
         if (offset >= 0) {
-          pageIndex = Math.floor(offset / that.pageSize());
+          pageIndex = Math.floor(offset / this.pageSize());
         }
 
         d.resolve(pageIndex);


### PR DESCRIPTION
### What
**DataGrid** no longer throws a `Cannot read properties of null (reading 'remoteOperations')` error when its data source is disposed or replaced while a focused-row navigation is still resolving (grids using `remoteOperations` together with `autoNavigateToFocusedRow`)

### How
The asynchronous row-index lookup now verifies that its data source is still the current one before continuing, and resolves as "row not found" instead of reading a disposed or swapped source
