### PR TITLE
GridCore data: Relocate _editingController to editing data-extenders

### DIFF
--- a/packages/devextreme/js/__internal/grids/data_grid/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/data_grid/m_editing.ts
@@ -7,7 +7,7 @@ import type { ModuleType } from '@ts/grids/grid_core/m_types';
 
 import gridCore from './m_core';
 
-const data = (Base: ModuleType<DataController>) => class DataEditingDataGridExtender extends editingDataControllerExtender(Base) {
+const data = (Base: ModuleType<DataController>) => class DataGridEditingDataControllerExtender extends editingDataControllerExtender(Base) {
   protected _changeRowExpandCore(key) {
     const editingController = this._editingController;
 

--- a/packages/devextreme/js/__internal/grids/data_grid/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/data_grid/m_editing.ts
@@ -1,12 +1,13 @@
 import './module_not_extended/editor_factory';
 
 import type { DataController } from '@ts/grids/grid_core/data_controller/data_controller';
-import { dataControllerEditingExtenderMixin, editingModule } from '@ts/grids/grid_core/editing/m_editing';
+import { editingDataControllerExtender } from '@ts/grids/grid_core/editing/extenders/editing_data_controller';
+import { editingModule } from '@ts/grids/grid_core/editing/m_editing';
 import type { ModuleType } from '@ts/grids/grid_core/m_types';
 
 import gridCore from './m_core';
 
-const data = (Base: ModuleType<DataController>) => class DataEditingDataGridExtender extends dataControllerEditingExtenderMixin(Base) {
+const data = (Base: ModuleType<DataController>) => class DataEditingDataGridExtender extends editingDataControllerExtender(Base) {
   protected _changeRowExpandCore(key) {
     const editingController = this._editingController;
 

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/types.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/types.ts
@@ -43,6 +43,7 @@ export type RowWatch = (
 
 export interface Cell {
   column?: Column;
+  isEditing?: boolean;
   update?: RowUpdate;
 }
 

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_data_controller.ts
@@ -3,7 +3,6 @@ import { equalByValue } from '@js/core/utils/common';
 import type { DeferredObj } from '@js/core/utils/deferred';
 import type { DataController } from '@ts/grids/grid_core/data_controller/data_controller';
 import type {
-  Cell,
   DataChange,
   GeneratedItem,
   ItemProcessingOptions,
@@ -17,11 +16,9 @@ import gridCoreUtils from '@ts/grids/grid_core/m_utils';
 import { EDITING_EDITROWKEY_OPTION_NAME } from '../const';
 import type { EditingController } from '../m_editing';
 
-type EditingCell = Cell & { isEditing?: boolean };
-
-export const dataControllerEditingExtenderMixin = (
+export const editingDataControllerExtender = (
   Base: ModuleType<DataController>,
-): ModuleType<DataController> => class DataControllerEditingExtender extends Base {
+): ModuleType<DataController> => class EditingDataControllerExtender extends Base {
   protected _editingController!: EditingController;
 
   public init(): void {
@@ -122,7 +119,7 @@ export const dataControllerEditingExtenderMixin = (
     columnIndex: number,
     isLiveUpdate?: boolean,
   ): boolean {
-    const cell = oldRow.cells?.[columnIndex] as EditingCell | undefined;
+    const cell = oldRow.cells?.[columnIndex];
     const isEditing = this._editingController
       && this._editingController.isEditCell(visibleRowIndex, columnIndex);
 

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_data_controller.ts
@@ -1,0 +1,168 @@
+import type { DataChange as EditingDataChange } from '@js/common/grids';
+import { equalByValue } from '@js/core/utils/common';
+import type { DeferredObj } from '@js/core/utils/deferred';
+import type { DataController } from '@ts/grids/grid_core/data_controller/data_controller';
+import type {
+  Cell,
+  DataChange,
+  GeneratedItem,
+  ItemProcessingOptions,
+  ProcessedItem,
+  UpdateChange,
+} from '@ts/grids/grid_core/data_controller/types';
+import type { RawItemData } from '@ts/grids/grid_core/data_source_adapter/types';
+import type { ModuleType, OptionChanged } from '@ts/grids/grid_core/m_types';
+import gridCoreUtils from '@ts/grids/grid_core/m_utils';
+
+import { EDITING_EDITROWKEY_OPTION_NAME } from '../const';
+import type { EditingController } from '../m_editing';
+
+export const dataControllerEditingExtenderMixin = (
+  Base: ModuleType<DataController>,
+): ModuleType<DataController> => class DataControllerEditingExtender extends Base {
+  protected _editingController!: EditingController;
+
+  public init(): void {
+    this._editingController = this.getController('editing');
+    super.init();
+  }
+
+  public reload(full?: boolean, repaintChangesOnly?: boolean): DeferredObj<unknown> {
+    if (!repaintChangesOnly) {
+      this._editingController.refresh();
+    }
+
+    return super.reload(full, repaintChangesOnly);
+  }
+
+  public repaintRows(
+    rowIndexes: number | (number | undefined)[] | undefined,
+    changesOnly?: boolean,
+  ): void {
+    if (this._editingController.isSaving()) {
+      return;
+    }
+
+    super.repaintRows(rowIndexes, changesOnly);
+  }
+
+  private _updateEditRow(items: ProcessedItem[] | undefined): void {
+    if (!items) {
+      return;
+    }
+
+    const editRowKey = this.option(EDITING_EDITROWKEY_OPTION_NAME);
+    const editRowIndex = gridCoreUtils.getIndexByKey(editRowKey, items);
+    const editItem = items[editRowIndex];
+    if (editItem) {
+      editItem.isEditing = true;
+      // @ts-expect-error Badly typed based class
+      this._updateEditItem?.(editItem);
+    }
+  }
+
+  protected _updateItemsCore(change: DataChange): void {
+    super._updateItemsCore(change);
+    this._updateEditRow(this.items(true));
+  }
+
+  protected applyChangeUpdate(change: UpdateChange): void {
+    this._updateEditRow(change.items);
+    super.applyChangeUpdate(change);
+  }
+
+  protected applyChangesOnly(change: DataChange): void {
+    this._updateEditRow(change.items);
+    super.applyChangesOnly(change);
+  }
+
+  protected _processItems(items: RawItemData[], change: DataChange): ProcessedItem[] {
+    const editingItems = this._editingController.processItems(items, change);
+    return super._processItems(editingItems, change);
+  }
+
+  protected _processDataItem(
+    generatedItem: GeneratedItem,
+    options: ItemProcessingOptions,
+  ): ProcessedItem {
+    this._editingController.processDataItem(generatedItem, options);
+    return super._processDataItem(generatedItem, options);
+  }
+
+  protected _processItem(dataItem: RawItemData, options: ItemProcessingOptions): ProcessedItem {
+    const processedItem = super._processItem(dataItem, options);
+
+    if (processedItem.isNewRow) {
+      options.dataIndex -= 1;
+      delete processedItem.dataIndex;
+    }
+
+    return processedItem;
+  }
+
+  protected _getChangedColumnIndices(
+    oldItem: ProcessedItem,
+    newItem: ProcessedItem,
+    visibleRowIndex: number,
+    isLiveUpdate?: boolean,
+  ): number[] | undefined {
+    if (oldItem.isNewRow !== newItem.isNewRow || oldItem.removed !== newItem.removed) {
+      return undefined;
+    }
+
+    return super._getChangedColumnIndices(oldItem, newItem, visibleRowIndex, isLiveUpdate);
+  }
+
+  protected _isCellChanged(
+    oldRow: ProcessedItem,
+    newRow: ProcessedItem,
+    visibleRowIndex: number,
+    columnIndex: number,
+    isLiveUpdate?: boolean,
+  ): boolean {
+    const cell = oldRow.cells?.[columnIndex] as (Cell & { isEditing?: boolean }) | undefined;
+    const isEditing = this._editingController
+      && this._editingController.isEditCell(visibleRowIndex, columnIndex);
+
+    if (isLiveUpdate && isEditing) {
+      return false;
+    }
+
+    if (cell?.column && !cell.column.showEditorAlways && cell.isEditing !== isEditing) {
+      return true;
+    }
+
+    return super._isCellChanged(oldRow, newRow, visibleRowIndex, columnIndex, isLiveUpdate);
+  }
+
+  protected needToRefreshOnDataSourceChange(args?: OptionChanged): boolean {
+    const value = args?.value;
+    const isParasiteChange = Array.isArray(value)
+      && value === args?.previousValue
+      && this._editingController.isSaving();
+    return !isParasiteChange;
+  }
+
+  protected _handleDataSourceChange(args: OptionChanged): boolean {
+    const result = super._handleDataSourceChange(args);
+    const changes = this.option('editing.changes') as EditingDataChange[];
+    const dataSource = args.value;
+    if (Array.isArray(dataSource) && changes.length) {
+      const dataSourceKeys = dataSource.map((item) => this.keyOf(item));
+      const newChanges = changes.filter(
+        (change) => change.type === 'insert' || dataSourceKeys.some((key) => equalByValue(change.key, key)),
+      );
+      if (newChanges.length !== changes.length) {
+        this.option('editing.changes', newChanges);
+      }
+      const editRowKey = this.option('editing.editRowKey');
+      const isEditNewItem = newChanges.some(
+        (change) => change.type === 'insert' && equalByValue(editRowKey, change.key),
+      );
+      if (!isEditNewItem && dataSourceKeys.every((key) => !equalByValue(editRowKey, key))) {
+        this.option('editing.editRowKey', undefined);
+      }
+    }
+    return result;
+  }
+};

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_data_controller.ts
@@ -55,7 +55,7 @@ export const editingDataControllerExtender = (
     const editItem = items[editRowIndex];
     if (editItem) {
       editItem.isEditing = true;
-      // @ts-expect-error Badly typed based class
+      // @ts-expect-error form-based leakage
       this._updateEditItem?.(editItem);
     }
   }

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_data_controller.ts
@@ -17,6 +17,8 @@ import gridCoreUtils from '@ts/grids/grid_core/m_utils';
 import { EDITING_EDITROWKEY_OPTION_NAME } from '../const';
 import type { EditingController } from '../m_editing';
 
+type EditingCell = Cell & { isEditing?: boolean };
+
 export const dataControllerEditingExtenderMixin = (
   Base: ModuleType<DataController>,
 ): ModuleType<DataController> => class DataControllerEditingExtender extends Base {
@@ -120,7 +122,7 @@ export const dataControllerEditingExtenderMixin = (
     columnIndex: number,
     isLiveUpdate?: boolean,
   ): boolean {
-    const cell = oldRow.cells?.[columnIndex] as (Cell & { isEditing?: boolean }) | undefined;
+    const cell = oldRow.cells?.[columnIndex] as EditingCell | undefined;
     const isEditing = this._editingController
       && this._editingController.isEditCell(visibleRowIndex, columnIndex);
 
@@ -145,24 +147,33 @@ export const dataControllerEditingExtenderMixin = (
 
   protected _handleDataSourceChange(args: OptionChanged): boolean {
     const result = super._handleDataSourceChange(args);
-    const changes = this.option('editing.changes') as EditingDataChange[];
     const dataSource = args.value;
-    if (Array.isArray(dataSource) && changes.length) {
-      const dataSourceKeys = dataSource.map((item) => this.keyOf(item));
-      const newChanges = changes.filter(
-        (change) => change.type === 'insert' || dataSourceKeys.some((key) => equalByValue(change.key, key)),
-      );
-      if (newChanges.length !== changes.length) {
-        this.option('editing.changes', newChanges);
-      }
-      const editRowKey = this.option('editing.editRowKey');
-      const isEditNewItem = newChanges.some(
-        (change) => change.type === 'insert' && equalByValue(editRowKey, change.key),
-      );
-      if (!isEditNewItem && dataSourceKeys.every((key) => !equalByValue(editRowKey, key))) {
-        this.option('editing.editRowKey', undefined);
-      }
+    if (Array.isArray(dataSource)) {
+      this._dropEditingStateForRemovedItems(dataSource);
     }
     return result;
+  }
+
+  private _dropEditingStateForRemovedItems(dataSource: RawItemData[]): void {
+    const changes = this.option('editing.changes') as EditingDataChange[];
+    if (!changes.length) {
+      return;
+    }
+
+    const dataSourceKeys = dataSource.map((item) => this.keyOf(item));
+    const survivingChanges = changes.filter(
+      (change) => change.type === 'insert' || dataSourceKeys.some((key) => equalByValue(change.key, key)),
+    );
+    if (survivingChanges.length !== changes.length) {
+      this.option('editing.changes', survivingChanges);
+    }
+
+    const editRowKey = this.option('editing.editRowKey');
+    const isEditingNewRow = survivingChanges.some(
+      (change) => change.type === 'insert' && equalByValue(editRowKey, change.key),
+    );
+    if (!isEditingNewRow && dataSourceKeys.every((key) => !equalByValue(editRowKey, key))) {
+      this.option('editing.editRowKey', undefined);
+    }
   }
 };

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_form_based_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_form_based_data_controller.ts
@@ -1,0 +1,37 @@
+import type { DataController } from '@ts/grids/grid_core/data_controller/data_controller';
+import type { ProcessedItem } from '@ts/grids/grid_core/data_controller/types';
+import type { ModuleType } from '@ts/grids/grid_core/m_types';
+
+import type { EditingController } from '../m_editing';
+
+export const dataControllerEditingFormBasedExtender = (
+  Base: ModuleType<DataController>,
+): ModuleType<DataController> => class DataEditingFormBasedExtender extends Base {
+  protected _editingController!: EditingController;
+
+  public init(): void {
+    this._editingController = this.getController('editing');
+    super.init();
+  }
+
+  private _updateEditItem(item: ProcessedItem): void {
+    // @ts-expect-error isFormEditMode is private on the editing controller
+    if (this._editingController.isFormEditMode()) {
+      item.rowType = 'detail';
+    }
+  }
+
+  protected _getChangedColumnIndices(
+    oldItem: ProcessedItem,
+    newItem: ProcessedItem,
+    visibleRowIndex: number,
+    isLiveUpdate?: boolean,
+  ): number[] | undefined {
+    // @ts-expect-error isFormEditMode is private on the editing controller
+    if (isLiveUpdate === false && newItem.isEditing && this._editingController.isFormEditMode()) {
+      return undefined;
+    }
+
+    return super._getChangedColumnIndices(oldItem, newItem, visibleRowIndex, isLiveUpdate);
+  }
+};

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_form_based_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_form_based_data_controller.ts
@@ -4,18 +4,21 @@ import type { ModuleType } from '@ts/grids/grid_core/m_types';
 
 import type { EditingController } from '../m_editing';
 
-export const dataControllerEditingFormBasedExtender = (
+interface FormBasedEditingControllerExtension {
+  isFormEditMode: () => boolean;
+}
+
+export const editingFormBasedDataControllerExtender = (
   Base: ModuleType<DataController>,
-): ModuleType<DataController> => class DataEditingFormBasedExtender extends Base {
-  protected _editingController!: EditingController;
+): ModuleType<DataController> => class EditingFormBasedDataControllerExtender extends Base {
+  protected _editingController!: EditingController & FormBasedEditingControllerExtension;
 
   public init(): void {
-    this._editingController = this.getController('editing');
+    this._editingController = this.getController('editing') as EditingController & FormBasedEditingControllerExtension;
     super.init();
   }
 
   private _updateEditItem(item: ProcessedItem): void {
-    // @ts-expect-error isFormEditMode is private on the editing controller
     if (this._editingController.isFormEditMode()) {
       item.rowType = 'detail';
     }
@@ -27,7 +30,6 @@ export const dataControllerEditingFormBasedExtender = (
     visibleRowIndex: number,
     isLiveUpdate?: boolean,
   ): number[] | undefined {
-    // @ts-expect-error isFormEditMode is private on the editing controller
     if (isLiveUpdate === false && newItem.isEditing && this._editingController.isFormEditMode()) {
       return undefined;
     }

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_row_based_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_row_based_data_controller.ts
@@ -4,9 +4,9 @@ import type { ModuleType } from '@ts/grids/grid_core/m_types';
 
 import type { EditingController } from '../m_editing';
 
-export const dataControllerEditingRowBasedExtender = (
+export const editingRowBasedDataControllerExtender = (
   Base: ModuleType<DataController>,
-): ModuleType<DataController> => class DataEditingRowBasedExtender extends Base {
+): ModuleType<DataController> => class EditingRowBasedDataControllerExtender extends Base {
   protected _editingController!: EditingController;
 
   public init(): void {

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_row_based_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_row_based_data_controller.ts
@@ -1,0 +1,29 @@
+import type { DataController } from '@ts/grids/grid_core/data_controller/data_controller';
+import type { ProcessedItem } from '@ts/grids/grid_core/data_controller/types';
+import type { ModuleType } from '@ts/grids/grid_core/m_types';
+
+import type { EditingController } from '../m_editing';
+
+export const dataControllerEditingRowBasedExtender = (
+  Base: ModuleType<DataController>,
+): ModuleType<DataController> => class DataEditingRowBasedExtender extends Base {
+  protected _editingController!: EditingController;
+
+  public init(): void {
+    this._editingController = this.getController('editing');
+    super.init();
+  }
+
+  protected _getChangedColumnIndices(
+    oldItem: ProcessedItem,
+    newItem: ProcessedItem,
+    visibleRowIndex: number,
+    isLiveUpdate?: boolean,
+  ): number[] | undefined {
+    if (this._editingController.isRowBasedEditMode() && oldItem.isEditing !== newItem.isEditing) {
+      return undefined;
+    }
+
+    return super._getChangedColumnIndices(oldItem, newItem, visibleRowIndex, isLiveUpdate);
+  }
+};

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
@@ -91,6 +91,7 @@ import {
   VIEWPORT_BOTTOM_NEW_ROW_POSITION,
   VIEWPORT_TOP_NEW_ROW_POSITION,
 } from './const';
+import { dataControllerEditingExtenderMixin } from './extenders/editing_data_controller';
 import type { ICellBasedEditingControllerExtender } from './m_editing_cell_based';
 import type { IFormBasedEditingControllerExtender } from './m_editing_form_based';
 import {
@@ -2544,117 +2545,7 @@ export type EditingController = EditingControllerImpl
   & ICellBasedEditingControllerExtender
   & IFormBasedEditingControllerExtender;
 
-export const dataControllerEditingExtenderMixin = (Base: ModuleType<DataController>) => class DataControllerEditingExtender extends Base {
-  public reload(full, repaintChangesOnly) {
-    !repaintChangesOnly && this._editingController.refresh();
-
-    return super.reload.apply(this, arguments as any);
-  }
-
-  public repaintRows() {
-    if (this._editingController.isSaving()) return;
-    return super.repaintRows.apply(this, arguments as any);
-  }
-
-  private _updateEditRow(items) {
-    const editRowKey = this.option(EDITING_EDITROWKEY_OPTION_NAME);
-    const editRowIndex = gridCoreUtils.getIndexByKey(editRowKey, items);
-    const editItem = items[editRowIndex];
-    if (editItem) {
-      editItem.isEditing = true;
-      // @ts-expect-error Badly typed based class
-      this._updateEditItem?.(editItem);
-    }
-  }
-
-  protected _updateItemsCore(change: DataChange): void {
-    super._updateItemsCore(change);
-    this._updateEditRow(this.items(true));
-  }
-
-  protected applyChangeUpdate(change) {
-    this._updateEditRow(change.items);
-    super.applyChangeUpdate(change);
-  }
-
-  protected applyChangesOnly(change) {
-    this._updateEditRow(change.items);
-    super.applyChangesOnly(change);
-  }
-
-  protected _processItems(items: RawItemData[], change: DataChange): ProcessedItem[] {
-    items = this._editingController.processItems(items, change);
-    return super._processItems(items, change);
-  }
-
-  protected _processDataItem(
-    generatedItem: GeneratedItem,
-    options: ItemProcessingOptions,
-  ): ProcessedItem {
-    this._editingController.processDataItem(generatedItem, options);
-    return super._processDataItem(generatedItem, options);
-  }
-
-  protected _processItem(dataItem: RawItemData, options: ItemProcessingOptions) {
-    const processedItem = super._processItem(dataItem, options);
-
-    if (processedItem.isNewRow) {
-      options.dataIndex--;
-      delete processedItem.dataIndex;
-    }
-
-    return processedItem;
-  }
-
-  protected _getChangedColumnIndices(oldItem, newItem, rowIndex, isLiveUpdate) {
-    if (oldItem.isNewRow !== newItem.isNewRow || oldItem.removed !== newItem.removed) {
-      return;
-    }
-
-    return super._getChangedColumnIndices.apply(this, arguments as any);
-  }
-
-  protected _isCellChanged(oldRow, newRow, visibleRowIndex, columnIndex, isLiveUpdate) {
-    const cell = oldRow.cells && oldRow.cells[columnIndex];
-    const isEditing = this._editingController && this._editingController.isEditCell(visibleRowIndex, columnIndex);
-
-    if (isLiveUpdate && isEditing) {
-      return false;
-    }
-
-    if (cell && cell.column && !cell.column.showEditorAlways && cell.isEditing !== isEditing) {
-      return true;
-    }
-
-    return super._isCellChanged.apply(this, arguments as any);
-  }
-
-  protected needToRefreshOnDataSourceChange(args) {
-    const isParasiteChange = Array.isArray(args.value) && args.value === args.previousValue && this._editingController.isSaving();
-    return !isParasiteChange;
-  }
-
-  protected _handleDataSourceChange(args) {
-    const result = super._handleDataSourceChange(args);
-    const changes: any = this.option('editing.changes');
-    const dataSource = args.value;
-    if (Array.isArray(dataSource) && changes.length) {
-      const dataSourceKeys = dataSource.map((item) => this.keyOf(item));
-      const newChanges = changes.filter((change) => change.type === 'insert' || dataSourceKeys.some((key) => equalByValue(change.key, key)));
-      if (newChanges.length !== changes.length) {
-        this.option('editing.changes', newChanges);
-      }
-      const editRowKey = this.option('editing.editRowKey');
-      const isEditNewItem = newChanges.some(
-        (change) => change.type === 'insert' && equalByValue(editRowKey, change.key),
-      );
-      if (!isEditNewItem && dataSourceKeys.every((key) => !equalByValue(editRowKey, key))) {
-        this.option('editing.editRowKey', undefined);
-      }
-    }
-    return result;
-  }
-};
+export { dataControllerEditingExtenderMixin };
 
 const rowsView = (Base: ModuleType<RowsView>) => class RowsViewEditingExtender extends Base {
   private _pointerDownTarget: any;

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing.ts
@@ -91,7 +91,7 @@ import {
   VIEWPORT_BOTTOM_NEW_ROW_POSITION,
   VIEWPORT_TOP_NEW_ROW_POSITION,
 } from './const';
-import { dataControllerEditingExtenderMixin } from './extenders/editing_data_controller';
+import { editingDataControllerExtender } from './extenders/editing_data_controller';
 import type { ICellBasedEditingControllerExtender } from './m_editing_cell_based';
 import type { IFormBasedEditingControllerExtender } from './m_editing_form_based';
 import {
@@ -2545,8 +2545,6 @@ export type EditingController = EditingControllerImpl
   & ICellBasedEditingControllerExtender
   & IFormBasedEditingControllerExtender;
 
-export { dataControllerEditingExtenderMixin };
-
 const rowsView = (Base: ModuleType<RowsView>) => class RowsViewEditingExtender extends Base {
   private _pointerDownTarget: any;
 
@@ -2869,7 +2867,7 @@ export const editingModule = {
   },
   extenders: {
     controllers: {
-      data: dataControllerEditingExtenderMixin,
+      data: editingDataControllerExtender,
     },
     views: {
       rowsView,

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing_form_based.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing_form_based.ts
@@ -33,7 +33,7 @@ import {
   FOCUSABLE_ELEMENT_SELECTOR,
   FORM_BUTTONS_CONTAINER_CLASS,
 } from './const';
-import { dataControllerEditingFormBasedExtender } from './extenders/editing_form_based_data_controller';
+import { editingFormBasedDataControllerExtender } from './extenders/editing_form_based_data_controller';
 import type { EditingController } from './m_editing';
 import { forEachFormItems, getEditorType } from './m_editing_utils';
 
@@ -584,7 +584,7 @@ export const editingFormBasedModule = {
   extenders: {
     controllers: {
       editing: editingControllerExtender,
-      data: dataControllerEditingFormBasedExtender,
+      data: editingFormBasedDataControllerExtender,
     },
     views: {
       rowsView,

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing_form_based.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing_form_based.ts
@@ -15,7 +15,6 @@ import Button from '@js/ui/button';
 import Form from '@js/ui/form';
 import Popup from '@js/ui/popup/ui.popup';
 import Scrollable from '@js/ui/scroll_view/ui.scrollable';
-import type { DataController } from '@ts/grids/grid_core/data_controller/data_controller';
 import type { RowsView } from '@ts/grids/grid_core/views/m_rows_view';
 
 import type { ModuleType } from '../m_types';
@@ -34,6 +33,7 @@ import {
   FOCUSABLE_ELEMENT_SELECTOR,
   FORM_BUTTONS_CONTAINER_CLASS,
 } from './const';
+import { dataControllerEditingFormBasedExtender } from './extenders/editing_form_based_data_controller';
 import type { EditingController } from './m_editing';
 import { forEachFormItems, getEditorType } from './m_editing_utils';
 
@@ -495,24 +495,6 @@ const editingControllerExtender = (Base: ModuleType<EditingController>) => class
   }
 };
 
-const data = (Base: ModuleType<DataController>) => class DataEditingFormBasedExtender extends Base {
-  private _updateEditItem(item) {
-    // @ts-expect-error
-    if (this._editingController.isFormEditMode()) {
-      item.rowType = 'detail';
-    }
-  }
-
-  protected _getChangedColumnIndices(oldItem, newItem, visibleRowIndex, isLiveUpdate) {
-    // @ts-expect-error
-    if (isLiveUpdate === false && newItem.isEditing && this._editingController.isFormEditMode()) {
-      return;
-    }
-
-    return super._getChangedColumnIndices.apply(this, arguments as any);
-  }
-};
-
 const rowsView = (Base: ModuleType<RowsView>) => class RowsViewEditingFormBasedExtender extends Base {
   protected _renderCellContent($cell, options) {
     // @ts-expect-error
@@ -602,7 +584,7 @@ export const editingFormBasedModule = {
   extenders: {
     controllers: {
       editing: editingControllerExtender,
-      data,
+      data: dataControllerEditingFormBasedExtender,
     },
     views: {
       rowsView,

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing_row_based.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing_row_based.ts
@@ -11,7 +11,7 @@ import {
   MODES_WITH_DELAYED_FOCUS,
   ROW_SELECTED_CLASS,
 } from './const';
-import { dataControllerEditingRowBasedExtender } from './extenders/editing_row_based_data_controller';
+import { editingRowBasedDataControllerExtender } from './extenders/editing_row_based_data_controller';
 import type { EditingController } from './m_editing';
 
 const editingControllerExtender = (Base: ModuleType<EditingController>) => class RowBasedEditingControllerExtender extends Base {
@@ -140,7 +140,7 @@ export const editingRowBasedModule = {
   extenders: {
     controllers: {
       editing: editingControllerExtender,
-      data: dataControllerEditingRowBasedExtender,
+      data: editingRowBasedDataControllerExtender,
     },
     views: {
       rowsView,

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing_row_based.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/m_editing_row_based.ts
@@ -1,6 +1,5 @@
 /* eslint-disable max-classes-per-file */
 import { equalByValue } from '@js/core/utils/common';
-import type { DataController } from '@ts/grids/grid_core/data_controller/data_controller';
 import type { RowsView } from '@ts/grids/grid_core/views/m_rows_view';
 
 import type { ModuleType } from '../m_types';
@@ -12,6 +11,7 @@ import {
   MODES_WITH_DELAYED_FOCUS,
   ROW_SELECTED_CLASS,
 } from './const';
+import { dataControllerEditingRowBasedExtender } from './extenders/editing_row_based_data_controller';
 import type { EditingController } from './m_editing';
 
 const editingControllerExtender = (Base: ModuleType<EditingController>) => class RowBasedEditingControllerExtender extends Base {
@@ -107,17 +107,6 @@ const editingControllerExtender = (Base: ModuleType<EditingController>) => class
   }
 };
 
-const data = (Base: ModuleType<DataController>) => class DataEditingRowBasedExtender extends Base {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected _getChangedColumnIndices(oldItem, newItem, rowIndex, isLiveUpdate) {
-    if (this._editingController.isRowBasedEditMode() && oldItem.isEditing !== newItem.isEditing) {
-      return;
-    }
-
-    return super._getChangedColumnIndices.apply(this, arguments as any);
-  }
-};
-
 const rowsView = (Base: ModuleType<RowsView>) => class RowsViewEditingRowBasedExtender extends Base {
   protected _createRow(row) {
     const $row = super._createRow.apply(this, arguments as any);
@@ -151,7 +140,7 @@ export const editingRowBasedModule = {
   extenders: {
     controllers: {
       editing: editingControllerExtender,
-      data,
+      data: dataControllerEditingRowBasedExtender,
     },
     views: {
       rowsView,

--- a/packages/devextreme/js/__internal/grids/tree_list/editing/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/tree_list/editing/m_editing.ts
@@ -8,7 +8,8 @@ import { extend } from '@js/core/utils/extend';
 import { isDefined } from '@js/core/utils/type';
 import errors from '@js/ui/widget/ui.errors';
 import type { DataController } from '@ts/grids/grid_core/data_controller/data_controller';
-import { dataControllerEditingExtenderMixin, editingModule } from '@ts/grids/grid_core/editing/m_editing';
+import { editingDataControllerExtender } from '@ts/grids/grid_core/editing/extenders/editing_data_controller';
+import { editingModule } from '@ts/grids/grid_core/editing/m_editing';
 import type { ModuleType } from '@ts/grids/grid_core/m_types';
 import gridCoreUtils from '@ts/grids/grid_core/m_utils';
 
@@ -233,7 +234,7 @@ const rowsView = (Base: ModuleType<RowsView>) => class TreeListEditingRowsViewEx
   }
 };
 
-const data = (Base: ModuleType<DataController>) => class DataControllerTreeListEditingExtender extends dataControllerEditingExtenderMixin(Base) {
+const data = (Base: ModuleType<DataController>) => class DataControllerTreeListEditingExtender extends editingDataControllerExtender(Base) {
   private changeRowExpand() {
     this._editingController.refresh();
     // @ts-expect-error

--- a/packages/devextreme/js/__internal/grids/tree_list/editing/m_editing.ts
+++ b/packages/devextreme/js/__internal/grids/tree_list/editing/m_editing.ts
@@ -234,7 +234,7 @@ const rowsView = (Base: ModuleType<RowsView>) => class TreeListEditingRowsViewEx
   }
 };
 
-const data = (Base: ModuleType<DataController>) => class DataControllerTreeListEditingExtender extends editingDataControllerExtender(Base) {
+const data = (Base: ModuleType<DataController>) => class TreeListEditingDataControllerExtender extends editingDataControllerExtender(Base) {
   private changeRowExpand() {
     this._editingController.refresh();
     // @ts-expect-error


### PR DESCRIPTION
### What
Adds local resolution of `_editingController` in the editing data-controller extenders (`m_editing`, form-based, row-based)

### How
Each editing data-extender declares the field and resolves the `editing` controller in its own `init()`