### PR TITLE
GridCore data: Relocate filter-controller fields (headerFilter, applyFilter)

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
@@ -139,7 +139,7 @@ export class DataController extends DataHelperMixin(modules.Controller) {
 
   protected _filterSyncController!: FilterSyncController;
 
-  protected _filterExcludedColumn: Column | null = null;
+  private _filterExcludedColumn: Column | null = null;
 
   protected _keyboardNavigationController!: KeyboardNavigationController;
 
@@ -347,12 +347,20 @@ export class DataController extends DataHelperMixin(modules.Controller) {
     return this.combinedFilter(undefined, returnDataField);
   }
 
-  public setFilterExcludedColumn(column: Column | null): void {
-    this._filterExcludedColumn = column;
-  }
-
   public getFilterExcludedColumn(): Column | null {
     return this._filterExcludedColumn;
+  }
+
+  public getCombinedFilterWithExcludedColumn(
+    excludedColumn: Column | null,
+    returnDataField?: boolean,
+  ): DataFilter {
+    this._filterExcludedColumn = excludedColumn;
+    try {
+      return this.getCombinedFilter(returnDataField);
+    } finally {
+      this._filterExcludedColumn = null;
+    }
   }
 
   private combinedFilter(filter: DataFilter, returnDataField?: boolean): DataFilter {

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
@@ -21,7 +21,7 @@ import errors from '@js/ui/widget/ui.errors';
 import { findChanges } from '@ts/core/utils/m_array_compare';
 import { fromPromise } from '@ts/core/utils/m_deferred';
 import type { ChangingEvent, DataSource, StoreLoadOptions } from '@ts/data/data_source/types';
-import type { ColumnsChanges } from '@ts/grids/grid_core/columns_controller/types';
+import type { Column, ColumnsChanges } from '@ts/grids/grid_core/columns_controller/types';
 import type DataSourceAdapter from '@ts/grids/grid_core/data_source_adapter/m_data_source_adapter';
 import type {
   ChangedEvent, DataSourceAdapterProvider, LoadOperation, OperationTypes, RawItemData,
@@ -30,10 +30,8 @@ import { isLocalStore } from '@ts/grids/grid_core/data_source_adapter/utils/stor
 import type { EditingController } from '@ts/grids/grid_core/editing/m_editing';
 import type { EditorFactory } from '@ts/grids/grid_core/editor_factory/m_editor_factory';
 import type { ErrorHandlingController } from '@ts/grids/grid_core/error_handling/m_error_handling';
-import type { ApplyFilterViewController } from '@ts/grids/grid_core/filter/m_filter_row';
 import type { FilterSyncController } from '@ts/grids/grid_core/filter/m_filter_sync';
 import type { FocusController } from '@ts/grids/grid_core/focus/m_focus';
-import type { HeaderFilterController } from '@ts/grids/grid_core/header_filter/m_header_filter';
 import type { KeyboardNavigationController } from '@ts/grids/grid_core/keyboard_navigation/m_keyboard_navigation';
 import modules from '@ts/grids/grid_core/m_modules';
 import type {
@@ -141,9 +139,7 @@ export class DataController extends DataHelperMixin(modules.Controller) {
 
   protected _filterSyncController!: FilterSyncController;
 
-  protected _headerFilterController!: HeaderFilterController;
-
-  protected _applyFilterController!: ApplyFilterViewController;
+  protected _filterExcludedColumn: Column | null = null;
 
   protected _keyboardNavigationController!: KeyboardNavigationController;
 
@@ -168,10 +164,8 @@ export class DataController extends DataHelperMixin(modules.Controller) {
     this._editorFactoryController = this.getController('editorFactory');
     this._errorHandlingController = this.getController('errorHandling');
     this._filterSyncController = this.getController('filterSync');
-    this._applyFilterController = this.getController('applyFilter');
     this._keyboardNavigationController = this.getController('keyboardNavigation');
     this._focusController = this.getController('focus');
-    this._headerFilterController = this.getController('headerFilter');
     this._selectionController = this.getController('selection');
     this._stateStoringController = this.getController('stateStoring');
 
@@ -351,6 +345,14 @@ export class DataController extends DataHelperMixin(modules.Controller) {
 
   public getCombinedFilter(returnDataField?: boolean): DataFilter {
     return this.combinedFilter(undefined, returnDataField);
+  }
+
+  public setFilterExcludedColumn(column: Column | null): void {
+    this._filterExcludedColumn = column;
+  }
+
+  public getFilterExcludedColumn(): Column | null {
+    return this._filterExcludedColumn;
   }
 
   private combinedFilter(filter: DataFilter, returnDataField?: boolean): DataFilter {

--- a/packages/devextreme/js/__internal/grids/grid_core/filter/m_filter_row.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/filter/m_filter_row.ts
@@ -550,9 +550,7 @@ const columnHeadersView = (Base: ModuleType<ColumnHeadersView>) => class ColumnH
     const dataSource = this._dataController.dataSource();
 
     if (options.lookup && this.option('syncLookupFilterValues')) {
-      this._dataController.setFilterExcludedColumn(options);
-      const filter = this._dataController.getCombinedFilter();
-      this._dataController.setFilterExcludedColumn(null);
+      const filter = this._dataController.getCombinedFilterWithExcludedColumn(options);
 
       const lookupDataSource = gridCoreUtils.getWrappedLookupDataSource(options, dataSource, filter);
       const lookupOptions = {
@@ -781,9 +779,7 @@ const columnHeadersView = (Base: ModuleType<ColumnHeadersView>) => class ColumnH
       const editor = getEditorInstance($cell?.find('.dx-editor-container'));
 
       if (editor) {
-        this._dataController.setFilterExcludedColumn(column);
-        const filter = this._dataController.getCombinedFilter() || null;
-        this._dataController.setFilterExcludedColumn(null);
+        const filter = this._dataController.getCombinedFilterWithExcludedColumn(column) || null;
 
         const editorDataSource = editor.option('dataSource');
         const shouldUpdateFilter = !filterChanged
@@ -831,7 +827,7 @@ const data = (Base: ModuleType<DataController>) => class DataControllerFilterRow
     const filters = [super._calculateAdditionalFilter()];
     const columns = this._columnsController.getVisibleColumns(null, true);
 
-    const excludedColumn = this._filterExcludedColumn;
+    const excludedColumn = this.getFilterExcludedColumn();
 
     each(columns, function () {
       const shouldSkip = excludedColumn?.index === this.index;

--- a/packages/devextreme/js/__internal/grids/grid_core/filter/m_filter_row.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/filter/m_filter_row.ts
@@ -550,9 +550,9 @@ const columnHeadersView = (Base: ModuleType<ColumnHeadersView>) => class ColumnH
     const dataSource = this._dataController.dataSource();
 
     if (options.lookup && this.option('syncLookupFilterValues')) {
-      this._applyFilterViewController.setCurrentColumnForFiltering(options);
+      this._dataController.setFilterExcludedColumn(options);
       const filter = this._dataController.getCombinedFilter();
-      this._applyFilterViewController.setCurrentColumnForFiltering(null);
+      this._dataController.setFilterExcludedColumn(null);
 
       const lookupDataSource = gridCoreUtils.getWrappedLookupDataSource(options, dataSource, filter);
       const lookupOptions = {
@@ -766,7 +766,6 @@ const columnHeadersView = (Base: ModuleType<ColumnHeadersView>) => class ColumnH
 
     const columns = this._columnsController.getVisibleColumns();
     const dataSource = this._dataController.dataSource();
-    const applyFilterViewController = this._applyFilterViewController;
     const rowIndex = this.element().find(`.${this.addWidgetPrefix(FILTER_ROW_CLASS)}`).index();
 
     if (rowIndex === -1) {
@@ -782,9 +781,9 @@ const columnHeadersView = (Base: ModuleType<ColumnHeadersView>) => class ColumnH
       const editor = getEditorInstance($cell?.find('.dx-editor-container'));
 
       if (editor) {
-        applyFilterViewController.setCurrentColumnForFiltering(column);
+        this._dataController.setFilterExcludedColumn(column);
         const filter = this._dataController.getCombinedFilter() || null;
-        applyFilterViewController.setCurrentColumnForFiltering(null);
+        this._dataController.setFilterExcludedColumn(null);
 
         const editorDataSource = editor.option('dataSource');
         const shouldUpdateFilter = !filterChanged
@@ -832,10 +831,10 @@ const data = (Base: ModuleType<DataController>) => class DataControllerFilterRow
     const filters = [super._calculateAdditionalFilter()];
     const columns = this._columnsController.getVisibleColumns(null, true);
 
-    const applyFilterController = this._applyFilterController;
+    const excludedColumn = this._filterExcludedColumn;
 
     each(columns, function () {
-      const shouldSkip = applyFilterController.getCurrentColumnForFiltering()?.index === this.index;
+      const shouldSkip = excludedColumn?.index === this.index;
       if (this.allowFiltering && this.calculateFilterExpression && isDefined(this.filterValue) && !shouldSkip) {
         const filter = this.createFilterExpression(this.filterValue, this.selectedFilterOperation || this.defaultFilterOperation, 'filterRow');
         filters.push(filter);
@@ -848,8 +847,6 @@ const data = (Base: ModuleType<DataController>) => class DataControllerFilterRow
 
 export class ApplyFilterViewController extends modules.ViewController {
   private _headerPanel: any;
-
-  private _currentColumn: any;
 
   private _columnsController!: ColumnsController;
 
@@ -900,14 +897,6 @@ export class ApplyFilterViewController extends modules.ViewController {
       columnHeadersViewElement.find(`.${this.addWidgetPrefix(FILTER_ROW_CLASS)} .${FILTER_MODIFIED_CLASS}`).removeClass(FILTER_MODIFIED_CLASS);
       this._getHeaderPanel().enableApplyButton(false);
     }
-  }
-
-  public setCurrentColumnForFiltering(column) {
-    this._currentColumn = column;
-  }
-
-  public getCurrentColumnForFiltering() {
-    return this._currentColumn;
   }
 }
 

--- a/packages/devextreme/js/__internal/grids/grid_core/filter/m_filter_sync.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/filter/m_filter_sync.ts
@@ -313,11 +313,11 @@ const data = (Base: ModuleType<DataController>) => class DataControllerFilterSyn
     let filterValue = this.option('filterValue');
 
     if (this.isFilterSyncActive()) {
-      const currentColumn = this._filterExcludedColumn;
-      const needRemoveCurrentColumnFilter = isDefined(currentColumn);
+      const excludedColumn = this.getFilterExcludedColumn();
+      const needRemoveCurrentColumnFilter = isDefined(excludedColumn);
 
       if (needRemoveCurrentColumnFilter && filterValue) {
-        filterValue = removeFieldConditionsFromFilter(filterValue, getColumnIdentifier(currentColumn));
+        filterValue = removeFieldConditionsFromFilter(filterValue, getColumnIdentifier(excludedColumn));
       }
     }
     const customOperations = this._filterSyncController.getCustomFilterOperations();

--- a/packages/devextreme/js/__internal/grids/grid_core/filter/m_filter_sync.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/filter/m_filter_sync.ts
@@ -313,10 +313,8 @@ const data = (Base: ModuleType<DataController>) => class DataControllerFilterSyn
     let filterValue = this.option('filterValue');
 
     if (this.isFilterSyncActive()) {
-      const currentColumnForHeaderFilter = this._headerFilterController.getCurrentColumn();
-      const currentColumnForFilterRow = this._applyFilterController.getCurrentColumnForFiltering();
-      const currentColumn = currentColumnForHeaderFilter || currentColumnForFilterRow;
-      const needRemoveCurrentColumnFilter = currentColumnForHeaderFilter || isDefined(currentColumnForFilterRow?.filterValue);
+      const currentColumn = this._filterExcludedColumn;
+      const needRemoveCurrentColumnFilter = isDefined(currentColumn);
 
       if (needRemoveCurrentColumnFilter && filterValue) {
         filterValue = removeFieldConditionsFromFilter(filterValue, getColumnIdentifier(currentColumn));

--- a/packages/devextreme/js/__internal/grids/grid_core/header_filter/m_header_filter.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/header_filter/m_header_filter.ts
@@ -124,8 +124,6 @@ export class HeaderFilterController extends Modules.ViewController {
 
   private _headerFilterView!: HeaderFilterView;
 
-  private _currentColumn: any;
-
   public init() {
     this._columnsController = this.getController('columns');
     this._dataController = this.getController('data');
@@ -253,9 +251,9 @@ export class HeaderFilterController extends Modules.ViewController {
       isLookup = true;
 
       if (this.option('syncLookupFilterValues')) {
-        this._currentColumn = column;
+        this._dataController.setFilterExcludedColumn(column);
         const filter = this._dataController.getCombinedFilter();
-        this._currentColumn = null;
+        this._dataController.setFilterExcludedColumn(null);
 
         options.dataSource = gridCoreUtils.getWrappedLookupDataSource(column, dataSource, filter);
       } else {
@@ -264,9 +262,9 @@ export class HeaderFilterController extends Modules.ViewController {
     } else {
       const cutoffLevel = Array.isArray(group) ? group.length - 1 : 0;
 
-      this._currentColumn = column;
+      this._dataController.setFilterExcludedColumn(column);
       const filter = this._dataController.getCombinedFilter();
-      this._currentColumn = null;
+      this._dataController.setFilterExcludedColumn(null);
 
       options.dataSource = {
         filter,
@@ -325,10 +323,6 @@ export class HeaderFilterController extends Modules.ViewController {
     };
 
     return options.dataSource;
-  }
-
-  public getCurrentColumn() {
-    return this._currentColumn;
   }
 
   public showHeaderFilterMenu(columnIndex, isGroupPanel) {
@@ -516,8 +510,7 @@ const data = (Base: ModuleType<DataController>) => class DataControllerFilterRow
     const that = this;
     const filters = [super._calculateAdditionalFilter()];
     const columns = that._columnsController.getVisibleColumns(null, true);
-    const headerFilterController = this._headerFilterController;
-    const currentColumn = headerFilterController.getCurrentColumn();
+    const currentColumn = this._filterExcludedColumn;
 
     each(columns, (_, column) => {
       let filter;

--- a/packages/devextreme/js/__internal/grids/grid_core/header_filter/m_header_filter.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/header_filter/m_header_filter.ts
@@ -251,9 +251,7 @@ export class HeaderFilterController extends Modules.ViewController {
       isLookup = true;
 
       if (this.option('syncLookupFilterValues')) {
-        this._dataController.setFilterExcludedColumn(column);
-        const filter = this._dataController.getCombinedFilter();
-        this._dataController.setFilterExcludedColumn(null);
+        const filter = this._dataController.getCombinedFilterWithExcludedColumn(column);
 
         options.dataSource = gridCoreUtils.getWrappedLookupDataSource(column, dataSource, filter);
       } else {
@@ -262,9 +260,7 @@ export class HeaderFilterController extends Modules.ViewController {
     } else {
       const cutoffLevel = Array.isArray(group) ? group.length - 1 : 0;
 
-      this._dataController.setFilterExcludedColumn(column);
-      const filter = this._dataController.getCombinedFilter();
-      this._dataController.setFilterExcludedColumn(null);
+      const filter = this._dataController.getCombinedFilterWithExcludedColumn(column);
 
       options.dataSource = {
         filter,
@@ -510,12 +506,12 @@ const data = (Base: ModuleType<DataController>) => class DataControllerFilterRow
     const that = this;
     const filters = [super._calculateAdditionalFilter()];
     const columns = that._columnsController.getVisibleColumns(null, true);
-    const currentColumn = this._filterExcludedColumn;
+    const excludedColumn = this.getFilterExcludedColumn();
 
     each(columns, (_, column) => {
       let filter;
 
-      if (currentColumn && currentColumn.index === column.index) {
+      if (excludedColumn && excludedColumn.index === column.index) {
         return;
       }
 

--- a/packages/devextreme/testing/helpers/gridBaseMocks.js
+++ b/packages/devextreme/testing/helpers/gridBaseMocks.js
@@ -236,9 +236,9 @@ module.exports = function($, gridCore, columnResizingReordering, domUtils, commo
 
             getCombinedFilter: commonUtils.noop,
 
-            setFilterExcludedColumn: commonUtils.noop,
-
             getFilterExcludedColumn: commonUtils.noop,
+
+            getCombinedFilterWithExcludedColumn: commonUtils.noop,
 
             getRowIndexByKey: function(key) {
                 return gridCore.getIndexByKey(key, options.items);

--- a/packages/devextreme/testing/helpers/gridBaseMocks.js
+++ b/packages/devextreme/testing/helpers/gridBaseMocks.js
@@ -236,6 +236,10 @@ module.exports = function($, gridCore, columnResizingReordering, domUtils, commo
 
             getCombinedFilter: commonUtils.noop,
 
+            setFilterExcludedColumn: commonUtils.noop,
+
+            getFilterExcludedColumn: commonUtils.noop,
+
             getRowIndexByKey: function(key) {
                 return gridCore.getIndexByKey(key, options.items);
             },

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/filterSync.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/filterSync.tests.js
@@ -729,9 +729,7 @@ QUnit.module('getCombinedFilter', {
             filterValue: [['Test', 'anyof', [1, 2, 3]], 'and', filterRowFilter]
         });
 
-        this.headerFilterController.getCurrentColumn = function() {
-            return { dataField: 'Test' };
-        };
+        this.dataController.setFilterExcludedColumn({ dataField: 'Test' });
 
         // assert
         assert.deepEqual(this.getCombinedFilter(true), undefined, 'combined filter');
@@ -749,9 +747,7 @@ QUnit.module('getCombinedFilter', {
             filterValue: [['Test', 'anyof', [1, 2, 3]], 'and', filterRowFilter]
         });
 
-        this.headerFilterController.getCurrentColumn = function() {
-            return { dataField: 'Test' };
-        };
+        this.dataController.setFilterExcludedColumn({ dataField: 'Test' });
 
         // assert
         assert.deepEqual(this.getCombinedFilter(true), [

--- a/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/filterSync.tests.js
+++ b/packages/devextreme/testing/tests/DevExpress.ui.widgets.dataGrid/filterSync.tests.js
@@ -729,10 +729,8 @@ QUnit.module('getCombinedFilter', {
             filterValue: [['Test', 'anyof', [1, 2, 3]], 'and', filterRowFilter]
         });
 
-        this.dataController.setFilterExcludedColumn({ dataField: 'Test' });
-
         // assert
-        assert.deepEqual(this.getCombinedFilter(true), undefined, 'combined filter');
+        assert.deepEqual(this.dataController.getCombinedFilterWithExcludedColumn({ dataField: 'Test' }, true), undefined, 'combined filter');
     });
 
     QUnit.test('add currentColumn header filter value when filterSyncEnabled = false', function(assert) {
@@ -747,10 +745,8 @@ QUnit.module('getCombinedFilter', {
             filterValue: [['Test', 'anyof', [1, 2, 3]], 'and', filterRowFilter]
         });
 
-        this.dataController.setFilterExcludedColumn({ dataField: 'Test' });
-
         // assert
-        assert.deepEqual(this.getCombinedFilter(true), [
+        assert.deepEqual(this.dataController.getCombinedFilterWithExcludedColumn({ dataField: 'Test' }, true), [
             [
                 ['Test', '=', 1],
                 'or',


### PR DESCRIPTION
### What
Removed the `_headerFilterController` and `_applyFilterController` references from the base `DataController`, so it no longer depends on the header-filter and filter-row controllers

### How
The temporary excluded-column context those controllers passed through their own state now lives on `DataController` (`setFilterExcludedColumn` / `getFilterExcludedColumn`), and the filter data-extenders read it from there instead of reaching into those controllers