### PR TITLE
GridCore dataController: reset guard flags when the guarded action throws

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
@@ -437,8 +437,11 @@ export class DataController extends DataHelperMixin(modules.Controller) {
       columnsController.updateColumnDataTypes(dataSource);
     }
     this._columnsUpdating = true;
-    columnsController.updateSortingGrouping(dataSource, !this._useSortingGroupingFromColumns);
-    this._columnsUpdating = false;
+    try {
+      columnsController.updateSortingGrouping(dataSource, !this._useSortingGroupingFromColumns);
+    } finally {
+      this._columnsUpdating = false;
+    }
 
     storeLoadOptions.sort = columnsController.getSortDataSourceParameters();
     storeLoadOptions.group = columnsController.getGroupDataSourceParameters();
@@ -1586,13 +1589,16 @@ export class DataController extends DataHelperMixin(modules.Controller) {
     }
 
     this._skipProcessingPagingChange = true;
-    if (optionName === 'pageSize' && value === 0) {
-      dataSource.pageIndex(0);
-      this.option('paging.pageIndex', 0);
+    try {
+      if (optionName === 'pageSize' && value === 0) {
+        dataSource.pageIndex(0);
+        this.option('paging.pageIndex', 0);
+      }
+      dataSource[optionName](value);
+      this.option(`paging.${optionName}`, value);
+    } finally {
+      this._skipProcessingPagingChange = false;
     }
-    dataSource[optionName](value);
-    this.option(`paging.${optionName}`, value);
-    this._skipProcessingPagingChange = false;
 
     const pageIndex = dataSource.pageIndex();
     this._isPaging = optionName === 'pageIndex';


### PR DESCRIPTION
### What
The data controller's guard flags (`_columnsUpdating`, `_skipProcessingPagingChange`) now reset even when the guarded operation throws. Previously a throw in `updateSortingGrouping` skipped `_columnsUpdating = false` and wedged the controller, permanently suppressing later sorting/grouping `columnsChanged` events.

### How
Both guarded blocks are wrapped in `try/finally` so the flags reset even if the operation throws.