### PR TITLE
T1307499 - TreeList – Editing the parentIdExpr column causes the row to disappear if the column has setCellValue

### DIFF
--- a/e2e/testcafe-devextreme/tests/common/treeList/editing/editing.ts
+++ b/e2e/testcafe-devextreme/tests/common/treeList/editing/editing.ts
@@ -58,3 +58,46 @@ test('TreeList - Insertafterkey doesn\'t work on children nodes', async (t) => {
     }
   },
 }));
+
+// T1307499
+test('TreeList - New row should stay visible after editing the parentId column with setCellValue', async (t) => {
+  const treeList = new TreeList('#container');
+  const addRowButton = treeList.getHeaderPanel().getAddRowButton();
+
+  await t.expect(treeList.isReady()).ok();
+
+  await t.click(addRowButton);
+
+  const newRow = treeList.getDataRow(0);
+  const parentIdCellEditor = newRow.getDataCell(1).getEditor();
+
+  await t
+    .expect(newRow.isInserted).ok()
+    .expect(parentIdCellEditor.element.value)
+    .eql('0')
+    .expect(treeList.dataRows.count)
+    .eql(2);
+
+  await t
+    .typeText(parentIdCellEditor.element, '1', { replace: true })
+    .pressKey('tab');
+
+  await t
+    .expect(parentIdCellEditor.element.value)
+    .eql('1')
+    .expect(treeList.dataRows.count)
+    .eql(2);
+}).before(async () => createWidget('dxTreeList', {
+  dataSource: [{ id: 1, parentId: 0, text: 'item 1' }],
+  keyExpr: 'id',
+  parentIdExpr: 'parentId',
+  editing: {
+    allowAdding: true,
+  },
+  columns: ['id', {
+    dataField: 'parentId',
+    setCellValue(newData, value) {
+      newData.parentId = value;
+    },
+  }, 'text'],
+}));

--- a/e2e/testcafe-devextreme/tests/common/treeList/editing/editing.ts
+++ b/e2e/testcafe-devextreme/tests/common/treeList/editing/editing.ts
@@ -59,8 +59,7 @@ test('TreeList - Insertafterkey doesn\'t work on children nodes', async (t) => {
   },
 }));
 
