### PR TITLE
Grids: remove deprecated `getDataByKeys` method

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
@@ -12,7 +12,6 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-plusplus */
 import type { DataSource, Store } from '@js/common/data';
-import $ from '@js/core/renderer';
 import type { Callback } from '@js/core/utils/callbacks';
 import { deferRender } from '@js/core/utils/common';
 import type { DeferredObj } from '@js/core/utils/deferred';
@@ -232,7 +231,6 @@ export class DataController extends DataHelperMixin(modules.Controller) {
       'endCustomLoading',
       'filter',
       'getCombinedFilter',
-      'getDataByKeys',
       'getDataSource',
       'getKeyByRowIndex',
       'getRowIndexByKey',
@@ -1609,24 +1607,6 @@ export class DataController extends DataHelperMixin(modules.Controller) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public getRowIndexOffset(byLoadedRows?: boolean): number {
     return 0;
-  }
-
-  private getDataByKeys(rowKeys: RowKey[]): DeferredObj<RawItemData[]> {
-    const result = Deferred<RawItemData[]>();
-    const deferreds: DeferredObj<RawItemData>[] = [];
-    const data: RawItemData[] = [];
-
-    each(rowKeys, (index: number, key: RowKey) => {
-      deferreds.push(this.byKey(key).done((keyData) => {
-        data[index] = keyData;
-      }));
-    });
-
-    when.apply($, deferreds).always(() => {
-      result.resolve(data);
-    });
-
-    return result;
   }
 
   private changePaging(optionName: PagingOptionName, value?: number): PagingResult {

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
@@ -2,7 +2,6 @@
 /* eslint-disable @stylistic/max-len */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-/* eslint-disable @typescript-eslint/init-declarations */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-floating-promises */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
@@ -16,7 +15,6 @@ import type { Callback } from '@js/core/utils/callbacks';
 import { deferRender } from '@js/core/utils/common';
 import type { DeferredObj } from '@js/core/utils/deferred';
 import { Deferred, when } from '@js/core/utils/deferred';
-import { each } from '@js/core/utils/iterator';
 import { isDefined } from '@js/core/utils/type';
 import errors from '@js/ui/widget/ui.errors';
 import { findChanges } from '@ts/core/utils/m_array_compare';

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/dataController.tests.js
@@ -2607,58 +2607,6 @@ QUnit.module('Initialization', { beforeEach: setupModule, afterEach: teardownMod
         assert.strictEqual(data, undefined, 'not data');
     });
 
-    QUnit.test('getDataByKeys from loaded items and data store', function(assert) {
-    // arrange
-        const array = [
-            { name: 'Alex', phone: '55-55-55' },
-            { name: 'Sam', phone: '66-66-66' },
-            { name: 'Dan', phone: '98-75-21' }
-        ];
-        let data;
-
-        const dataSource = createDataSource(array, { key: 'name' }, { pageSize: 2 });
-
-        this.dataController.setDataSource(dataSource);
-        dataSource.load();
-
-        // act
-        this.dataController.getDataByKeys(['Alex', 'Dan']).done(function(result) {
-            data = result;
-        });
-
-        // assert
-        assert.equal(this.dataController.items().length, 2, 'count loaded items');
-        assert.equal(data.length, 2, 'count data');
-        assert.deepEqual(data[0], { name: 'Alex', phone: '55-55-55' }, 'data 1');
-        assert.deepEqual(data[1], { name: 'Dan', phone: '98-75-21' }, 'data 2');
-    });
-
-    QUnit.test('getDataByKeys not has keys', function(assert) {
-    // arrange
-        const array = [
-            { name: 'Alex', phone: '55-55-55' },
-            { name: 'Sam', phone: '66-66-66' },
-            { name: 'Dan', phone: '98-75-21' }
-        ];
-        let data;
-
-        const dataSource = createDataSource(array, { key: 'name' }, { pageSize: 2 });
-
-        this.dataController.setDataSource(dataSource);
-        dataSource.load();
-
-        // act
-        this.dataController.getDataByKeys(['Sam', 'Test2']).done(function(result) {
-            data = result;
-        });
-
-        // assert
-        assert.equal(this.dataController.items().length, 2, 'count loaded items');
-        assert.equal(data.length, 1, 'count data');
-        assert.deepEqual(data[0], { name: 'Sam', phone: '66-66-66' }, 'data 1');
-        assert.strictEqual(data[1], undefined, 'not data 2');
-    });
-
     QUnit.test('getKeyByRowIndex', function(assert) {
     // arrange
         const array = [


### PR DESCRIPTION
<!--
Before you submit a pull request, review our contribution guidelines (CONTRIBUTING.md).

If your pull request contains a bug fix, its title should include "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What does the PR change?
2. How did you achieve this?
3. How can we verify these changes?

-->
