### PR TITLE
 Grids: forbid bare signal reads with a custom ESLint rule (T1334012)

### DIFF
--- a/packages/devextreme/eslint.config.mjs
+++ b/packages/devextreme/eslint.config.mjs
@@ -679,6 +679,20 @@ export default [
             '@typescript-eslint/lines-between-class-members': 'off',
         },
     },
+    // Rules for signal-based code
+    {
+        files: [
+            'js/__internal/grids/new/**/*.ts?(x)',
+            'js/__internal/core/state_manager/**/*.ts',
+        ],
+        ignores: [
+            '**/*.test.ts',
+            '**/*.test.tsx',
+        ],
+        rules: {
+            'devextreme-custom/no-bare-property-read': 'error',
+        },
+    },
     // Rules for Jest tests
     {
         files: ['js/__internal/**/*test.ts?(x)'],

--- a/packages/devextreme/eslint_plugins/index.js
+++ b/packages/devextreme/eslint_plugins/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable spellcheck/spell-checker */
 const noDirectPreactSignalsCoreImport = require('./no_direct_preact_signals_core_import');
+const noBarePropertyRead = require('./no_bare_property_read');
 const preferSwitchTrue = require('./prefer_switch_true');
 const noDeferred = require('./no_deferred');
 const jsdocDefaultMatchesType = require('./jsdoc_default_matches_type');
@@ -7,6 +8,7 @@ const jsdocDefaultMatchesType = require('./jsdoc_default_matches_type');
 module.exports = {
     rules: {
         'no-direct-preact-signals-core-import': noDirectPreactSignalsCoreImport,
+        'no-bare-property-read': noBarePropertyRead,
         'prefer-switch-true': preferSwitchTrue,
         'no-deferred': noDeferred,
         'jsdoc-default-matches-type': jsdocDefaultMatchesType,

--- a/packages/devextreme/eslint_plugins/no_bare_property_read.js
+++ b/packages/devextreme/eslint_plugins/no_bare_property_read.js
@@ -1,0 +1,55 @@
+const TRANSPARENT_WRAPPERS = [
+    'ChainExpression',
+    'TSNonNullExpression',
+    'TSAsExpression',
+];
+
+function collectBareReads(node) {
+    if(!node) {
+        return [];
+    }
+
+    if(node.type === 'MemberExpression') {
+        return [node];
+    }
+
+    if(TRANSPARENT_WRAPPERS.includes(node.type)) {
+        return collectBareReads(node.expression);
+    }
+
+    if(node.type === 'UnaryExpression' && node.operator === 'void') {
+        return collectBareReads(node.argument);
+    }
+
+    if(node.type === 'SequenceExpression') {
+        return node.expressions.flatMap((expression) => collectBareReads(expression));
+    }
+
+    return [];
+}
+
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Prevent standalone property reads, which minifiers with compress.pure_getters delete.',
+        },
+        schema: [],
+        messages: {
+            bareRead: 'A standalone property read is deleted by minifiers with compress.pure_getters (T1334012). If this is a signal subscription, use "track(...)" from "@ts/core/state_manager/index"; otherwise delete the statement.',
+        },
+    },
+
+    create(context) {
+        return {
+            ExpressionStatement(node) {
+                collectBareReads(node.expression).forEach((read) => {
+                    context.report({
+                        node: read,
+                        messageId: 'bareRead',
+                    });
+                });
+            },
+        };
+    },
+};

--- a/packages/devextreme/eslint_plugins/no_bare_property_read.test.js
+++ b/packages/devextreme/eslint_plugins/no_bare_property_read.test.js
@@ -1,0 +1,82 @@
+/* eslint-disable spellcheck/spell-checker */
+const { RuleTester } = require('eslint');
+const tsParser = require('@typescript-eslint/parser');
+const rule = require('./no_bare_property_read');
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+    },
+});
+
+const tsRuleTester = new RuleTester({
+    languageOptions: {
+        parser: tsParser,
+        ecmaVersion: 2020,
+        sourceType: 'module',
+    },
+});
+
+const bareRead = (count = 1) => new Array(count).fill({
+    messageId: 'bareRead',
+    type: 'MemberExpression',
+});
+
+ruleTester.run('no-bare-property-read', rule, {
+    valid: [
+        'track(this.visibleColumnsLayout.value);',
+        'const layout = this.visibleColumnsLayout.value;',
+        'this.items.value = [];',
+        'this.dataController.items.value.forEach(handler);',
+        'if(this.isLoaded.value) { load(); }',
+        'delete cache.items;',
+        'load();',
+        '\'use strict\';',
+    ],
+
+    invalid: [
+        {
+            code: 'this.visibleColumnsLayout.value;',
+            errors: bareRead(),
+        },
+        {
+            code: 'this.dataController.items.value;',
+            errors: bareRead(),
+        },
+        {
+            code: 'options[\'value\'];',
+            errors: bareRead(),
+        },
+        {
+            // `void` slips past the stock no-unused-expressions rule, and terser deletes it too
+            code: 'void this.componentDescription.value;',
+            errors: bareRead(),
+        },
+        {
+            code: 'this.items.value, this.isLoaded.value;',
+            errors: bareRead(2),
+        },
+        {
+            code: 'this.searchController?.highlightTextOptions.value;',
+            errors: bareRead(),
+        },
+    ],
+});
+
+tsRuleTester.run('no-bare-property-read (typescript)', rule, {
+    valid: [
+        'track(this.actionOption.value as unknown);',
+    ],
+
+    invalid: [
+        {
+            code: 'this.actionOption!.value;',
+            errors: bareRead(),
+        },
+        {
+            code: 'this.actionOption.value as unknown;',
+            errors: bareRead(),
+        },
+    ],
+});


### PR DESCRIPTION
<!--
Before you submit a pull request, review our contribution guidelines (CONTRIBUTING.md).

If your pull request contains a bug fix, its title should include "fixes ISSUE_ID" or "resolves ISSUE_ID".

In addition, please clarify:

1. What does the PR change?
2. How did you achieve this?
3. How can we verify these changes?

-->
