### PR TITLE
CI: Remove workflow_call trigger from packages_publishing & use GH CLI for call

### DIFF
--- a/.github/workflows/packages_publishing.yml
+++ b/.github/workflows/packages_publishing.yml
@@ -15,20 +15,6 @@ on:
         type: string
         description: Package file filter pattern
         required: false
-  workflow_call:
-    inputs:
-      tag:
-        type: string
-        default: daily
-        required: false
-      filter:
-        type: string
-        default: ''
-        required: false
-      branch:
-        type: string
-        default: ''
-        required: false
 
 permissions:
   contents: read
@@ -44,14 +30,12 @@ jobs:
   build:
     name: Build packages
     runs-on: ubuntu-latest
-    environment: ${{ (inputs.tag == 'stable' || (github.event_name == 'workflow_dispatch' && !contains(github.workflow_ref, '/.github/workflows/packages_publishing_scheduler.yml@'))) && 'packages-publishing' || 'packages-publishing-automation' }}
+    environment: ${{ (inputs.tag == 'stable' && 'packages-publishing-stable') || 'packages-publishing-daily' }}
     outputs:
       packages: ${{ steps.filter.outputs.packages }}
     steps:
       - name: Get sources
         uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.branch || github.ref }}
 
       - name: Set up nodejs
         uses: actions/setup-node@v6

--- a/.github/workflows/packages_publishing.yml
+++ b/.github/workflows/packages_publishing.yml
@@ -158,8 +158,6 @@ jobs:
     steps:
       - name: Get sources
         uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.branch || github.ref }}
 
       - name: Download packages
         uses: actions/download-artifact@v8

--- a/.github/workflows/packages_publishing_scheduler.yml
+++ b/.github/workflows/packages_publishing_scheduler.yml
@@ -3,19 +3,24 @@ name: Publishing to GitHub Packages (scheduler)
 on:
   schedule:
     - cron: '00 18 * * *'
-
-permissions:
-  contents: read
-  packages: write
+  pull_request:
 
 jobs:
   publish:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
         branch: ['24_2', '25_1', '25_2', '26_1', 'main']
+
     name: Run Packages Publishing workflow
-    uses: ./.github/workflows/packages_publishing.yml
-    with:
-      tag: daily
-      branch: ${{ matrix.branch }}
-    secrets: inherit
+    steps:
+      - name: Get sources
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: README.md
+
+      - name: Publish Packages (${{ matrix.branch }})
+        run: |
+          gh workflow run packages_publishing.yml -f tag=daily --ref ${{ matrix.branch }}          

--- a/.github/workflows/packages_publishing_scheduler.yml
+++ b/.github/workflows/packages_publishing_scheduler.yml
@@ -3,7 +3,6 @@ name: Publishing to GitHub Packages (scheduler)
 on:
   schedule:
     - cron: '00 18 * * *'
-  pull_request:
 
 jobs:
   publish:

--- a/.github/workflows/packages_publishing_scheduler.yml
+++ b/.github/workflows/packages_publishing_scheduler.yml
@@ -22,4 +22,4 @@ jobs:
 
       - name: Publish Packages (${{ matrix.branch }})
         run: |
-          gh workflow run packages_publishing.yml -f tag=daily --ref ${{ matrix.branch }}          
+          gh workflow run packages_publishing.yml -f tag=daily --ref ${{ matrix.branch }}


### PR DESCRIPTION
This PR reverts:
1. https://github.com/DevExpress/DevExtreme/pull/34733
2. https://github.com/DevExpress/DevExtreme/pull/34783

After this change, the following logic applies:
1. `daily` releases can only be published from a protected branch
2. `stable` releases should be **approved** and can only be published from a protected branch
