### PR TITLE
T1332912 - DataGrid - Focused row indicator is duplicated when navigating between grouped rows with repaintChangesOnly

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.integration.test.ts
@@ -261,7 +261,7 @@ describe('GridCore focus', () => {
     };
 
     const countFocusedRows = (): number => document
-      .querySelectorAll('.dx-data-row.dx-row-focused').length;
+      .querySelectorAll(`#${GRID_CONTAINER_ID} .dx-row.dx-row-focused`).length;
 
     it('should keep a single focused row indicator (T1332912)', async () => {
       const { instance } = await createDataGrid({

--- a/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.integration.test.ts
@@ -7,7 +7,7 @@ import type { StoreChange } from '@js/data/store';
 import DataGrid from '@js/ui/data_grid';
 
 import {
-  afterTest, beforeTest, createDataGrid, type DataGridInstance, flushAsync, GRID_CONTAINER_ID,
+  afterTest, beforeTest, createDataGrid, flushAsync, GRID_CONTAINER_ID,
 } from '../__tests__/__mock__/helpers/utils';
 
 describe('GridCore focus', () => {
@@ -253,18 +253,8 @@ describe('GridCore focus', () => {
   });
 
   describe('when focusedRowKey is set to a row inside a collapsed group with repaintChangesOnly', () => {
-    const flushUntil = async (predicate: () => boolean): Promise<void> => {
-      for (let attempt = 0; attempt < 20 && !predicate(); attempt += 1) {
-        // eslint-disable-next-line no-await-in-loop
-        await flushAsync();
-      }
-    };
-
     const countFocusedRows = (): number => document
       .querySelectorAll(`#${GRID_CONTAINER_ID} .dx-row.dx-row-focused`).length;
-
-    const isRowVisible = (instance: DataGridInstance, key: number): boolean => instance
-      .getVisibleRows().some((row) => row.key === key);
 
     it('should keep a single focused row indicator (T1332912)', async () => {
       const { instance } = await createDataGrid({
@@ -292,12 +282,10 @@ describe('GridCore focus', () => {
         ],
       });
 
-      await flushUntil(() => isRowVisible(instance, 1) && countFocusedRows() === 1);
-
       expect(countFocusedRows()).toBe(1);
 
       instance.option('focusedRowKey', 9);
-      await flushUntil(() => isRowVisible(instance, 9) && countFocusedRows() === 1);
+      await flushAsync();
 
       expect(instance.option('focusedRowKey')).toBe(9);
       expect(countFocusedRows()).toBe(1);

--- a/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.integration.test.ts
@@ -251,4 +251,53 @@ describe('GridCore focus', () => {
       expect(instance.option('focusedRowIndex')).toBe(9);
     });
   });
+
+  describe('when focusedRowKey is set to a row inside a collapsed group with repaintChangesOnly', () => {
+    const settle = async (): Promise<void> => {
+      for (let i = 0; i < 20; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await flushAsync();
+      }
+    };
+
+    const countFocusedRows = (): number => document
+      .querySelectorAll('.dx-data-row.dx-row-focused').length;
+
+    it('should keep a single focused row indicator (T1332912)', async () => {
+      const { instance } = await createDataGrid({
+        dataSource: {
+          store: {
+            type: 'array',
+            key: 'id',
+            data: [
+              { id: 1, name: 'Alice', department: 'Engineering' },
+              { id: 2, name: 'Bob', department: 'Engineering' },
+              { id: 3, name: 'Carol', department: 'Engineering' },
+              { id: 9, name: 'Ivy', department: 'Finance' },
+              { id: 10, name: 'Jack', department: 'Finance' },
+            ],
+          },
+        },
+        focusedRowEnabled: true,
+        focusedRowKey: 1,
+        repaintChangesOnly: true,
+        grouping: { autoExpandAll: false },
+        columns: [
+          'id',
+          'name',
+          { dataField: 'department', groupIndex: 0 },
+        ],
+      });
+
+      await settle();
+
+      expect(countFocusedRows()).toBe(1);
+
+      instance.option('focusedRowKey', 9);
+      await settle();
+
+      expect(instance.option('focusedRowKey')).toBe(9);
+      expect(countFocusedRows()).toBe(1);
+    });
+  });
 });

--- a/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.integration.test.ts
@@ -7,7 +7,7 @@ import type { StoreChange } from '@js/data/store';
 import DataGrid from '@js/ui/data_grid';
 
 import {
-  afterTest, beforeTest, createDataGrid, flushAsync, GRID_CONTAINER_ID,
+  afterTest, beforeTest, createDataGrid, type DataGridInstance, flushAsync, GRID_CONTAINER_ID,
 } from '../__tests__/__mock__/helpers/utils';
 
 describe('GridCore focus', () => {
@@ -253,8 +253,8 @@ describe('GridCore focus', () => {
   });
 
   describe('when focusedRowKey is set to a row inside a collapsed group with repaintChangesOnly', () => {
-    const settle = async (): Promise<void> => {
-      for (let i = 0; i < 20; i += 1) {
+    const flushUntil = async (predicate: () => boolean): Promise<void> => {
+      for (let attempt = 0; attempt < 20 && !predicate(); attempt += 1) {
         // eslint-disable-next-line no-await-in-loop
         await flushAsync();
       }
@@ -262,6 +262,9 @@ describe('GridCore focus', () => {
 
     const countFocusedRows = (): number => document
       .querySelectorAll(`#${GRID_CONTAINER_ID} .dx-row.dx-row-focused`).length;
+
+    const isRowVisible = (instance: DataGridInstance, key: number): boolean => instance
+      .getVisibleRows().some((row) => row.key === key);
 
     it('should keep a single focused row indicator (T1332912)', async () => {
       const { instance } = await createDataGrid({
@@ -289,12 +292,12 @@ describe('GridCore focus', () => {
         ],
       });
 
-      await settle();
+      await flushUntil(() => isRowVisible(instance, 1) && countFocusedRows() === 1);
 
       expect(countFocusedRows()).toBe(1);
 
       instance.option('focusedRowKey', 9);
-      await settle();
+      await flushUntil(() => isRowVisible(instance, 9) && countFocusedRows() === 1);
 
       expect(instance.option('focusedRowKey')).toBe(9);
       expect(countFocusedRows()).toBe(1);

--- a/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.ts
@@ -566,26 +566,33 @@ const data = (Base: ModuleType<DataController>) => class FocusDataControllerExte
 
     if (this.option('focusedRowEnabled') && this._dataSource) {
       const isPartialUpdate = e.changeType === 'update' && e.repaintChangesOnly;
-      const isPartialUpdateWithDeleting = isPartialUpdate && e.changeTypes && e.changeTypes.indexOf('remove') >= 0;
+      const isPartialUpdateWithDeleting = isPartialUpdate && !!e.changeTypes && e.changeTypes.indexOf('remove') >= 0;
+      const isRefreshWithItems = e.changeType === 'refresh' && !!e.items.length;
+      const isAppendOrPrepend = e.changeType === 'append' || e.changeType === 'prepend';
 
       if (forceUpdateFocusedRow && this.isEmpty()) {
         this._focusController._resetFocusedRow();
-      } else if (e.changeType === 'refresh' && e.items.length || isPartialUpdateWithDeleting) {
+      } else if (isRefreshWithItems || isPartialUpdateWithDeleting) {
         this._updatePageIndexes();
         this._updateFocusedRowIfNeeded(e, forceUpdateFocusedRow);
-      } else if (e.changeType === 'append' || e.changeType === 'prepend') {
+      } else if (isAppendOrPrepend) {
         this._updatePageIndexes();
       } else if (isPartialUpdate) {
         this._updateFocusedRowIfNeeded(e, forceUpdateFocusedRow);
-        this._reapplyFocusedRowAfterPartialUpdate();
+        this._reapplyFocusedRowAfterPartialUpdate(e);
       }
     }
   }
 
-  private _reapplyFocusedRowAfterPartialUpdate() {
+  private _reapplyFocusedRowAfterPartialUpdate(e: { rowIndices?: number[] }): void {
     const focusedRowKey = this.option('focusedRowKey');
+    const focusedRowIndex = this.getRowIndexByKey(focusedRowKey);
 
-    if (isDefined(focusedRowKey) && this.getRowIndexByKey(focusedRowKey) >= 0) {
+    const hasFocusedRowKey = isDefined(focusedRowKey);
+    const isFocusedRowVisible = focusedRowIndex >= 0;
+    const isFocusedRowInChange = !!e.rowIndices?.includes(focusedRowIndex);
+
+    if (hasFocusedRowKey && isFocusedRowVisible && isFocusedRowInChange) {
       this._focusController.updateFocusedRow({ focusedRowKey, preventScroll: true });
     }
   }

--- a/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.ts
@@ -586,13 +586,16 @@ const data = (Base: ModuleType<DataController>) => class FocusDataControllerExte
 
   private _reapplyFocusedRowAfterPartialUpdate(e: { rowIndices?: number[] }): void {
     const focusedRowKey = this.option('focusedRowKey');
-    const focusedRowIndex = this.getRowIndexByKey(focusedRowKey);
 
-    const hasFocusedRowKey = isDefined(focusedRowKey);
+    if (!isDefined(focusedRowKey)) {
+      return;
+    }
+
+    const focusedRowIndex = this.getRowIndexByKey(focusedRowKey);
     const isFocusedRowVisible = focusedRowIndex >= 0;
     const isFocusedRowInChange = !!e.rowIndices?.includes(focusedRowIndex);
 
-    if (hasFocusedRowKey && isFocusedRowVisible && isFocusedRowInChange) {
+    if (isFocusedRowVisible && isFocusedRowInChange) {
       this._focusController.updateFocusedRow({ focusedRowKey, preventScroll: true });
     }
   }

--- a/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.ts
@@ -577,7 +577,16 @@ const data = (Base: ModuleType<DataController>) => class FocusDataControllerExte
         this._updatePageIndexes();
       } else if (isPartialUpdate) {
         this._updateFocusedRowIfNeeded(e, forceUpdateFocusedRow);
+        this._reapplyFocusedRowAfterPartialUpdate();
       }
+    }
+  }
+
+  private _reapplyFocusedRowAfterPartialUpdate() {
+    const focusedRowKey = this.option('focusedRowKey');
+
+    if (isDefined(focusedRowKey) && this.getRowIndexByKey(focusedRowKey) >= 0) {
+      this._focusController.updateFocusedRow({ focusedRowKey, preventScroll: true });
     }
   }
 

--- a/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/focus/m_focus.ts
@@ -579,12 +579,14 @@ const data = (Base: ModuleType<DataController>) => class FocusDataControllerExte
         this._updatePageIndexes();
       } else if (isPartialUpdate) {
         this._updateFocusedRowIfNeeded(e, forceUpdateFocusedRow);
-        this._reapplyFocusedRowAfterPartialUpdate(e);
+        // on a partial render the previously focused row may not be re-rendered, so its
+        // focused class survives and two rows look focused; reset the focused row to drop it
+        this._resetStaleFocusedRowAfterPartialUpdate(e);
       }
     }
   }
 
-  private _reapplyFocusedRowAfterPartialUpdate(e: { rowIndices?: number[] }): void {
+  private _resetStaleFocusedRowAfterPartialUpdate(e: { rowIndices?: number[] }): void {
     const focusedRowKey = this.option('focusedRowKey');
 
     if (!isDefined(focusedRowKey)) {


### PR DESCRIPTION
### What
Fixed **DataGrid** showing two focused-row highlights at the same time when the focused row moves into a collapsed group while `repaintChangesOnly` is enabled

### How
After a partial update the grid now re-applies the focused-row highlight, so the previously highlighted row is cleared and only the current one stays highlighted