### PR TITLE
T1333073 - DataGrid - Bound pageIndex does not update after internal page reset

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/__tests__/m_data_controller.integration.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/__tests__/m_data_controller.integration.test.ts
@@ -1,0 +1,88 @@
+import {
+  afterEach, beforeEach, describe, expect, it, jest,
+} from '@jest/globals';
+
+import {
+  afterTest, beforeTest, createDataGrid, flushAsync,
+} from '../../__tests__/__mock__/helpers/utils';
+
+const employees = [
+  { id: 1, name: 'Alice Johnson', department: 'Engineering' },
+  { id: 2, name: 'Bob Smith', department: 'Engineering' },
+  { id: 3, name: 'Carol White', department: 'Engineering' },
+  { id: 4, name: 'Dan Brown', department: 'Sales' },
+  { id: 5, name: 'Eve Davis', department: 'Sales' },
+  { id: 6, name: 'Frank Miller', department: 'Sales' },
+  { id: 7, name: 'Grace Wilson', department: 'HR' },
+  { id: 8, name: 'Hank Moore', department: 'HR' },
+  { id: 9, name: 'Ivy Taylor', department: 'Finance' },
+  { id: 10, name: 'Jack Anderson', department: 'Finance' },
+];
+
+describe('DataController paging.pageIndex option sync', () => {
+  beforeEach(beforeTest);
+  afterEach(afterTest);
+
+  it('should reset bound paging.pageIndex to 0 when a filter shrinks the page count (T1333073)', async () => {
+    const onOptionChanged = jest.fn();
+    const { instance } = await createDataGrid({
+      dataSource: employees,
+      keyExpr: 'id',
+      paging: { pageIndex: 2, pageSize: 3 },
+      onOptionChanged,
+    });
+
+    expect(instance.option('paging.pageIndex')).toBe(2);
+    onOptionChanged.mockClear();
+
+    instance.filter(['department', '=', 'Engineering']);
+    await flushAsync();
+
+    expect(instance.option('paging.pageIndex')).toBe(0);
+    const pageIndexCall = onOptionChanged.mock.calls
+      .find((call) => (call[0] as { fullName: string }).fullName === 'paging.pageIndex');
+    expect(pageIndexCall?.[0]).toMatchObject({ fullName: 'paging.pageIndex', value: 0 });
+  });
+
+  it('should reset bound paging.pageIndex to 0 when the search panel shrinks the page count (T1333073)', async () => {
+    const onOptionChanged = jest.fn();
+    const { instance } = await createDataGrid({
+      dataSource: employees,
+      keyExpr: 'id',
+      paging: { pageIndex: 2, pageSize: 3 },
+      searchPanel: { visible: true },
+      onOptionChanged,
+    });
+
+    expect(instance.option('paging.pageIndex')).toBe(2);
+    onOptionChanged.mockClear();
+
+    instance.option('searchPanel.text', 'Alice');
+    await flushAsync();
+
+    expect(instance.option('paging.pageIndex')).toBe(0);
+    const pageIndexCall = onOptionChanged.mock.calls
+      .find((call) => (call[0] as { fullName: string }).fullName === 'paging.pageIndex');
+    expect(pageIndexCall?.[0]).toMatchObject({ fullName: 'paging.pageIndex', value: 0 });
+  });
+
+  it('should not fire paging.pageIndex change when filtering while already on the first page (T1333073)', async () => {
+    const onOptionChanged = jest.fn();
+    const { instance } = await createDataGrid({
+      dataSource: employees,
+      keyExpr: 'id',
+      paging: { pageIndex: 0, pageSize: 3 },
+      onOptionChanged,
+    });
+
+    onOptionChanged.mockClear();
+
+    instance.filter(['department', '=', 'Engineering']);
+    await flushAsync();
+
+    expect(instance.option('paging.pageIndex')).toBe(0);
+    const pageIndexCall = onOptionChanged.mock.calls
+      .find((call) => (call[0] as { fullName: string }).fullName === 'paging.pageIndex');
+    expect(pageIndexCall).toBeUndefined();
+  });
+});

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
@@ -1294,7 +1294,7 @@ export class DataController extends DataHelperMixin(modules.Controller) {
     if (dataSource) {
       dataSource.pageIndex(0);
       if (this.option('paging.pageIndex')) {
-        this.resetPageIndexOption();
+        this._silentOption('paging.pageIndex', 0);
       }
       this._isFilterApplying = true;
 
@@ -1307,12 +1307,6 @@ export class DataController extends DataHelperMixin(modules.Controller) {
 
     // @ts-expect-error
     return new Deferred().resolve();
-  }
-
-  private resetPageIndexOption(): void {
-    this._skipProcessingPagingChange = true;
-    this.option('paging.pageIndex', 0);
-    this._skipProcessingPagingChange = false;
   }
 
   public resetFilterApplying() {

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
@@ -97,7 +97,7 @@ export class DataController extends DataHelperMixin(modules.Controller) {
 
   protected _changes!: any[];
 
-  private _skipProcessingPagingChange: boolean | undefined;
+  private _skipProcessingPagingChange?: boolean;
 
   private _useSortingGroupingFromColumns: boolean | undefined;
 
@@ -1622,7 +1622,7 @@ export class DataController extends DataHelperMixin(modules.Controller) {
     return result;
   }
 
-  private _changePaging(optionName: 'pageIndex' | 'pageSize', value?: number): any {
+  private changePaging(optionName: 'pageIndex' | 'pageSize', value?: number): any {
     const dataSource = this._dataSource;
 
     if (!dataSource) {
@@ -1662,11 +1662,11 @@ export class DataController extends DataHelperMixin(modules.Controller) {
    * @extended: virtual_scrolling
    */
   public pageIndex(value?: number): any {
-    return this._changePaging('pageIndex', value);
+    return this.changePaging('pageIndex', value);
   }
 
   public pageSize(value?: number): any {
-    return this._changePaging('pageSize', value);
+    return this.changePaging('pageSize', value);
   }
 
   public isCustomLoading() {

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
@@ -49,41 +49,6 @@ import gridCoreUtils from '../m_utils';
 import type { VirtualScrollController } from '../virtual_scrolling/m_virtual_scrolling_core';
 import { DataHelperMixin } from './data_helper_mixin';
 
-const changePaging = function (that, optionName, value) {
-  const dataSource = that._dataSource;
-
-  if (dataSource) {
-    if (value !== undefined) {
-      const oldValue = that._getPagingOptionValue(optionName);
-      if (oldValue !== value) {
-        that._skipProcessingPagingChange = true;
-        if (optionName === 'pageSize' && value === 0) {
-          dataSource.pageIndex(0);
-          that.option('paging.pageIndex', 0);
-        }
-        dataSource[optionName](value);
-        that.option(`paging.${optionName}`, value);
-        that._skipProcessingPagingChange = false;
-        const pageIndex = dataSource.pageIndex();
-        that._isPaging = optionName === 'pageIndex';
-        return dataSource[optionName === 'pageIndex' ? 'load' : 'reload']()
-          .done(() => {
-            that._isPaging = false;
-            that.pageChanged.fire(pageIndex);
-          });
-      }
-      return Deferred().resolve().promise();
-    }
-    return dataSource[optionName]();
-  }
-
-  if (optionName === 'pageIndex' && value !== undefined) {
-    return Deferred().resolve().promise();
-  }
-
-  return 0;
-};
-
 export interface HandleDataChangedArguments {
   changeType?: 'refresh' | 'update' | 'loadError';
   isDelayed?: boolean;
@@ -1657,15 +1622,51 @@ export class DataController extends DataHelperMixin(modules.Controller) {
     return result;
   }
 
+  private _changePaging(optionName: 'pageIndex' | 'pageSize', value?: number): any {
+    const dataSource = this._dataSource;
+
+    if (!dataSource) {
+      return optionName === 'pageIndex' && value !== undefined
+        ? Deferred().resolve().promise()
+        : 0;
+    }
+
+    if (value === undefined) {
+      return dataSource[optionName]();
+    }
+
+    const oldValue = this._getPagingOptionValue(optionName);
+    if (oldValue === value) {
+      return Deferred().resolve().promise();
+    }
+
+    this._skipProcessingPagingChange = true;
+    if (optionName === 'pageSize' && value === 0) {
+      dataSource.pageIndex(0);
+      this.option('paging.pageIndex', 0);
+    }
+    dataSource[optionName](value);
+    this.option(`paging.${optionName}`, value);
+    this._skipProcessingPagingChange = false;
+
+    const pageIndex = dataSource.pageIndex();
+    this._isPaging = optionName === 'pageIndex';
+    return dataSource[optionName === 'pageIndex' ? 'load' : 'reload']()
+      .done(() => {
+        this._isPaging = false;
+        this.pageChanged.fire(pageIndex);
+      });
+  }
+
   /**
    * @extended: virtual_scrolling
    */
-  public pageIndex(value?) {
-    return changePaging(this, 'pageIndex', value);
+  public pageIndex(value?: number): any {
+    return this._changePaging('pageIndex', value);
   }
 
-  public pageSize(value?) {
-    return changePaging(this, 'pageSize', value);
+  public pageSize(value?: number): any {
+    return this._changePaging('pageSize', value);
   }
 
   public isCustomLoading() {

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
@@ -132,7 +132,7 @@ export class DataController extends DataHelperMixin(modules.Controller) {
 
   protected _changes!: any[];
 
-  private readonly _skipProcessingPagingChange: boolean | undefined;
+  private _skipProcessingPagingChange: boolean | undefined;
 
   private _useSortingGroupingFromColumns: boolean | undefined;
 
@@ -1328,6 +1328,9 @@ export class DataController extends DataHelperMixin(modules.Controller) {
 
     if (dataSource) {
       dataSource.pageIndex(0);
+      if (this.option('paging.pageIndex')) {
+        this.resetPageIndexOption();
+      }
       this._isFilterApplying = true;
 
       return this.reload().done(() => {
@@ -1339,6 +1342,12 @@ export class DataController extends DataHelperMixin(modules.Controller) {
 
     // @ts-expect-error
     return new Deferred().resolve();
+  }
+
+  private resetPageIndexOption(): void {
+    this._skipProcessingPagingChange = true;
+    this.option('paging.pageIndex', 0);
+    this._skipProcessingPagingChange = false;
   }
 
   public resetFilterApplying() {


### PR DESCRIPTION
### What
**DataGrid** now updates the bound `paging.pageIndex` option when the grid resets to the first page internally (after filtering or searching), so `onOptionChanged` fires and any value bound to `pageIndex` stays in sync with the built-in pager

### How
The filter-apply flow now writes `paging.pageIndex` back to `0` alongside resetting the internal data source, matching how manual paging already keeps the option in sync