-// T1307499
-test('TreeList - New row should stay visible after editing the parentId column with setCellValue', async (t) => {
+test('TreeList - New row should stay visible after editing the parentId column with setCellValue (T1307499)', async (t) => {
   const treeList = new TreeList('#container');
   const addRowButton = treeList.getHeaderPanel().getAddRowButton();
 

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
@@ -859,7 +859,10 @@ class EditingControllerImpl extends modules.ViewController {
   }
 
   private _createInsertInfo(parentKey?: RowKey): InsertInfo {
-    return { [INSERT_INDEX]: this._getInsertIndex(), parentKey };
+    return {
+      [INSERT_INDEX]: this._getInsertIndex(),
+      parentKey,
+    };
   }
 
   private _addInsertInfo(

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
@@ -277,7 +277,7 @@ class EditingControllerImpl extends modules.ViewController {
     }
   }
 
-  private _getInternalData(key: RowKey): InternalEditData | undefined {
+  protected _getInternalData(key: RowKey): InternalEditData | undefined {
     return this._internalState.get(getKeyHash(key));
   }
 
@@ -858,8 +858,8 @@ class EditingControllerImpl extends modules.ViewController {
     }
   }
 
-  private _createInsertInfo(): InsertInfo {
-    return { [INSERT_INDEX]: this._getInsertIndex() };
+  private _createInsertInfo(parentKey?: RowKey): InsertInfo {
+    return { [INSERT_INDEX]: this._getInsertIndex(), parentKey };
   }
 
   private _addInsertInfo(
@@ -877,7 +877,7 @@ class EditingControllerImpl extends modules.ViewController {
     if (!isDefined(insertInfo)) {
       const insertAfterOrBeforeKey = this._getInsertAfterOrBeforeKey(change);
 
-      insertInfo = this._createInsertInfo();
+      insertInfo = this._createInsertInfo(parentKey);
 
       if (!isDefined(insertAfterOrBeforeKey)) {
         this._setInsertAfterOrBeforeKey(change, parentKey);

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/types.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/types.ts
@@ -15,6 +15,7 @@ export interface NormalizedEditCellOptions {
 
 export interface InsertInfo {
   [INSERT_INDEX]: number;
+  parentKey?: RowKey;
 }
 
 export interface InternalEditData {

--- a/packages/devextreme/js/__internal/grids/tree_list/editing/__tests__/parent_id_set_cell_value.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/tree_list/editing/__tests__/parent_id_set_cell_value.integration.test.ts
@@ -43,11 +43,12 @@ describe('TreeList editing parentIdExpr column', () => {
   });
 
   // T1307499
-  it('should keep the new row visible after editing the parentId column with setCellValue', async () => {
+  it.each([0, null])('should keep the new row visible after editing the parentId column with setCellValue (rootValue: %p)', async (rootValue) => {
     const { component, instance } = createTreeList({
-      dataSource: [{ id: 1, parentId: 0, text: 'item 1' }],
+      dataSource: [{ id: 1, parentId: rootValue, text: 'item 1' }],
       keyExpr: 'id',
       parentIdExpr: 'parentId',
+      rootValue,
       editing: {
         allowAdding: true,
       },

--- a/packages/devextreme/js/__internal/grids/tree_list/editing/__tests__/parent_id_set_cell_value.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/tree_list/editing/__tests__/parent_id_set_cell_value.integration.test.ts
@@ -42,8 +42,7 @@ describe('TreeList editing parentIdExpr column', () => {
     jest.useRealTimers();
   });
 
-  // T1307499
-  it.each([0, null])('should keep the new row visible after editing the parentId column with setCellValue (rootValue: %p)', async (rootValue) => {
+  it.each([0, null])('T1307499 - new row stays visible after editing the parentId column with setCellValue (rootValue: %p)', async (rootValue) => {
     const { component, instance } = createTreeList({
       dataSource: [{ id: 1, parentId: rootValue, text: 'item 1' }],
       keyExpr: 'id',

--- a/packages/devextreme/js/__internal/grids/tree_list/editing/__tests__/parent_id_set_cell_value.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/tree_list/editing/__tests__/parent_id_set_cell_value.integration.test.ts
@@ -1,0 +1,76 @@
+import {
+  afterEach, beforeEach, describe, expect, it, jest,
+} from '@jest/globals';
+import $ from '@js/core/renderer';
+import type { Properties as TreeListProperties } from '@js/ui/tree_list';
+import TreeList from '@js/ui/tree_list';
+import { TreeListModel } from '@ts/grids/tree_list/__tests__/__mock__/model/tree_list';
+
+const TREELIST_CONTAINER_ID = 'treeListContainer';
+
+const flushAsync = async (): Promise<void> => {
+  jest.runAllTimers();
+  await Promise.resolve();
+};
+
+const createTreeList = (
+  options: TreeListProperties = {},
+): { component: TreeListModel; instance: TreeList } => {
+  const $container = $('<div>')
+    .attr('id', TREELIST_CONTAINER_ID)
+    .appendTo(document.body);
+
+  const instance = new TreeList($container.get(0) as HTMLDivElement, options);
+  const component = new TreeListModel($container.get(0) as HTMLElement);
+
+  jest.runAllTimers();
+
+  return { component, instance };
+};
+
+describe('TreeList editing parentIdExpr column', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    const $container = $(`#${TREELIST_CONTAINER_ID}`);
+
+    (TreeList.getInstance($container.get(0) as HTMLElement) as TreeList)?.dispose();
+    $container.remove();
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  // T1307499
+  it('should keep the new row visible after editing the parentId column with setCellValue', async () => {
+    const { component, instance } = createTreeList({
+      dataSource: [{ id: 1, parentId: 0, text: 'item 1' }],
+      keyExpr: 'id',
+      parentIdExpr: 'parentId',
+      editing: {
+        allowAdding: true,
+      },
+      columns: ['id', {
+        dataField: 'parentId',
+        setCellValue(newData, value): void {
+          newData.parentId = value;
+        },
+      }, 'text'],
+    });
+
+    await instance.addRow();
+    await flushAsync();
+
+    const newRowIndex = instance.getVisibleRows().findIndex((row) => row.isNewRow);
+
+    expect(newRowIndex).toBeGreaterThanOrEqual(0);
+    expect(component.getDataRows()).toHaveLength(2);
+
+    instance.cellValue(newRowIndex, 'parentId', 1);
+    await flushAsync();
+
+    expect(instance.getVisibleRows().some((row) => row.isNewRow)).toBe(true);
+    expect(component.getDataRows()).toHaveLength(2);
+  });
+});

--- a/packages/devextreme/js/__internal/grids/tree_list/editing/__tests__/parent_id_set_cell_value.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/tree_list/editing/__tests__/parent_id_set_cell_value.integration.test.ts
@@ -42,7 +42,7 @@ describe('TreeList editing parentIdExpr column', () => {
     jest.useRealTimers();
   });
 
-  it.each([0, null])('T1307499 - new row stays visible after editing the parentId column with setCellValue (rootValue: %p)', async (rootValue) => {
+  it.each([0, null])('new row should stay visible after editing the parentId column with setCellValue, rootValue %p (T1307499)', async (rootValue) => {
     const { component, instance } = createTreeList({
       dataSource: [{ id: 1, parentId: rootValue, text: 'item 1' }],
       keyExpr: 'id',

--- a/packages/devextreme/js/__internal/grids/tree_list/editing/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/tree_list/editing/m_editing.ts
@@ -50,21 +50,22 @@ class EditingController extends editingModule.controllers.editing {
     }
   }
 
-  protected _getLoadedRowIndex(items, change) {
+  protected _getLoadedRowIndex(items, change, isProcessedItems?) {
     const dataSourceAdapter = this._dataController.dataSource();
-    const parentKey = dataSourceAdapter?.parentKeyOf(change.data);
+    const insertParentKey = this._getInternalData(change.key)?.insertInfo?.parentKey;
+    const parentKey = isDefined(insertParentKey)
+      ? insertParentKey
+      : dataSourceAdapter?.parentKeyOf(change.data);
 
     if (parentKey !== undefined && parentKey !== this.option('rootValue')) {
       const rowIndex = gridCoreUtils.getIndexByKey(parentKey, items);
       // @ts-expect-error
-      if (rowIndex >= 0 && this._dataController.isRowExpanded(parentKey)) {
-        // @ts-expect-error
-        return super._getLoadedRowIndex.apply(this, arguments);
+      if (!(rowIndex >= 0 && this._dataController.isRowExpanded(parentKey))) {
+        return -1;
       }
-      return -1;
     }
-    // @ts-expect-error
-    return super._getLoadedRowIndex.apply(this, arguments);
+
+    return super._getLoadedRowIndex(items, change, isProcessedItems);
   }
 
   protected _isEditColumnVisible() {

--- a/packages/devextreme/js/__internal/grids/tree_list/editing/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/tree_list/editing/m_editing.ts
@@ -53,7 +53,7 @@ class EditingController extends editingModule.controllers.editing {
   protected _getLoadedRowIndex(items, change, isProcessedItems?) {
     const dataSourceAdapter = this._dataController.dataSource();
     const insertParentKey = this._getInternalData(change.key)?.insertInfo?.parentKey;
-    const parentKey = isDefined(insertParentKey)
+    const parentKey = insertParentKey !== undefined
       ? insertParentKey
       : dataSourceAdapter?.parentKeyOf(change.data);
 


### PR DESCRIPTION
### What
New rows in **TreeList** now stay visible when you edit the parent id column that uses a `setCellValue` handler

### How
The parent key is captured when the row is added and reused when deciding whether the row is shown, instead of re-reading the value from the cell being edited