### PR TITLE
 WG Demos - Update editorType/widget import statements in components

### DIFF
--- a/apps/demos/Demos/Common/FormsOverview/Angular/app/app.component.ts
+++ b/apps/demos/Demos/Common/FormsOverview/Angular/app/app.component.ts
@@ -1,12 +1,10 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { Component, enableProdMode, provideZoneChangeDetection } from '@angular/core';
 import {
-  DxSelectBoxModule,
-  DxTextAreaModule,
-  DxDateBoxModule,
   DxFormModule,
 } from 'devextreme-angular';
-
+import 'devextreme/ui/select_box';
+import 'devextreme/ui/text_area';
 import { Service, Employee } from './app.service';
 
 if (!/localhost/.test(document.location.host)) {
@@ -25,9 +23,6 @@ if (window && window.config?.packageConfigPaths) {
   templateUrl: `.${modulePrefix}/app.component.html`,
   styleUrls: [`.${modulePrefix}/app.component.css`],
   imports: [
-    DxSelectBoxModule,
-    DxTextAreaModule,
-    DxDateBoxModule,
     DxFormModule,
   ],
 })

--- a/apps/demos/Demos/Common/FormsOverview/React/App.tsx
+++ b/apps/demos/Demos/Common/FormsOverview/React/App.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import {
   Form, GroupItem, Label, SimpleItem,
 } from 'devextreme-react/form';
-import 'devextreme-react/text-area';
+import 'devextreme/ui/select_box';
+import 'devextreme/ui/text_area';
 
 import { employee, positions, states } from './data.ts';
 

--- a/apps/demos/Demos/Common/FormsOverview/ReactJs/App.js
+++ b/apps/demos/Demos/Common/FormsOverview/ReactJs/App.js
@@ -2,7 +2,8 @@ import React from 'react';
 import {
   Form, GroupItem, Label, SimpleItem,
 } from 'devextreme-react/form';
-import 'devextreme-react/text-area';
+import 'devextreme/ui/select_box';
+import 'devextreme/ui/text_area';
 import { employee, positions, states } from './data.js';
 
 const birthDateOptions = { width: '100%' };

--- a/apps/demos/Demos/Common/FormsOverview/Vue/App.vue
+++ b/apps/demos/Demos/Common/FormsOverview/Vue/App.vue
@@ -61,7 +61,8 @@ import {
   DxGroupItem,
   DxLabel,
 } from 'devextreme-vue/form';
-import { DxTextArea } from 'devextreme-vue/text-area'; // needs for editor-type="dxTextArea"
+import 'devextreme/ui/select_box';
+import 'devextreme/ui/text_area';
 import { employee, positions, states } from './data.ts';
 
 const formData = employee;

--- a/apps/demos/Demos/Form/ItemCustomization/Angular/app/app.component.ts
+++ b/apps/demos/Demos/Form/ItemCustomization/Angular/app/app.component.ts
@@ -7,12 +7,12 @@ import {
   provideZoneChangeDetection,
 } from '@angular/core';
 import {
-  DxSelectBoxModule,
-  DxTextAreaModule,
   DxFormModule,
   DxFormComponent,
   DxTooltipModule,
 } from 'devextreme-angular';
+import 'devextreme/ui/select_box';
+import 'devextreme/ui/text_area';
 
 import { Employee, Service } from './app.service';
 
