### PR TITLE
chore(deps): update Chrome to 150.0.7871.181 in workflows

### DIFF
--- a/.github/workflows/playgrounds_tests.yml
+++ b/.github/workflows/playgrounds_tests.yml
@@ -133,7 +133,7 @@ jobs:
     - name: Setup Chrome
       uses: ./.github/actions/setup-chrome
       with:
-        chrome-version: '149.0.7827.114'
+        chrome-version: '150.0.7871.181'
 
     - name: Use Node.js
       uses: actions/setup-node@v6

--- a/.github/workflows/run-testcafe-on-gh-pages.yml
+++ b/.github/workflows/run-testcafe-on-gh-pages.yml
@@ -54,7 +54,7 @@ jobs:
             - name: Setup Chrome
               uses: ./devextreme/.github/actions/setup-chrome
               with:
-                chrome-version: '149.0.7827.114'
+                chrome-version: '150.0.7871.181'
 
             - uses: pnpm/action-setup@v6
               with:

--- a/.github/workflows/testcafe_tests.yml
+++ b/.github/workflows/testcafe_tests.yml
@@ -298,7 +298,7 @@ jobs:
     - name: Setup Chrome
       uses: ./.github/actions/setup-chrome
       with:
-        chrome-version: '149.0.7827.114'
+        chrome-version: '150.0.7871.181'
 
     - name: Use Node.js
       uses: actions/setup-node@v6
@@ -427,7 +427,7 @@ jobs:
     - name: Setup Chrome
       uses: ./.github/actions/setup-chrome
       with:
-        chrome-version: '149.0.7827.114'
+        chrome-version: '150.0.7871.181'
 
     - name: Use Node.js
       uses: actions/setup-node@v6

--- a/.github/workflows/visual-tests-demos.yml
+++ b/.github/workflows/visual-tests-demos.yml
@@ -706,7 +706,7 @@ jobs:
     - name: Setup Chrome
       uses: ./.github/actions/setup-chrome
       with:
-        chrome-version: '149.0.7827.114'
+        chrome-version: '150.0.7871.181'
 
     - name: Use Node.js
       uses: actions/setup-node@v6
@@ -873,7 +873,7 @@ jobs:
     - name: Setup Chrome
       uses: ./.github/actions/setup-chrome
       with:
-        chrome-version: '149.0.7827.114'
+        chrome-version: '150.0.7871.181'
 
     - name: Use Node.js
       uses: actions/setup-node@v6
@@ -1002,7 +1002,7 @@ jobs:
       - name: Setup Chrome
         uses: ./.github/actions/setup-chrome
         with:
-          chrome-version: '149.0.7827.114'
+          chrome-version: '150.0.7871.181'
 
       - name: Use Node.js
         uses: actions/setup-node@v6
@@ -1183,7 +1183,7 @@ jobs:
     - name: Setup Chrome
       uses: ./.github/actions/setup-chrome
       with:
-        chrome-version: '149.0.7827.114'
+        chrome-version: '150.0.7871.181'
 
     - name: Use Node.js
       uses: actions/setup-node@v6
@@ -1266,7 +1266,7 @@ jobs:
     - name: Setup Chrome
       uses: ./.github/actions/setup-chrome
       with:
-        chrome-version: '149.0.7827.114'
+        chrome-version: '150.0.7871.181'
 
     - name: Use Node.js
       uses: actions/setup-node@v6

--- a/.github/workflows/wrapper_tests.yml
+++ b/.github/workflows/wrapper_tests.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Download Browser
         if: matrix.framework == 'angular'
         run: |
-          PUPPETEER_CMD="browsers install chrome@149.0.7827.22"
+          PUPPETEER_CMD="browsers install chrome@150.0.7871.124"
           pnpm --filter devextreme-angular exec puppeteer $PUPPETEER_CMD
 
       - name: Test ${{ matrix.framework }}

--- a/.github/workflows/wrapper_tests_e2e.yml
+++ b/.github/workflows/wrapper_tests_e2e.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Setup Chrome
         uses: ./.github/actions/setup-chrome
         with:
-          chrome-version: '149.0.7827.114'
+          chrome-version: '150.0.7871.181'
 
       - name: Use Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
I updated the pinned Chrome version used in CI, per Tribe Duty (major upgrades only, applied to the three most recent branches).

Two separate Chrome pins are bumped, from two different sources:
- **Workflow `chrome-version:` pins** (stable channel, installed via .deb): `149.0.7827.114` → `150.0.7871.181` — the current Linux stable. Files: `testcafe_tests.yml`, `visual-tests-demos.yml`, `playgrounds_tests.yml`, `run-testcafe-on-gh-pages.yml`, `wrapper_tests_e2e.yml`.
- **Angular wrapper tests Puppeteer pin** (`wrapper_tests.yml`, installed from the Chrome for Testing catalog): `149.0.7827.22` → `150.0.7871.124`. The stable build `.181` is intentionally *not* used here — it does not exist in the Chrome for Testing catalog; `150.0.7871.124` is the newest available 150.x build there (verified downloadable for linux64). Only the major version needs to match across CI.

This second pin uses a different versioning scheme and is not tracked by Renovate's `chrome-version` regex manager, so it was updated manually.

Done manually rather than via the Dependency Dashboard `update dependency chrome` checkbox, because Renovate has been inactive since June 16 (no open PRs, dashboard issue gone) — worth a separate card for the Infrastructure squad.

**No etalon updates needed** — Chrome 150 introduced no rendering changes; all screenshot/visual-test jobs pass.

Follow-up after all three merge: bump preinstalled Chrome on the self-hosted runner (`devextreme-shr2` Dockerfile).