### PR TITLE
Grids: extract dataController remoteOperations normalization into utils

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
@@ -17,8 +17,6 @@
 /* eslint-disable prefer-rest-params */
 /* eslint-disable prefer-spread */
 import type { DataSource } from '@js/common/data';
-import ArrayStore from '@js/common/data/array_store';
-import { CustomStore } from '@js/common/data/custom_store';
 import $ from '@js/core/renderer';
 import type { Callback } from '@js/core/utils/callbacks';
 import { deferRender, equalByValue } from '@js/core/utils/common';
@@ -26,7 +24,7 @@ import type { DeferredObj } from '@js/core/utils/deferred';
 import { Deferred, when } from '@js/core/utils/deferred';
 import { extend } from '@js/core/utils/extend';
 import { each } from '@js/core/utils/iterator';
-import { isDefined, isObject } from '@js/core/utils/type';
+import { isDefined } from '@js/core/utils/type';
 import errors from '@js/ui/widget/ui.errors';
 import { findChanges } from '@ts/core/utils/m_array_compare';
 import type { EditingController } from '@ts/grids/grid_core/editing/m_editing';
@@ -62,6 +60,7 @@ import type {
   PagingResult,
 } from './types';
 import { resolvePaginate, syncPaging } from './utils/paging';
+import { normalizeRemoteOperations } from './utils/remoteOperations';
 import { generateRowValues } from './utils/row_values';
 
 export class DataController extends DataHelperMixin(modules.Controller) {
@@ -1354,33 +1353,11 @@ export class DataController extends DataHelperMixin(modules.Controller) {
     return dataSourceAdapter;
   }
 
-  public isLocalStore(store = this.store()) {
-    return store instanceof ArrayStore;
-  }
-
-  private isCustomStore(store) {
-    store = store || this.store();
-    return store instanceof CustomStore;
-  }
-
   private _createDataSourceAdapter(dataSource) {
-    let remoteOperations: any = this.option('remoteOperations');
-    const store = dataSource.store();
-    const enabledRemoteOperations = {
-      filtering: true, sorting: true, paging: true, grouping: true, summary: true,
-    };
-
-    // @ts-expect-error
-    if (isObject(remoteOperations) && remoteOperations.groupPaging) {
-      remoteOperations = extend({}, enabledRemoteOperations, remoteOperations);
-    }
-
-    if (remoteOperations === 'auto') {
-      remoteOperations = this.isLocalStore(store) || this.isCustomStore(store) ? {} : { filtering: true, sorting: true, paging: true };
-    }
-    if (remoteOperations === true) {
-      remoteOperations = enabledRemoteOperations;
-    }
+    const remoteOperations = normalizeRemoteOperations(
+      this.option('remoteOperations'),
+      dataSource.store(),
+    );
 
     return this._createDataSourceAdapterCore(dataSource, remoteOperations);
   }

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/types.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/types.ts
@@ -1,5 +1,7 @@
+import type { Mode } from '@js/common';
 import type { DataSource } from '@js/common/data';
 import type { DeferredObj } from '@js/core/utils/deferred';
+import type { Properties } from '@js/ui/data_grid';
 
 import type { OperationTypes } from '../data_source_adapter/types';
 
@@ -108,3 +110,7 @@ export type PagingResult = number | DeferredObj<unknown> | Promise<unknown>;
 export interface CallbackFlags {
   stopOnFalse: boolean;
 }
+
+export type RemoteOperations = Properties['remoteOperations'];
+
+export type RemoteOperationsOptions = Exclude<RemoteOperations, boolean | Mode | undefined>;

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/utils/__tests__/remoteOperations.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/utils/__tests__/remoteOperations.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from '@jest/globals';
+import ArrayStore from '@js/common/data/array_store';
+import { CustomStore } from '@js/common/data/custom_store';
+import type { Store } from '@js/data';
+
+import { normalizeRemoteOperations } from '../remoteOperations';
+
+const arrayStore = new ArrayStore([]);
+const customStore = new CustomStore({ load: (): unknown[] => [] });
+const remoteStore = {} as Store;
+
+describe('normalizeRemoteOperations', () => {
+  describe("'auto'", () => {
+    it.each([
+      { store: arrayStore, storeKind: 'local', expected: {} },
+      { store: customStore, storeKind: 'custom', expected: {} },
+      {
+        store: remoteStore,
+        storeKind: 'remote',
+        expected: { filtering: true, sorting: true, paging: true },
+      },
+    ])('resolves against a $storeKind store', ({ store, expected }) => {
+      expect(normalizeRemoteOperations('auto', store)).toEqual(expected);
+    });
+  });
+
+  it('true enables every operation, including grouping and summary', () => {
+    expect(normalizeRemoteOperations(true, remoteStore)).toEqual({
+      filtering: true, sorting: true, paging: true, grouping: true, summary: true,
+    });
+  });
+
+  it('false is returned as is', () => {
+    expect(normalizeRemoteOperations(false, remoteStore)).toBe(false);
+  });
+
+  it('an object without groupPaging is returned unchanged', () => {
+    expect(normalizeRemoteOperations({ filtering: true, sorting: false }, remoteStore))
+      .toEqual({ filtering: true, sorting: false });
+  });
+
+  it('an object with groupPaging is merged onto all enabled operations', () => {
+    expect(normalizeRemoteOperations({ groupPaging: true }, remoteStore)).toEqual({
+      filtering: true,
+      sorting: true,
+      paging: true,
+      grouping: true,
+      summary: true,
+      groupPaging: true,
+    });
+  });
+
+  it('groupPaging object overrides individual operation flags', () => {
+    const result = normalizeRemoteOperations({ groupPaging: true, filtering: false }, remoteStore);
+
+    expect(result).toEqual({
+      filtering: false,
+      sorting: true,
+      paging: true,
+      grouping: true,
+      summary: true,
+      groupPaging: true,
+    });
+  });
+});

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/utils/__tests__/store.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/utils/__tests__/store.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from '@jest/globals';
+import ArrayStore from '@js/common/data/array_store';
+import { CustomStore } from '@js/common/data/custom_store';
+import type { Store } from '@js/data';
+
+import { isCustomStore, isLocalStore } from '../store';
+
+const arrayStore = new ArrayStore([]);
+const customStore = new CustomStore({ load: (): unknown[] => [] });
+const remoteStore = {} as Store;
+
+describe('isLocalStore', () => {
+  it('is true only for an ArrayStore', () => {
+    expect(isLocalStore(arrayStore)).toBe(true);
+    expect(isLocalStore(customStore)).toBe(false);
+    expect(isLocalStore(remoteStore)).toBe(false);
+  });
+});
+
+describe('isCustomStore', () => {
+  it('is true only for a CustomStore', () => {
+    expect(isCustomStore(customStore)).toBe(true);
+    expect(isCustomStore(arrayStore)).toBe(false);
+    expect(isCustomStore(remoteStore)).toBe(false);
+  });
+});

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/utils/remoteOperations.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/utils/remoteOperations.ts
@@ -1,0 +1,37 @@
+import { isObject } from '@js/core/utils/type';
+import type { Store } from '@js/data';
+
+import type { RemoteOperations, RemoteOperationsOptions } from '../types';
+import { isCustomStore, isLocalStore } from './store';
+
+export function normalizeRemoteOperations(
+  remoteOperations: RemoteOperations,
+  store: Store,
+): RemoteOperationsOptions | false | undefined {
+  const allExceptGroupPagingEnabled: RemoteOperationsOptions = {
+    filtering: true,
+    sorting: true,
+    paging: true,
+    grouping: true,
+    summary: true,
+  };
+
+  // groupPaging only works when every operation runs remotely.
+  if (isObject(remoteOperations) && remoteOperations.groupPaging) {
+    return { ...allExceptGroupPagingEnabled, ...remoteOperations };
+  }
+  if (remoteOperations === 'auto') {
+    return isLocalStore(store) || isCustomStore(store)
+      ? {}
+      : {
+        filtering: true,
+        sorting: true,
+        paging: true,
+      };
+  }
+  if (remoteOperations === true) {
+    return allExceptGroupPagingEnabled;
+  }
+
+  return remoteOperations;
+}

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/utils/store.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/utils/store.ts
@@ -1,0 +1,10 @@
+import { ArrayStore, CustomStore } from '@js/common/data';
+import type { Store } from '@js/data';
+
+export function isLocalStore(store: Store): store is ArrayStore {
+  return store instanceof ArrayStore;
+}
+
+export function isCustomStore(store: Store): store is CustomStore {
+  return store instanceof CustomStore;
+}

--- a/packages/devextreme/js/__internal/grids/grid_core/views/m_rows_view.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/views/m_rows_view.ts
@@ -29,6 +29,7 @@ import type { ValidatingController } from '@ts/grids/grid_core/validating/m_vali
 import type { ResizingController } from '@ts/grids/grid_core/views/m_grid_view';
 
 import { CLASSES as REORDERING_CLASSES } from '../columns_resizing_reordering/const';
+import { isLocalStore } from '../data_controller/utils/store';
 import type { EditingController } from '../editing/m_editing';
 import gridCoreUtils from '../m_utils';
 import { CLASSES } from '../sticky_columns/const';
@@ -356,7 +357,7 @@ export class RowsView extends ColumnsView {
       $element.append('<div>');
     }
     if (force || !that._loadPanel) {
-      that._renderLoadPanel($element, $element.parent(), that._dataController.isLocalStore());
+      that._renderLoadPanel($element, $element.parent(), isLocalStore(that._dataController.store()));
     }
 
     if ((force || !that.getScrollable()) && that._dataController.isLoaded()) {
@@ -1239,7 +1240,7 @@ export class RowsView extends ColumnsView {
       return;
     }
 
-    if (!loadPanel && messageText !== undefined && dataController.isLocalStore() && loadPanelOptions.enabled === 'auto' && $element) {
+    if (!loadPanel && messageText !== undefined && isLocalStore(dataController.store()) && loadPanelOptions.enabled === 'auto' && $element) {
       that._renderLoadPanel($element, $element.parent());
       loadPanel = that._loadPanel;
     }


### PR DESCRIPTION
### What
The grids' data controller now resolves the `remoteOperations` option through a dedicated helper instead of inline logiс

### How
The `'auto'`, `true` and `groupPaging` normalization and the store-type checks moved out of `_createDataSourceAdapter` into a new *utils/adapter.ts* module that the controller calls