@@ -32,8 +32,6 @@ if (window && window.config?.packageConfigPaths) {
   templateUrl: `.${modulePrefix}/app.component.html`,
   styleUrls: [`.${modulePrefix}/app.component.css`],
   imports: [
-    DxSelectBoxModule,
-    DxTextAreaModule,
     DxFormModule,
     DxTooltipModule,
   ],

--- a/apps/demos/Demos/Form/ItemCustomization/React/App.tsx
+++ b/apps/demos/Demos/Form/ItemCustomization/React/App.tsx
@@ -11,7 +11,8 @@ import type { ITextBoxOptions } from 'devextreme-react/text-box';
 import type { ISelectBoxOptions } from 'devextreme-react/select-box';
 import type { IDateBoxOptions } from 'devextreme-react/date-box';
 import type { ITextAreaOptions } from 'devextreme-react/text-area';
-import 'devextreme-react/text-area';
+import 'devextreme/ui/select_box';
+import 'devextreme/ui/text_area';
 
 import { employee, positions } from './data.ts';
 

--- a/apps/demos/Demos/Form/ItemCustomization/ReactJs/App.js
+++ b/apps/demos/Demos/Form/ItemCustomization/ReactJs/App.js
@@ -2,7 +2,8 @@ import React, { useCallback } from 'react';
 import {
   Form, Item, GroupItem, Label,
 } from 'devextreme-react/form';
-import 'devextreme-react/text-area';
+import 'devextreme/ui/select_box';
+import 'devextreme/ui/text_area';
 import { employee, positions } from './data.js';
 import LabelTemplate from './LabelTemplate.js';
 import LabelNotesTemplate from './LabelNotesTemplate.js';

--- a/apps/demos/Demos/Form/ItemCustomization/Vue/App.vue
+++ b/apps/demos/Demos/Form/ItemCustomization/Vue/App.vue
@@ -121,7 +121,8 @@ import {
 } from 'devextreme-vue/form';
 import { type ValidationRule } from 'devextreme-vue/common';
 import service from './data.ts';
-import 'devextreme-vue/text-area';
+import 'devextreme/ui/select_box';
+import 'devextreme/ui/text_area';
 
 import LabelTemplate from './LabelTemplate.vue';
 import LabelNotesTemplate from './LabelNotesTemplate.vue';

--- a/apps/demos/Demos/Stepper/FormIntegration/Angular/app/additional-form/additional-form.component.ts
+++ b/apps/demos/Demos/Stepper/FormIntegration/Angular/app/additional-form/additional-form.component.ts
@@ -1,7 +1,8 @@
 import { Component, Input } from '@angular/core';
-import { DxFormModule, DxTextAreaModule } from 'devextreme-angular';
+import { DxFormModule } from 'devextreme-angular';
 import { type DxFormTypes } from 'devextreme-angular/ui/form';
 import { type DxTextAreaTypes } from 'devextreme-angular/ui/text-area';
+import 'devextreme/ui/text_area';
 import type { BookingFormData } from '../app.types';
 
 let modulePrefix = '';
@@ -15,7 +16,6 @@ if (window && window.config?.packageConfigPaths) {
   templateUrl: `.${modulePrefix}/additional-form/additional-form.component.html`,
   imports: [
     DxFormModule,
-    DxTextAreaModule,
   ],
 })
 export class AdditionalFormComponent {

--- a/apps/demos/Demos/Stepper/FormIntegration/Angular/app/dates-form/dates-form.component.ts
+++ b/apps/demos/Demos/Stepper/FormIntegration/Angular/app/dates-form/dates-form.component.ts
@@ -1,7 +1,8 @@
 import { Component, Input, SimpleChanges, ViewChild } from '@angular/core';
-import { DxFormModule, DxDateRangeBoxModule } from 'devextreme-angular';
+import { DxFormModule } from 'devextreme-angular';
 import { DxFormComponent, type DxFormTypes } from 'devextreme-angular/ui/form';
 import { type DxDateRangeBoxTypes } from 'devextreme-angular/ui/date-range-box';
+import 'devextreme/ui/date_range_box';
 import type { BookingFormData } from '../app.types';
 
 let modulePrefix = '';
@@ -15,7 +16,6 @@ if (window && window.config?.packageConfigPaths) {
   templateUrl: `.${modulePrefix}/dates-form/dates-form.component.html`,
   imports: [
     DxFormModule,
-    DxDateRangeBoxModule,
   ],
 })
 export class DatesFormComponent {

--- a/apps/demos/Demos/Stepper/FormIntegration/Angular/app/guests-form/guests-form.component.ts
+++ b/apps/demos/Demos/Stepper/FormIntegration/Angular/app/guests-form/guests-form.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, SimpleChanges, ViewChild } from '@angular/core';
-import { DxFormModule, DxNumberBoxModule } from 'devextreme-angular';
+import { DxFormModule } from 'devextreme-angular';
 import { DxFormComponent, type DxFormTypes } from 'devextreme-angular/ui/form';
 import { type DxNumberBoxTypes } from 'devextreme-angular/ui/number-box';
 import type { BookingFormData } from '../app.types';
