### PR TITLE
Cherry-pick #34560 to 26_1: WG Demos - Update editorType/widget import statements for Grid-related demos

### DIFF
--- a/apps/demos/Demos/CardView/DataValidation/Angular/app/app.component.ts
+++ b/apps/demos/Demos/CardView/DataValidation/Angular/app/app.component.ts
@@ -1,7 +1,8 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { HttpClient, provideHttpClient, withFetch } from '@angular/common/http';
 import { Component, enableProdMode, provideZoneChangeDetection } from '@angular/core';
-import { DxCardViewModule, DxTextAreaModule } from 'devextreme-angular';
+import { DxCardViewModule } from 'devextreme-angular';
+import 'devextreme/ui/text_area';
 import { lastValueFrom } from 'rxjs';
 import { Employee, Service } from './app.service';
 import 'anti-forgery';
@@ -22,7 +23,6 @@ if (window && window.config?.packageConfigPaths) {
   providers: [Service],
   imports: [
     DxCardViewModule,
-    DxTextAreaModule,
   ],
 })
 export class AppComponent {

--- a/apps/demos/Demos/CardView/DataValidation/React/App.tsx
+++ b/apps/demos/Demos/CardView/DataValidation/React/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import CardView, { Column, CardCover, Editing, SearchPanel, Form, Item, RequiredRule, EmailRule, AsyncRule, CustomRule } from 'devextreme-react/card-view';
+import 'devextreme/ui/text_area';
 import type { ValidationCallbackData } from 'devextreme-react/common';
 
 import { employees } from './data.ts';

--- a/apps/demos/Demos/CardView/DataValidation/ReactJs/App.js
+++ b/apps/demos/Demos/CardView/DataValidation/ReactJs/App.js
@@ -11,6 +11,7 @@ import CardView, {
   AsyncRule,
   CustomRule,
 } from 'devextreme-react/card-view';
+import 'devextreme/ui/text_area';
 import { employees } from './data.js';
 
 function altExpr({ fullName }) {

--- a/apps/demos/Demos/CardView/DataValidation/Vue/App.vue
+++ b/apps/demos/Demos/CardView/DataValidation/Vue/App.vue
@@ -174,7 +174,7 @@ import {
   DxAsyncRule, DxCustomRule,
 } from 'devextreme-vue/card-view';
 import { type ValidationCallbackData } from 'devextreme-vue/common';
-import 'devextreme-vue/text-area';
+import 'devextreme/ui/text_area';
 import { employees, type Employee } from './data.ts';
 
 function altExpr({ fullName }: Employee): string {

--- a/apps/demos/Demos/CardView/PopupEditing/Angular/app/app.component.ts
+++ b/apps/demos/Demos/CardView/PopupEditing/Angular/app/app.component.ts
@@ -1,6 +1,7 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { Component, enableProdMode, provideZoneChangeDetection } from '@angular/core';
-import { DxCardViewModule, DxTextAreaModule } from 'devextreme-angular';
+import { DxCardViewModule } from 'devextreme-angular';
+import 'devextreme/ui/text_area';
 import { Employee, Service } from './app.service';
 
 if (!/localhost/.test(document.location.host)) {
@@ -19,7 +20,6 @@ if (window && window.config?.packageConfigPaths) {
   providers: [Service],
   imports: [
     DxCardViewModule,
-    DxTextAreaModule,
   ],
 })
 export class AppComponent {

--- a/apps/demos/Demos/CardView/PopupEditing/React/App.tsx
+++ b/apps/demos/Demos/CardView/PopupEditing/React/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import CardView, { Column, CardCover, Editing, SearchPanel, Form, Item } from 'devextreme-react/card-view';
-import 'devextreme-react/text-area';
+import 'devextreme/ui/text_area';
 
 import { employees } from './data.ts';
 import type { Employee } from './data.ts';

--- a/apps/demos/Demos/CardView/PopupEditing/ReactJs/App.js
+++ b/apps/demos/Demos/CardView/PopupEditing/ReactJs/App.js
@@ -7,7 +7,7 @@ import CardView, {
   Form,
   Item,
 } from 'devextreme-react/card-view';
-import 'devextreme-react/text-area';
+import 'devextreme/ui/text_area';
 import { employees } from './data.js';
 
 function altExpr({ fullName }) {

--- a/apps/demos/Demos/CardView/PopupEditing/Vue/App.vue
+++ b/apps/demos/Demos/CardView/PopupEditing/Vue/App.vue
@@ -144,7 +144,7 @@
 import {
   DxCardView, DxColumn, DxCardCover, DxSearchPanel, DxEditing, DxForm, DxItem,
 } from 'devextreme-vue/card-view';
-import 'devextreme-vue/text-area';
+import 'devextreme/ui/text_area';
 import { employees, type Employee } from './data.ts';
 
 function altExpr({ fullName }: Employee) {

--- a/apps/demos/Demos/CardView/WebAPIService/Angular/app/app.component.ts
+++ b/apps/demos/Demos/CardView/WebAPIService/Angular/app/app.component.ts
@@ -1,7 +1,8 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { Component, enableProdMode, provideZoneChangeDetection } from '@angular/core';
 import * as AspNetData from 'devextreme-aspnet-data-nojquery';
-import { DxCardViewModule, DxSelectBoxModule } from 'devextreme-angular';
+import { DxCardViewModule } from 'devextreme-angular';
+import 'devextreme/ui/select_box';
 import 'anti-forgery';
 
 if (!/localhost/.test(document.location.host)) {
@@ -21,7 +22,6 @@ const url = 'https://js.devexpress.com/Demos/NetCore/api/TreeListTasks';
   templateUrl: `.${modulePrefix}/app.component.html`,
   imports: [
     DxCardViewModule,
-    DxSelectBoxModule,
   ],
 })
 export class AppComponent {

--- a/apps/demos/Demos/CardView/WebAPIService/React/App.tsx
+++ b/apps/demos/Demos/CardView/WebAPIService/React/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as AspNetData from 'devextreme-aspnet-data-nojquery';
 import CardView, { Column, Editing, RequiredRule, SearchPanel, HeaderFilter, Form, Item } from 'devextreme-react/card-view';
-import 'devextreme-react/text-area';
+import 'devextreme/ui/select_box';
 
 const url = 'https://js.devexpress.com/Demos/NetCore/api/TreeListTasks';
 

--- a/apps/demos/Demos/CardView/WebAPIService/ReactJs/App.js
+++ b/apps/demos/Demos/CardView/WebAPIService/ReactJs/App.js
@@ -9,7 +9,7 @@ import CardView, {
   Form,
   Item,
 } from 'devextreme-react/card-view';
-import 'devextreme-react/text-area';
+import 'devextreme/ui/select_box';
 
 const url = 'https://js.devexpress.com/Demos/NetCore/api/TreeListTasks';
 const dataSource = AspNetData.createStore({

--- a/apps/demos/Demos/CardView/WebAPIService/Vue/App.vue
+++ b/apps/demos/Demos/CardView/WebAPIService/Vue/App.vue
@@ -69,7 +69,7 @@ import {
   DxCardView, DxColumn, DxEditing, DxSearchPanel, DxHeaderFilter, DxRequiredRule, DxForm, DxItem,
 } from 'devextreme-vue/card-view';
 import * as AspNetData from 'devextreme-aspnet-data-nojquery';
-import 'devextreme-vue/text-area';
+import 'devextreme/ui/select_box';
 
 const url = 'https://js.devexpress.com/Demos/NetCore/api/TreeListTasks';
 

--- a/apps/demos/Demos/DataGrid/FormEditing/Angular/app/app.component.ts
+++ b/apps/demos/Demos/DataGrid/FormEditing/Angular/app/app.component.ts
@@ -1,6 +1,7 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { Component, enableProdMode, provideZoneChangeDetection } from '@angular/core';
-import { DxDataGridModule, DxTextAreaModule } from 'devextreme-angular';
+import { DxDataGridModule } from 'devextreme-angular';
+import 'devextreme/ui/text_area';
 import { Service, Employee, State } from './app.service';
 
 if (!/localhost/.test(document.location.host)) {
@@ -20,7 +21,6 @@ if (window && window.config?.packageConfigPaths) {
   providers: [Service],
   imports: [
     DxDataGridModule,
-    DxTextAreaModule,
   ],
 })
 export class AppComponent {

--- a/apps/demos/Demos/DataGrid/FormEditing/React/App.tsx
+++ b/apps/demos/Demos/DataGrid/FormEditing/React/App.tsx
@@ -6,7 +6,7 @@ import DataGrid, {
   Paging,
   Lookup,
 } from 'devextreme-react/data-grid';
-import 'devextreme-react/text-area';
+import 'devextreme/ui/text_area';
 import { employees, states } from './data.ts';
 
 const notesEditorOptions = { height: 100 };

--- a/apps/demos/Demos/DataGrid/FormEditing/ReactJs/App.js
+++ b/apps/demos/Demos/DataGrid/FormEditing/ReactJs/App.js
@@ -2,7 +2,7 @@ import React from 'react';
 import DataGrid, {
   Column, FormItem, Editing, Paging, Lookup,
 } from 'devextreme-react/data-grid';
-import 'devextreme-react/text-area';
+import 'devextreme/ui/text_area';
 import { employees, states } from './data.js';
 
 const notesEditorOptions = { height: 100 };

--- a/apps/demos/Demos/DataGrid/FormEditing/Vue/App.vue
+++ b/apps/demos/Demos/DataGrid/FormEditing/Vue/App.vue
@@ -64,7 +64,7 @@ import {
   DxEditing,
   DxLookup,
 } from 'devextreme-vue/data-grid';
-import 'devextreme-vue/text-area';
+import 'devextreme/ui/text_area';
 import { employees, states } from './data.ts';
 
 </script>

--- a/apps/demos/Demos/DataGrid/PopupEditing/Angular/app/app.component.ts
+++ b/apps/demos/Demos/DataGrid/PopupEditing/Angular/app/app.component.ts
@@ -1,6 +1,7 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { Component, enableProdMode, provideZoneChangeDetection } from '@angular/core';
-import { DxDataGridModule, DxTextAreaModule } from 'devextreme-angular';
+import { DxDataGridModule } from 'devextreme-angular';
+import 'devextreme/ui/text_area';
 import { Service, Employee, State } from './app.service';
 
 if (!/localhost/.test(document.location.host)) {
@@ -20,7 +21,6 @@ if (window && window.config?.packageConfigPaths) {
   providers: [Service],
   imports: [
     DxDataGridModule,
-    DxTextAreaModule,
   ],
 })
 export class AppComponent {

--- a/apps/demos/Demos/DataGrid/PopupEditing/React/App.tsx
+++ b/apps/demos/Demos/DataGrid/PopupEditing/React/App.tsx
@@ -7,7 +7,7 @@ import DataGrid, {
   Lookup,
   Form,
 } from 'devextreme-react/data-grid';
-import 'devextreme-react/text-area';
+import 'devextreme/ui/text_area';
 import { Item } from 'devextreme-react/form';
 import { employees, states } from './data.ts';
 

--- a/apps/demos/Demos/DataGrid/PopupEditing/ReactJs/App.js
+++ b/apps/demos/Demos/DataGrid/PopupEditing/ReactJs/App.js
@@ -2,7 +2,7 @@ import React from 'react';
 import DataGrid, {
   Column, Editing, Popup, Paging, Lookup, Form,
 } from 'devextreme-react/data-grid';
-import 'devextreme-react/text-area';
+import 'devextreme/ui/text_area';
 import { Item } from 'devextreme-react/form';
 import { employees, states } from './data.js';
 

--- a/apps/demos/Demos/DataGrid/PopupEditing/Vue/App.vue
+++ b/apps/demos/Demos/DataGrid/PopupEditing/Vue/App.vue
@@ -101,7 +101,7 @@ import {
   DxLookup,
   DxForm,
 } from 'devextreme-vue/data-grid';
-import 'devextreme-vue/text-area';
+import 'devextreme/ui/text_area';
 import { DxItem } from 'devextreme-vue/form';
 import { employees, states } from './data.ts';
 

--- a/apps/demos/Demos/DataGrid/Toolbar/Angular/app/app.component.ts
+++ b/apps/demos/Demos/DataGrid/Toolbar/Angular/app/app.component.ts
@@ -3,7 +3,6 @@ import { Component, ViewChild, enableProdMode, provideZoneChangeDetection } from
 import {
   DxDataGridModule,
   DxDataGridComponent,
-  DxButtonModule,
 } from 'devextreme-angular';
 import { DxButtonTypes } from 'devextreme-angular/ui/button';
 import { query } from 'devextreme-angular/common/data';
@@ -28,7 +27,6 @@ if (window && window.config?.packageConfigPaths) {
   imports: [
     DxDataGridModule,
     DxSelectBoxModule,
-    DxButtonModule,
   ],
 })
 export class AppComponent {


### PR DESCRIPTION
**What does the PR change?**

1. Updates the editorType and widget import statements in grid-related widget demos to use the correct module references.

**How did you achieve this?**
1. Reviewed the grid-related widget demos that use editorType and widget imports.
2. Updated the import statements to align with the current module structure and import conventions.
3. Verified that the affected demos compile and load successfully after the changes.

**How can we verify these changes?**
1. Build and run the WG Demos project.
2. Open the grid-related widget demos.
3. Confirm that the demos render correctly without import or module resolution errors.
5. Verify that all grid-related widgets function as expected