@@ -15,7 +15,6 @@ if (window && window.config?.packageConfigPaths) {
   templateUrl: `.${modulePrefix}/guests-form/guests-form.component.html`,
   imports: [
     DxFormModule,
-    DxNumberBoxModule,
   ],
 })
 export class GuestsFormComponent {

--- a/apps/demos/Demos/Stepper/FormIntegration/Angular/app/room-meal-plan-form/room-meal-plan-form.component.ts
+++ b/apps/demos/Demos/Stepper/FormIntegration/Angular/app/room-meal-plan-form/room-meal-plan-form.component.ts
@@ -1,7 +1,8 @@
 import { Component, Input, SimpleChanges, ViewChild } from '@angular/core';
-import { DxFormModule, DxSelectBoxModule } from 'devextreme-angular';
+import { DxFormModule } from 'devextreme-angular';
 import { DxFormComponent, type DxFormTypes } from 'devextreme-angular/ui/form';
 import { type DxSelectBoxTypes } from 'devextreme-angular/ui/select-box';
+import 'devextreme/ui/select_box';
 import type { BookingFormData } from '../app.types';
 
 let modulePrefix = '';
@@ -15,7 +16,6 @@ if (window && window.config?.packageConfigPaths) {
   templateUrl: `.${modulePrefix}/room-meal-plan-form/room-meal-plan-form.component.html`,
   imports: [
     DxFormModule,
-    DxSelectBoxModule,
   ],
 })
 export class RoomMealPlanFormComponent {

--- a/apps/demos/Demos/Stepper/FormIntegration/React/AdditionalForm.tsx
+++ b/apps/demos/Demos/Stepper/FormIntegration/React/AdditionalForm.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
 import type { FC } from 'react';
-import 'devextreme-react/text-area';
+import 'devextreme/ui/text_area';
 import { Form, SimpleItem } from 'devextreme-react/form';
 
 import type { FormProps } from './types.ts';

--- a/apps/demos/Demos/Stepper/FormIntegration/React/Confirmation.tsx
+++ b/apps/demos/Demos/Stepper/FormIntegration/React/Confirmation.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import type { FC } from 'react';
-import 'devextreme-react/date-range-box';
 
 import type { BookingFormData } from './types.ts';
 

--- a/apps/demos/Demos/Stepper/FormIntegration/React/DatesForm.tsx
+++ b/apps/demos/Demos/Stepper/FormIntegration/React/DatesForm.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
 import type { FC } from 'react';
-import 'devextreme-react/date-range-box';
+import 'devextreme/ui/date_range_box';
 import { Form, SimpleItem } from 'devextreme-react/form';
 
 import type { FormProps } from './types.ts';

--- a/apps/demos/Demos/Stepper/FormIntegration/React/GuestsForm.tsx
+++ b/apps/demos/Demos/Stepper/FormIntegration/React/GuestsForm.tsx
@@ -1,7 +1,6 @@
 import React, { memo } from 'react';
 import type { FC } from 'react';
 import { Form, RangeRule, SimpleItem } from 'devextreme-react/form';
-import 'devextreme-react/number-box';
 
 import type { FormProps } from './types.ts';
 

--- a/apps/demos/Demos/Stepper/FormIntegration/React/RoomMealPlanForm.tsx
+++ b/apps/demos/Demos/Stepper/FormIntegration/React/RoomMealPlanForm.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
 import type { FC } from 'react';
-import 'devextreme-react/select-box';
+import 'devextreme/ui/select_box';
 import { Form, SimpleItem } from 'devextreme-react/form';
 
 import type { FormProps } from './types.ts';

--- a/apps/demos/Demos/Stepper/FormIntegration/ReactJs/AdditionalForm.js
+++ b/apps/demos/Demos/Stepper/FormIntegration/ReactJs/AdditionalForm.js
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import 'devextreme-react/text-area';
+import 'devextreme/ui/text_area';
 import { Form, SimpleItem } from 'devextreme-react/form';
 
 const AdditionalForm = memo(({ formData }) => (

--- a/apps/demos/Demos/Stepper/FormIntegration/ReactJs/Confirmation.js
+++ b/apps/demos/Demos/Stepper/FormIntegration/ReactJs/Confirmation.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import 'devextreme-react/date-range-box';
 
 const Confirmation = ({ formData, isConfirmed }) => {
   if (isConfirmed) {

--- a/apps/demos/Demos/Stepper/FormIntegration/ReactJs/DatesForm.js
+++ b/apps/demos/Demos/Stepper/FormIntegration/ReactJs/DatesForm.js
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import 'devextreme-react/date-range-box';
+import 'devextreme/ui/date_range_box';
 import { Form, SimpleItem } from 'devextreme-react/form';
 
 const DatesForm = memo(({ formData, validationGroup }) => (

--- a/apps/demos/Demos/Stepper/FormIntegration/ReactJs/GuestsForm.js
+++ b/apps/demos/Demos/Stepper/FormIntegration/ReactJs/GuestsForm.js
@@ -1,6 +1,5 @@
 import React, { memo } from 'react';
 import { Form, RangeRule, SimpleItem } from 'devextreme-react/form';
-import 'devextreme-react/number-box';
 
 const GuestsForm = memo(({ formData, validationGroup }) => (
   <>

--- a/apps/demos/Demos/Stepper/FormIntegration/ReactJs/RoomMealPlanForm.js
+++ b/apps/demos/Demos/Stepper/FormIntegration/ReactJs/RoomMealPlanForm.js
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import 'devextreme-react/select-box';
+import 'devextreme/ui/select_box';
 import { Form, SimpleItem } from 'devextreme-react/form';
 import { mealPlans, roomTypes } from './data.js';
 

--- a/apps/demos/Demos/Stepper/FormIntegration/Vue/AdditionalTemplate.vue
+++ b/apps/demos/Demos/Stepper/FormIntegration/Vue/AdditionalTemplate.vue
@@ -14,7 +14,7 @@
 
 <script setup lang="ts">
 import { DxForm, DxSimpleItem } from 'devextreme-vue/form';
-import 'devextreme-vue/text-area';
+import 'devextreme/ui/text_area';
 import type { BookingFormData } from './types.ts';
 import { initialFormData } from './data.ts';
 

--- a/apps/demos/Demos/Stepper/FormIntegration/Vue/DatesTemplate.vue
+++ b/apps/demos/Demos/Stepper/FormIntegration/Vue/DatesTemplate.vue
@@ -21,7 +21,7 @@
 
 <script setup lang="ts">
 import DxForm, { DxSimpleItem } from 'devextreme-vue/form';
-import 'devextreme-vue/date-range-box';
+import 'devextreme/ui/date_range_box';
 import { ref, watch } from 'vue';
 import type { BookingFormData } from './types.ts';
 import { getInitialFormData } from './data.ts';

--- a/apps/demos/Demos/Stepper/FormIntegration/Vue/GuestsTemplate.vue
+++ b/apps/demos/Demos/Stepper/FormIntegration/Vue/GuestsTemplate.vue
@@ -36,7 +36,6 @@
 
 <script setup lang="ts">
 import { DxForm, DxRangeRule, DxSimpleItem } from 'devextreme-vue/form';
-import 'devextreme-vue/number-box';
 import { watch, ref } from 'vue';
 import type { BookingFormData } from './types.ts';
 import { getInitialFormData } from './data.ts';

--- a/apps/demos/Demos/Stepper/FormIntegration/Vue/RoomMealPlanTemplate.vue
+++ b/apps/demos/Demos/Stepper/FormIntegration/Vue/RoomMealPlanTemplate.vue
@@ -29,7 +29,7 @@
 
 <script setup lang="ts">
 import DxForm, { DxSimpleItem } from 'devextreme-vue/form';
-import 'devextreme-vue/select-box';
+import 'devextreme/ui/select_box';
 import { watch, ref } from 'vue';
 import type { BookingFormData } from './types.ts';
 import { roomTypes, mealPlans, getInitialFormData } from './data.ts';

--- a/apps/demos/Demos/Toolbar/Overview/Angular/app/app.component.ts
+++ b/apps/demos/Demos/Toolbar/Overview/Angular/app/app.component.ts
@@ -1,6 +1,7 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { Component, enableProdMode, provideZoneChangeDetection } from '@angular/core';
-import { DxListModule, DxToolbarModule, DxSelectBoxModule } from 'devextreme-angular';
+import { DxListModule, DxToolbarModule } from 'devextreme-angular';
+import 'devextreme/ui/select_box';
 import { DataSource } from 'devextreme-angular/common/data';
 import notify from 'devextreme/ui/notify';
 import type { DxButtonTypes } from 'devextreme-angular/ui/button';
@@ -25,7 +26,6 @@ if (window && window.config?.packageConfigPaths) {
   imports: [
     DxListModule,
     DxToolbarModule,
-    DxSelectBoxModule,
   ],
 })
 export class AppComponent {


### PR DESCRIPTION
**What does the PR change?**

1. Updates the editorType and widget import statements in components-related widget demos to use the correct module references.

**How did you achieve this?**
1. Reviewed the navigation-related widget demos that use editorType and widget imports.
2. Updated the import statements to align with the current module structure and import conventions.
3. Verified that the affected demos compile and load successfully after the changes.

**How can we verify these changes?**
1. Build and run the WG Demos project.
2. Open the navigation and editors related widget demos.
3. Confirm that the demos render correctly without import or module resolution errors.
5. Verify that all navigation-related widgets function as expected