### PR TITLE
T1283037 - Charts - DashStyle throws a TypeScript error when a combination of dash styles (e.g., 'dashdotdash') is used

### DIFF
--- a/packages/devextreme/js/common/charts.d.ts
+++ b/packages/devextreme/js/common/charts.d.ts
@@ -2,6 +2,7 @@ import { HorizontalAlignment } from '../common';
 import { Format } from '../localization';
 import { BaseLegendItem } from '../viz/common';
 import { baseSeriesObject } from '../viz/chart';
+import { RepeatUnion } from '../core';
 
 /**
  * @public
@@ -48,8 +49,9 @@ export type ChartsDataType = 'datetime' | 'numeric' | 'string';
 /**
  * @public
  * @namespace DevExpress.common.charts
+ * @type 'dash'|'dot'|'longDash'|'solid'
  */
-export type DashStyle = 'dash' | 'dot' | 'longDash' | 'solid';
+export type DashStyle = 'solid' | RepeatUnion<'dash' | 'dot' | 'longDash', 5>;
 
 /**
  * @public

--- a/packages/devextreme/js/common/charts.d.ts
+++ b/packages/devextreme/js/common/charts.d.ts
@@ -2,7 +2,6 @@ import { HorizontalAlignment } from '../common';
 import { Format } from '../localization';
 import { BaseLegendItem } from '../viz/common';
 import { baseSeriesObject } from '../viz/chart';
-import { RepeatUnion } from '../core';
 
 /**
  * @public
@@ -49,9 +48,13 @@ export type ChartsDataType = 'datetime' | 'numeric' | 'string';
 /**
  * @public
  * @namespace DevExpress.common.charts
- * @type 'dash'|'dot'|'longDash'|'solid'
  */
-export type DashStyle = 'solid' | RepeatUnion<'dash' | 'dot' | 'longDash', 5>;
+export type DashStyle = 'solid'
+| 'dash' | 'dot' | 'longDash'
+| `${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}`
+| `${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}`
+| `${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}`
+| `${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}`;
 
 /**
  * @public

--- a/packages/devextreme/js/core/index.d.ts
+++ b/packages/devextreme/js/core/index.d.ts
@@ -63,24 +63,6 @@ export type AllPermutations<T extends string> = UnionLength<T> extends PermutedU
   [K in T]: Permutations<T> | AllPermutations<Exclude<T, K>>
 }[T] : string;
 
-type BuildTuple<Length extends number, Result extends unknown[] = []> = Result['length'] extends Length
-  ? Result
-  : BuildTuple<Length, [...Result, unknown]>;
-
-type Tail<T extends unknown[]> = T extends [unknown, ...infer Rest] ? Rest : [];
-
-type RepeatUnionInternal<
-  T extends string,
-  DepthTuple extends unknown[],
-> = DepthTuple['length'] extends 0
-  ? never
-  : T | `${T}${RepeatUnionInternal<T, Tail<DepthTuple>>}`;
-
-export type RepeatUnion<
-  T extends string,
-  Depth extends number,
-> = RepeatUnionInternal<T, BuildTuple<Depth>>;
-
 /// #DEBUG
 
 export type EventProps<T> = Extract<keyof T, `on${any}`>;

--- a/packages/devextreme/js/core/index.d.ts
+++ b/packages/devextreme/js/core/index.d.ts
@@ -63,6 +63,24 @@ export type AllPermutations<T extends string> = UnionLength<T> extends PermutedU
   [K in T]: Permutations<T> | AllPermutations<Exclude<T, K>>
 }[T] : string;
 
+type BuildTuple<Length extends number, Result extends unknown[] = []> = Result['length'] extends Length
+  ? Result
+  : BuildTuple<Length, [...Result, unknown]>;
+
+type Tail<T extends unknown[]> = T extends [unknown, ...infer Rest] ? Rest : [];
+
+type RepeatUnionInternal<
+  T extends string,
+  DepthTuple extends unknown[],
+> = DepthTuple['length'] extends 0
+  ? never
+  : T | `${T}${RepeatUnionInternal<T, Tail<DepthTuple>>}`;
+
+export type RepeatUnion<
+  T extends string,
+  Depth extends number,
+> = RepeatUnionInternal<T, BuildTuple<Depth>>;
+
 /// #DEBUG
 
 export type EventProps<T> = Extract<keyof T, `on${any}`>;

--- a/packages/devextreme/ts/dx.all.d.ts
+++ b/packages/devextreme/ts/dx.all.d.ts
@@ -2075,7 +2075,9 @@ declare module DevExpress.common.charts {
   };
   export type ChartsDataType = 'datetime' | 'numeric' | 'string';
   export type ChartsLabelOverlap = 'hide' | 'none' | 'stack';
-  export type DashStyle = 'dash' | 'dot' | 'longDash' | 'solid';
+  export type DashStyle =
+    | 'solid'
+    | DevExpress.core.RepeatUnion<'dash' | 'dot' | 'longDash', 5>;
   export type DiscreteAxisDivisionMode = 'betweenLabels' | 'crossLabels';
   /**
    * [descr:Font]
@@ -7192,6 +7194,15 @@ declare module DevExpress.core {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
+  type BuildTuple<
+    Length extends number,
+    Result extends unknown[] = []
+  > = Result['length'] extends Length
+    ? Result
+    : BuildTuple<Length, [...Result, unknown]>;
+  /**
+   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
+   */
   export type ComponentFactory<TComponent> = {
     new (
       element: UserDefinedElement,
@@ -7486,6 +7497,22 @@ declare module DevExpress.core {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
+  export type RepeatUnion<
+    T extends string,
+    Depth extends number
+  > = RepeatUnionInternal<T, BuildTuple<Depth>>;
+  /**
+   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
+   */
+  type RepeatUnionInternal<
+    T extends string,
+    DepthTuple extends unknown[]
+  > = DepthTuple['length'] extends 0
+    ? never
+    : T | `${T}${RepeatUnionInternal<T, Tail<DepthTuple>>}`;
+  /**
+   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
+   */
   export type Scalar =
     | string
     | String
@@ -7501,6 +7528,12 @@ declare module DevExpress.core {
     | Array<unknown>
     | null
     | undefined;
+  /**
+   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
+   */
+  type Tail<T extends unknown[]> = T extends [unknown, ...infer Rest]
+    ? Rest
+    : [];
 
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.

--- a/packages/devextreme/ts/dx.all.d.ts
+++ b/packages/devextreme/ts/dx.all.d.ts
@@ -697,12 +697,11 @@ declare module DevExpress {
    * [descr:DOMComponentOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface DOMComponentOptions<TComponent>
-    extends ComponentOptions<
-      DevExpress.common.core.events.EventInfo<TComponent>,
-      DevExpress.common.core.events.InitializedEventInfo<TComponent>,
-      DevExpress.DOMComponent.OptionChangedEventInfo<TComponent>
-    > {
+  export interface DOMComponentOptions<TComponent> extends ComponentOptions<
+    DevExpress.common.core.events.EventInfo<TComponent>,
+    DevExpress.common.core.events.InitializedEventInfo<TComponent>,
+    DevExpress.DOMComponent.OptionChangedEventInfo<TComponent>
+  > {
     /**
      * [descr:DOMComponentOptions.elementAttr]
      */
@@ -2077,7 +2076,13 @@ declare module DevExpress.common.charts {
   export type ChartsLabelOverlap = 'hide' | 'none' | 'stack';
   export type DashStyle =
     | 'solid'
-    | DevExpress.core.RepeatUnion<'dash' | 'dot' | 'longDash', 5>;
+    | 'dash'
+    | 'dot'
+    | 'longDash'
+    | `${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}`
+    | `${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}`
+    | `${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}`
+    | `${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}${'dash' | 'dot' | 'longDash'}`;
   export type DiscreteAxisDivisionMode = 'betweenLabels' | 'crossLabels';
   /**
    * [descr:Font]
@@ -3269,8 +3274,10 @@ declare module DevExpress.common.data {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface AbstractStoreOptions<TItem = any, TKey = any>
-    extends StoreOptions<TItem, TKey> {
+  export interface AbstractStoreOptions<
+    TItem = any,
+    TKey = any
+  > extends StoreOptions<TItem, TKey> {
     /**
      * [descr:StoreOptions.onLoaded]
      */
@@ -7194,15 +7201,6 @@ declare module DevExpress.core {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  type BuildTuple<
-    Length extends number,
-    Result extends unknown[] = []
-  > = Result['length'] extends Length
-    ? Result
-    : BuildTuple<Length, [...Result, unknown]>;
-  /**
-   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
-   */
   export type ComponentFactory<TComponent> = {
     new (
       element: UserDefinedElement,
@@ -7497,22 +7495,6 @@ declare module DevExpress.core {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export type RepeatUnion<
-    T extends string,
-    Depth extends number
-  > = RepeatUnionInternal<T, BuildTuple<Depth>>;
-  /**
-   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
-   */
-  type RepeatUnionInternal<
-    T extends string,
-    DepthTuple extends unknown[]
-  > = DepthTuple['length'] extends 0
-    ? never
-    : T | `${T}${RepeatUnionInternal<T, Tail<DepthTuple>>}`;
-  /**
-   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
-   */
   export type Scalar =
     | string
     | String
@@ -7528,12 +7510,6 @@ declare module DevExpress.core {
     | Array<unknown>
     | null
     | undefined;
-  /**
-   * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
-   */
-  type Tail<T extends unknown[]> = T extends [unknown, ...infer Rest]
-    ? Rest
-    : [];
 
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
@@ -7584,9 +7560,8 @@ declare module DevExpress.core.utils {
     * [descr:DxPromise]
     * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
     */
-   export type DxPromise<T = void> = {} extends PromiseType<T>
-    ? Promise<T>
-    : PromiseType<T>;
+   export type DxPromise<T = void> =
+    {} extends PromiseType<T> ? Promise<T> : PromiseType<T>;
 }
 declare module DevExpress.data {
   /**
@@ -8588,8 +8563,7 @@ declare module DevExpress.fileManagement {
    * @deprecated [depNote:CustomFileSystemProviderOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface CustomFileSystemProviderOptions
-    extends FileSystemProviderBaseOptions<CustomFileSystemProvider> {
+  export interface CustomFileSystemProviderOptions extends FileSystemProviderBaseOptions<CustomFileSystemProvider> {
     /**
      * [descr:CustomFileSystemProviderOptions.abortFileUpload]
      */
@@ -8880,8 +8854,7 @@ declare module DevExpress.fileManagement {
    * @deprecated [depNote:ObjectFileSystemProviderOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface ObjectFileSystemProviderOptions
-    extends FileSystemProviderBaseOptions<ObjectFileSystemProvider> {
+  export interface ObjectFileSystemProviderOptions extends FileSystemProviderBaseOptions<ObjectFileSystemProvider> {
     /**
      * [descr:ObjectFileSystemProviderOptions.contentExpr]
      */
@@ -8913,8 +8886,7 @@ declare module DevExpress.fileManagement {
    * @deprecated [depNote:RemoteFileSystemProviderOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface RemoteFileSystemProviderOptions
-    extends FileSystemProviderBaseOptions<RemoteFileSystemProvider> {
+  export interface RemoteFileSystemProviderOptions extends FileSystemProviderBaseOptions<RemoteFileSystemProvider> {
     /**
      * [descr:RemoteFileSystemProviderOptions.beforeAjaxSend]
      */
@@ -9253,7 +9225,8 @@ declare module DevExpress.ui {
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
   export class DateBoxBase<
-    TProperties extends DevExpress.ui.Editor.EditorOptionsWithValue = DevExpress.ui.dxDateBox.Properties
+    TProperties extends DevExpress.ui.Editor.EditorOptionsWithValue =
+      DevExpress.ui.dxDateBox.Properties
   > extends dxDropDownEditor<TProperties> {
     /**
      * [descr:DateBoxBase.close()]
@@ -9268,8 +9241,10 @@ declare module DevExpress.ui {
    * [descr:DateBoxBaseOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface DateBoxBaseOptions<TComponent>
-    extends Omit<dxDropDownEditorOptions<TComponent>, 'fieldAddons'> {
+  export interface DateBoxBaseOptions<TComponent> extends Omit<
+    dxDropDownEditorOptions<TComponent>,
+    'fieldAddons'
+  > {
     /**
      * [descr:DateBoxBaseOptions.applyButtonText]
      */
@@ -9331,8 +9306,9 @@ declare module DevExpress.ui {
    * [descr:DraggableBaseOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface DraggableBaseOptions<TComponent>
-    extends DOMComponentOptions<TComponent> {
+  export interface DraggableBaseOptions<
+    TComponent
+  > extends DOMComponentOptions<TComponent> {
     /**
      * [descr:DraggableBaseOptions.autoScroll]
      */
@@ -9971,8 +9947,7 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxAutocompleteOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxAutocompleteOptions
-    extends dxDropDownListOptions<dxAutocomplete> {
+  export interface dxAutocompleteOptions extends dxDropDownListOptions<dxAutocomplete> {
     /**
      * [descr:dxAutocompleteOptions.maxItemCount]
      */
@@ -11184,8 +11159,10 @@ declare module DevExpress.ui {
    * [descr:dxCardViewOptions]
    * @deprecated [depNote:dxCardViewOptions]
    */
-  export interface dxCardViewOptions<TCardData = unknown, TKey = unknown>
-    extends Omit<WidgetOptions<dxCardView>, 'onOptionChanged'> {
+  export interface dxCardViewOptions<
+    TCardData = unknown,
+    TKey = unknown
+  > extends Omit<WidgetOptions<dxCardView>, 'onOptionChanged'> {
     /**
      * [descr:dxCardViewOptions.dataSource]
      */
@@ -12136,8 +12113,7 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxColorBoxOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxColorBoxOptions
-    extends dxDropDownEditorOptions<dxColorBox> {
+  export interface dxColorBoxOptions extends dxDropDownEditorOptions<dxColorBox> {
     /**
      * [descr:dxColorBoxOptions.applyButtonText]
      */
@@ -14424,8 +14400,10 @@ declare module DevExpress.ui {
    * @deprecated Use the DevExpress.ui.dxDataGrid.Column type instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxDataGridColumn<TRowData = any, TKey = any>
-    extends DevExpress.ui.dxDataGrid.ColumnBase<TRowData> {
+  export interface dxDataGridColumn<
+    TRowData = any,
+    TKey = any
+  > extends DevExpress.ui.dxDataGrid.ColumnBase<TRowData> {
     /**
      * [descr:dxDataGridColumn.allowExporting]
      */
@@ -16699,8 +16677,7 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxDraggableOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxDraggableOptions
-    extends DraggableBaseOptions<dxDraggable> {
+  export interface dxDraggableOptions extends DraggableBaseOptions<dxDraggable> {
     /**
      * [descr:dxDraggableOptions.clone]
      */
@@ -16968,7 +16945,8 @@ declare module DevExpress.ui {
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
   export interface dxDropDownBoxOptions
-    extends DataExpressionMixinOptions<dxDropDownBox>,
+    extends
+      DataExpressionMixinOptions<dxDropDownBox>,
       dxDropDownEditorOptions<dxDropDownBox> {
     /**
      * [descr:dxDropDownBoxOptions.acceptCustomValue]
@@ -17127,8 +17105,7 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxDropDownButtonOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxDropDownButtonOptions
-    extends WidgetOptions<dxDropDownButton> {
+  export interface dxDropDownButtonOptions extends WidgetOptions<dxDropDownButton> {
     /**
      * [descr:dxDropDownButtonOptions.dataSource]
      */
@@ -17272,7 +17249,8 @@ declare module DevExpress.ui {
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
   export class dxDropDownEditor<
-    TProperties extends DevExpress.ui.Editor.EditorOptionsWithValue = DevExpress.ui.dxDropDownEditor.Properties
+    TProperties extends DevExpress.ui.Editor.EditorOptionsWithValue =
+      DevExpress.ui.dxDropDownEditor.Properties
   > extends dxTextBox<TProperties> {
     /**
      * [descr:dxDropDownEditor.close()]
@@ -17317,8 +17295,10 @@ declare module DevExpress.ui {
    * [descr:dxDropDownEditorOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxDropDownEditorOptions<TComponent>
-    extends Omit<dxTextBoxOptions<TComponent>, 'validationMessagePosition'> {
+  export interface dxDropDownEditorOptions<TComponent> extends Omit<
+    dxTextBoxOptions<TComponent>,
+    'validationMessagePosition'
+  > {
     /**
      * [descr:dxDropDownEditorOptions.acceptCustomValue]
      */
@@ -17424,7 +17404,8 @@ declare module DevExpress.ui {
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
   export interface dxDropDownListOptions<TComponent>
-    extends DataExpressionMixinOptions<TComponent>,
+    extends
+      DataExpressionMixinOptions<TComponent>,
       Omit<dxDropDownEditorOptions<TComponent>, 'fieldAddons'> {
     /**
      * [descr:dxDropDownListOptions.displayValue]
@@ -19161,8 +19142,7 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxFilterBuilderOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxFilterBuilderOptions
-    extends WidgetOptions<dxFilterBuilder> {
+  export interface dxFilterBuilderOptions extends WidgetOptions<dxFilterBuilder> {
     /**
      * [descr:dxFilterBuilderOptions.allowHierarchicalFields]
      */
@@ -20857,8 +20837,10 @@ declare module DevExpress.ui {
    * [descr:dxGanttColumn]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  interface dxGanttColumnBlank<TRowData = any, TKey = any>
-    extends Omit<DevExpress.ui.dxTreeList.Column<TRowData, TKey>, 'ai'> {
+  interface dxGanttColumnBlank<TRowData = any, TKey = any> extends Omit<
+    DevExpress.ui.dxTreeList.Column<TRowData, TKey>,
+    'ai'
+  > {
     /**
      * [descr:dxGanttColumn.allowEditing]
      */
@@ -22689,7 +22671,9 @@ declare module DevExpress.ui {
   export interface dxListOptions<
     TItem extends DevExpress.ui.dxList.ItemLike = any,
     TKey = any
-  > extends CollectionWidgetOptions<dxList<TItem, TKey>, TItem, TKey>,
+  >
+    extends
+      CollectionWidgetOptions<dxList<TItem, TKey>, TItem, TKey>,
       SearchBoxMixinOptions {
     /**
      * [descr:dxListOptions.activeStateEnabled]
@@ -22952,8 +22936,7 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxLoadIndicatorOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxLoadIndicatorOptions
-    extends WidgetOptions<dxLoadIndicator> {
+  export interface dxLoadIndicatorOptions extends WidgetOptions<dxLoadIndicator> {
     /**
      * [descr:dxLoadIndicatorOptions.animationType]
      */
@@ -23895,9 +23878,9 @@ declare module DevExpress.ui {
     TItem extends DevExpress.ui.dxMenuBase.ItemLike = any,
     TKey = any
   > extends Omit<
-      HierarchicalCollectionWidgetOptions<TComponent, TItem, TKey>,
-      'dataSource'
-    > {
+    HierarchicalCollectionWidgetOptions<TComponent, TItem, TKey>,
+    'dataSource'
+  > {
     /**
      * [descr:dxMenuBaseOptions.activeStateEnabled]
      */
@@ -24446,8 +24429,9 @@ declare module DevExpress.ui {
    * [descr:dxOverlayOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxOverlayOptions<TComponent>
-    extends WidgetOptions<TComponent> {
+  export interface dxOverlayOptions<
+    TComponent
+  > extends WidgetOptions<TComponent> {
     /**
      * [descr:dxOverlayOptions.animation]
      */
@@ -24566,8 +24550,7 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxPaginationOptions]
    */
   export interface dxPaginationOptions
-    extends DevExpress.common.PagerBase,
-      WidgetOptions<dxPagination> {
+    extends DevExpress.common.PagerBase, WidgetOptions<dxPagination> {
     /**
      * [descr:dxPaginationOptions.pageIndex]
      */
@@ -24846,8 +24829,7 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxPivotGridFieldChooserOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxPivotGridFieldChooserOptions
-    extends WidgetOptions<dxPivotGridFieldChooser> {
+  export interface dxPivotGridFieldChooserOptions extends WidgetOptions<dxPivotGridFieldChooser> {
     /**
      * [descr:dxPivotGridFieldChooserOptions.allowSearch]
      */
@@ -25583,8 +25565,9 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxPopoverOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxPopoverOptions<TComponent>
-    extends dxPopupOptions<TComponent> {
+  export interface dxPopoverOptions<
+    TComponent
+  > extends dxPopupOptions<TComponent> {
     /**
      * [descr:dxPopoverOptions.animation]
      */
@@ -25733,8 +25716,9 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxPopupOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxPopupOptions<TComponent>
-    extends dxOverlayOptions<TComponent> {
+  export interface dxPopupOptions<
+    TComponent
+  > extends dxOverlayOptions<TComponent> {
     /**
      * [descr:dxPopupOptions.animation]
      */
@@ -25893,8 +25877,7 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxProgressBarOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxProgressBarOptions
-    extends dxTrackBarOptions<dxProgressBar> {
+  export interface dxProgressBarOptions extends dxTrackBarOptions<dxProgressBar> {
     /**
      * [descr:dxProgressBarOptions.onComplete]
      */
@@ -25959,7 +25942,8 @@ declare module DevExpress.ui {
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
   export interface dxRadioGroupOptions
-    extends EditorOptions<dxRadioGroup>,
+    extends
+      EditorOptions<dxRadioGroup>,
       DataExpressionMixinOptions<dxRadioGroup> {
     /**
      * [descr:dxRadioGroupOptions.activeStateEnabled]
@@ -26046,8 +26030,7 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxRangeSliderOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxRangeSliderOptions
-    extends dxSliderBaseOptions<dxRangeSlider> {
+  export interface dxRangeSliderOptions extends dxSliderBaseOptions<dxRangeSlider> {
     /**
      * [descr:dxRangeSliderOptions.end]
      */
@@ -27684,11 +27667,8 @@ declare module DevExpress.ui {
      * [descr:ScrollEventInfo]
      * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
      */
-    export interface ScrollEventInfo<T>
-      extends DevExpress.common.core.events.NativeEventInfo<
-        T,
-        WheelEvent | MouseEvent | Event
-      > {
+    export interface ScrollEventInfo<T> extends DevExpress.common.core.events
+      .NativeEventInfo<T, WheelEvent | MouseEvent | Event> {
       /**
        * [descr:ScrollEventInfo.scrollOffset]
        */
@@ -27715,8 +27695,9 @@ declare module DevExpress.ui {
    * [descr:dxScrollableOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxScrollableOptions<TComponent>
-    extends DOMComponentOptions<TComponent> {
+  export interface dxScrollableOptions<
+    TComponent
+  > extends DOMComponentOptions<TComponent> {
     /**
      * [descr:dxScrollableOptions.bounceEnabled]
      */
@@ -27817,8 +27798,7 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxScrollViewOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxScrollViewOptions
-    extends dxScrollableOptions<dxScrollView> {
+  export interface dxScrollViewOptions extends dxScrollableOptions<dxScrollView> {
     /**
      * [descr:dxScrollViewOptions.onPullDown]
      */
@@ -27852,7 +27832,8 @@ declare module DevExpress.ui {
    * [descr:dxSelectBox]
    */
   export class dxSelectBox<
-    TProperties extends DevExpress.ui.Editor.EditorOptionsWithValue = DevExpress.ui.dxSelectBox.Properties
+    TProperties extends DevExpress.ui.Editor.EditorOptionsWithValue =
+      DevExpress.ui.dxSelectBox.Properties
   > extends dxDropDownList<TProperties> {}
   module dxSelectBox {
     /**
@@ -28016,8 +27997,9 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxSelectBoxOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxSelectBoxOptions<TComponent>
-    extends dxDropDownListOptions<TComponent> {
+  export interface dxSelectBoxOptions<
+    TComponent
+  > extends dxDropDownListOptions<TComponent> {
     /**
      * [descr:dxSelectBoxOptions.acceptCustomValue]
      */
@@ -28120,8 +28102,9 @@ declare module DevExpress.ui {
    * [descr:dxSliderBaseOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxSliderBaseOptions<TComponent>
-    extends dxTrackBarOptions<TComponent> {
+  export interface dxSliderBaseOptions<
+    TComponent
+  > extends dxTrackBarOptions<TComponent> {
     /**
      * [descr:dxSliderBaseOptions.activeStateEnabled]
      */
@@ -28828,8 +28811,7 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxSpeedDialActionOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxSpeedDialActionOptions
-    extends WidgetOptions<dxSpeedDialAction> {
+  export interface dxSpeedDialActionOptions extends WidgetOptions<dxSpeedDialAction> {
     /**
      * [descr:dxSpeedDialActionOptions.icon]
      */
@@ -30001,11 +29983,10 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxTagBoxOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxTagBoxOptions
-    extends Pick<
-      dxSelectBoxOptions<dxTagBox>,
-      Exclude<keyof dxSelectBoxOptions<dxTagBox>, 'onSelectionChanged'>
-    > {
+  export interface dxTagBoxOptions extends Pick<
+    dxSelectBoxOptions<dxTagBox>,
+    Exclude<keyof dxSelectBoxOptions<dxTagBox>, 'onSelectionChanged'>
+  > {
     /**
      * [descr:dxTagBoxOptions.applyValueMode]
      */
@@ -30216,7 +30197,8 @@ declare module DevExpress.ui {
    * [descr:dxTextBox]
    */
   export class dxTextBox<
-    TProperties extends DevExpress.ui.Editor.EditorOptionsWithValue = DevExpress.ui.dxTextBox.Properties
+    TProperties extends DevExpress.ui.Editor.EditorOptionsWithValue =
+      DevExpress.ui.dxTextBox.Properties
   > extends dxTextEditor<TProperties> {
     /**
      * [descr:dxTextBox.reset(value)]
@@ -30346,8 +30328,9 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxTextBoxOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxTextBoxOptions<TComponent>
-    extends dxTextEditorOptions<TComponent> {
+  export interface dxTextBoxOptions<
+    TComponent
+  > extends dxTextEditorOptions<TComponent> {
     /**
      * [descr:dxTextBoxOptions.maxLength]
      */
@@ -30366,7 +30349,8 @@ declare module DevExpress.ui {
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
   export class dxTextEditor<
-    TProperties extends DevExpress.ui.Editor.EditorOptionsWithValue = DevExpress.ui.dxTextEditor.Properties
+    TProperties extends DevExpress.ui.Editor.EditorOptionsWithValue =
+      DevExpress.ui.dxTextEditor.Properties
   > extends Editor<TProperties> {
     /**
      * [descr:dxTextEditor.blur()]
@@ -30395,8 +30379,9 @@ declare module DevExpress.ui {
    * [descr:dxTextEditorOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxTextEditorOptions<TComponent>
-    extends EditorOptions<TComponent> {
+  export interface dxTextEditorOptions<
+    TComponent
+  > extends EditorOptions<TComponent> {
     /**
      * [descr:dxTextEditorOptions.buttons]
      */
@@ -31121,8 +31106,9 @@ declare module DevExpress.ui {
    * [descr:dxTrackBarOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxTrackBarOptions<TComponent>
-    extends EditorOptions<TComponent> {
+  export interface dxTrackBarOptions<
+    TComponent
+  > extends EditorOptions<TComponent> {
     /**
      * [descr:dxTrackBarOptions.max]
      */
@@ -31618,8 +31604,8 @@ declare module DevExpress.ui {
     /**
      * [descr:dxTreeListEditing]
      */
-    export interface Editing<TRowData = any, TKey = any>
-      extends DevExpress.common.grids.EditingBase<TRowData, TKey> {
+    export interface Editing<TRowData = any, TKey = any> extends DevExpress
+      .common.grids.EditingBase<TRowData, TKey> {
       /**
        * [descr:dxTreeListOptions.editing.allowAdding]
        */
@@ -32557,8 +32543,10 @@ declare module DevExpress.ui {
    * @deprecated Use the DevExpress.ui.dxTreeList.Column type instead
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxTreeListColumn<TRowData = any, TKey = any>
-    extends DevExpress.common.grids.ColumnBase<TRowData> {
+  export interface dxTreeListColumn<
+    TRowData = any,
+    TKey = any
+  > extends DevExpress.common.grids.ColumnBase<TRowData> {
     /**
      * [descr:dxTreeListColumn.buttons]
      */
@@ -33274,7 +33262,9 @@ declare module DevExpress.ui {
   export interface dxTreeViewOptions<
     TItem extends DevExpress.ui.dxTreeView.ItemLike = any,
     TKey = any
-  > extends Omit<
+  >
+    extends
+      Omit<
         HierarchicalCollectionWidgetOptions<
           dxTreeView<TItem, TKey>,
           TItem,
@@ -33480,8 +33470,7 @@ declare module DevExpress.ui {
    * @deprecated [depNote:dxValidationGroupOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxValidationGroupOptions
-    extends DOMComponentOptions<dxValidationGroup> {}
+  export interface dxValidationGroupOptions extends DOMComponentOptions<dxValidationGroup> {}
   /**
    * [descr:dxValidationGroupResult]
    * @deprecated [depNote:dxValidationGroupResult]
@@ -33529,8 +33518,7 @@ declare module DevExpress.ui {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxValidationMessageOptions
-    extends dxOverlayOptions<dxValidationMessage> {
+  export interface dxValidationMessageOptions extends dxOverlayOptions<dxValidationMessage> {
     mode?: string;
 
     validationErrors?: Array<object> | null;
@@ -33630,10 +33618,10 @@ declare module DevExpress.ui {
     TItem extends DevExpress.ui.CollectionWidget.ItemLike = any,
     TKey = any
   > extends CollectionWidgetOptions<
-      dxValidationSummary<TItem, TKey>,
-      TItem,
-      TKey
-    > {
+    dxValidationSummary<TItem, TKey>,
+    TItem,
+    TKey
+  > {
     /**
      * [descr:dxValidationSummaryOptions.validationGroup]
      */
@@ -33807,7 +33795,8 @@ declare module DevExpress.ui {
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
   export class Editor<
-    TProperties extends DevExpress.ui.Editor.EditorOptionsWithValue = DevExpress.ui.Editor.Properties
+    TProperties extends DevExpress.ui.Editor.EditorOptionsWithValue =
+      DevExpress.ui.Editor.Properties
   > extends Widget<TProperties> {
     /**
      * [descr:Editor.clear()]
@@ -34166,8 +34155,9 @@ declare module DevExpress.ui {
    * [descr:WidgetOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface WidgetOptions<TComponent>
-    extends DOMComponentOptions<TComponent> {
+  export interface WidgetOptions<
+    TComponent
+  > extends DOMComponentOptions<TComponent> {
     /**
      * [descr:WidgetOptions.accessKey]
      */
@@ -35173,16 +35163,10 @@ declare module DevExpress.ui.dxHtmlEditor {
   /**
    * [descr:AIToolbarItem]
    */
-  export interface AIToolbarItem
-    extends Omit<
-      DevExpress.ui.dxToolbar.Item,
-      | 'menuItemTemplate'
-      | 'showText'
-      | 'widget'
-      | 'options'
-      | 'template'
-      | 'html'
-    > {
+  export interface AIToolbarItem extends Omit<
+    DevExpress.ui.dxToolbar.Item,
+    'menuItemTemplate' | 'showText' | 'widget' | 'options' | 'template' | 'html'
+  > {
     /**
      * [descr:AIToolbarItem.name]
      */
@@ -35517,8 +35501,7 @@ declare module DevExpress.viz {
    * [descr:BaseChartAnnotationConfig]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface BaseChartAnnotationConfig
-    extends BaseWidgetAnnotationConfig {
+  export interface BaseChartAnnotationConfig extends BaseWidgetAnnotationConfig {
     /**
      * [descr:BaseChartAnnotationConfig.argument]
      */
@@ -35681,8 +35664,9 @@ declare module DevExpress.viz {
    * [descr:BaseChartTooltip]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface BaseChartTooltip<TPointInfo = any>
-    extends BaseWidgetTooltip {
+  export interface BaseChartTooltip<
+    TPointInfo = any
+  > extends BaseWidgetTooltip {
     /**
      * [descr:BaseChartOptions.tooltip.argumentFormat]
      */
@@ -35776,8 +35760,7 @@ declare module DevExpress.viz {
    * [descr:BaseGaugeLoadingIndicator]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface BaseGaugeLoadingIndicator
-    extends BaseWidgetLoadingIndicator {
+  export interface BaseGaugeLoadingIndicator extends BaseWidgetLoadingIndicator {
     /**
      * [descr:BaseGaugeOptions.loadingIndicator.enabled]
      */
@@ -35787,8 +35770,9 @@ declare module DevExpress.viz {
    * [descr:BaseGaugeOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface BaseGaugeOptions<TComponent>
-    extends BaseWidgetOptions<TComponent> {
+  export interface BaseGaugeOptions<
+    TComponent
+  > extends BaseWidgetOptions<TComponent> {
     /**
      * [descr:BaseGaugeOptions.animation]
      */
@@ -36288,8 +36272,9 @@ declare module DevExpress.viz {
    * [descr:BaseSparklineOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface BaseSparklineOptions<TComponent>
-    extends BaseWidgetOptions<TComponent> {
+  export interface BaseSparklineOptions<
+    TComponent
+  > extends BaseWidgetOptions<TComponent> {
     /**
      * [descr:BaseSparklineOptions.export]
      */
@@ -36696,8 +36681,9 @@ declare module DevExpress.viz {
    * [descr:BaseWidgetOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface BaseWidgetOptions<TComponent>
-    extends DOMComponentOptions<TComponent> {
+  export interface BaseWidgetOptions<
+    TComponent
+  > extends DOMComponentOptions<TComponent> {
     /**
      * [descr:BaseWidgetOptions.disabled]
      */
@@ -39180,8 +39166,7 @@ declare module DevExpress.viz {
    * [descr:dxChartAnnotationConfig]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartAnnotationConfig
-    extends dxChartCommonAnnotationConfig {
+  export interface dxChartAnnotationConfig extends dxChartCommonAnnotationConfig {
     /**
      * [descr:dxChartAnnotationConfig.name]
      */
@@ -39191,8 +39176,7 @@ declare module DevExpress.viz {
    * [descr:dxChartCommonAnnotationConfig]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartCommonAnnotationConfig
-    extends BaseChartAnnotationConfig {
+  export interface dxChartCommonAnnotationConfig extends BaseChartAnnotationConfig {
     /**
      * [descr:dxChartCommonAnnotationConfig.axis]
      */
@@ -39229,8 +39213,10 @@ declare module DevExpress.viz {
    * @deprecated [depNote:dxChartOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartOptions
-    extends BaseChartOptions<dxChart, chartPointObject> {
+  export interface dxChartOptions extends BaseChartOptions<
+    dxChart,
+    chartPointObject
+  > {
     /**
      * [descr:dxChartOptions.adjustOnZoom]
      */
@@ -39759,8 +39745,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesAreaSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesAreaSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.AreaSeries.aggregation]
      */
@@ -39785,8 +39770,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesAreaSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesAreaSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.AreaSeries.aggregation.method]
      */
@@ -39815,8 +39799,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesBarSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesBarSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.BarSeries.aggregation]
      */
@@ -39841,8 +39824,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesBarSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesBarSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.BarSeries.aggregation.method]
      */
@@ -39861,8 +39843,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesBubbleSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesBubbleSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.BubbleSeries.aggregation]
      */
@@ -39887,8 +39868,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesBubbleSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesBubbleSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.BubbleSeries.aggregation.method]
      */
@@ -39907,8 +39887,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesCandleStickSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesCandleStickSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.CandleStickSeries.aggregation]
      */
@@ -39945,8 +39924,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesCandleStickSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesCandleStickSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.CandleStickSeries.aggregation.method]
      */
@@ -39955,8 +39933,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesCandleStickSeriesHoverStyle
-    extends dxChartSeriesTypesCommonSeriesHoverStyle {
+  export interface dxChartSeriesTypesCandleStickSeriesHoverStyle extends dxChartSeriesTypesCommonSeriesHoverStyle {
     /**
      * [descr:dxChartSeriesTypes.CandleStickSeries.hoverStyle.hatching]
      */
@@ -39965,8 +39942,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesCandleStickSeriesHoverStyleHatching
-    extends dxChartSeriesTypesCommonSeriesHoverStyleHatching {
+  export interface dxChartSeriesTypesCandleStickSeriesHoverStyleHatching extends dxChartSeriesTypesCommonSeriesHoverStyleHatching {
     /**
      * [descr:dxChartSeriesTypes.CandleStickSeries.hoverStyle.hatching.direction]
      */
@@ -39985,8 +39961,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesCandleStickSeriesSelectionStyle
-    extends dxChartSeriesTypesCommonSeriesSelectionStyle {
+  export interface dxChartSeriesTypesCandleStickSeriesSelectionStyle extends dxChartSeriesTypesCommonSeriesSelectionStyle {
     /**
      * [descr:dxChartSeriesTypes.CandleStickSeries.selectionStyle.hatching]
      */
@@ -39995,8 +39970,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesCandleStickSeriesSelectionStyleHatching
-    extends dxChartSeriesTypesCommonSeriesSelectionStyleHatching {
+  export interface dxChartSeriesTypesCandleStickSeriesSelectionStyleHatching extends dxChartSeriesTypesCommonSeriesSelectionStyleHatching {
     /**
      * [descr:dxChartSeriesTypes.CandleStickSeries.selectionStyle.hatching.direction]
      */
@@ -40389,8 +40363,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesFullStackedAreaSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesFullStackedAreaSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.FullStackedAreaSeries.aggregation]
      */
@@ -40415,8 +40388,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesFullStackedAreaSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesFullStackedAreaSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.FullStackedAreaSeries.aggregation.method]
      */
@@ -40445,8 +40417,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesFullStackedBarSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesFullStackedBarSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.FullStackedBarSeries.aggregation]
      */
@@ -40471,8 +40442,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesFullStackedBarSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesFullStackedBarSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.FullStackedBarSeries.aggregation.method]
      */
@@ -40495,8 +40465,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesFullStackedLineSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesFullStackedLineSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.FullStackedLineSeries.aggregation]
      */
@@ -40517,8 +40486,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesFullStackedLineSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesFullStackedLineSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.FullStackedLineSeries.aggregation.method]
      */
@@ -40537,8 +40505,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesFullStackedSplineAreaSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesFullStackedSplineAreaSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.FullStackedSplineAreaSeries.aggregation]
      */
@@ -40563,8 +40530,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesFullStackedSplineAreaSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesFullStackedSplineAreaSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.FullStackedSplineAreaSeries.aggregation.method]
      */
@@ -40593,8 +40559,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesFullStackedSplineSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesFullStackedSplineSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.FullStackedSplineSeries.aggregation]
      */
@@ -40615,8 +40580,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesFullStackedSplineSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesFullStackedSplineSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.FullStackedSplineSeries.aggregation.method]
      */
@@ -40635,8 +40599,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesLineSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesLineSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.LineSeries.aggregation]
      */
@@ -40657,8 +40620,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesLineSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesLineSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.LineSeries.aggregation.method]
      */
@@ -40677,8 +40639,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesRangeAreaSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesRangeAreaSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.RangeAreaSeries.aggregation]
      */
@@ -40703,8 +40664,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesRangeAreaSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesRangeAreaSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.RangeAreaSeries.aggregation.method]
      */
@@ -40733,8 +40693,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesRangeBarSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesRangeBarSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.RangeBarSeries.aggregation]
      */
@@ -40759,8 +40718,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesRangeBarSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesRangeBarSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.RangeBarSeries.aggregation.method]
      */
@@ -40779,8 +40737,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesScatterSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesScatterSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.ScatterSeries.aggregation]
      */
@@ -40793,8 +40750,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesScatterSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesScatterSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.ScatterSeries.aggregation.method]
      */
@@ -40813,8 +40769,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesSplineAreaSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesSplineAreaSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.SplineAreaSeries.aggregation]
      */
@@ -40839,8 +40794,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesSplineAreaSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesSplineAreaSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.SplineAreaSeries.aggregation.method]
      */
@@ -40869,8 +40823,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesSplineSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesSplineSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.SplineSeries.aggregation]
      */
@@ -40891,8 +40844,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesSplineSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesSplineSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.SplineSeries.aggregation.method]
      */
@@ -40911,8 +40863,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStackedAreaSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesStackedAreaSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.StackedAreaSeries.aggregation]
      */
@@ -40937,8 +40888,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStackedAreaSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesStackedAreaSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.StackedAreaSeries.aggregation.method]
      */
@@ -40967,8 +40917,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStackedBarSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesStackedBarSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.StackedBarSeries.aggregation]
      */
@@ -40993,8 +40942,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStackedBarSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesStackedBarSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.StackedBarSeries.aggregation.method]
      */
@@ -41017,8 +40965,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStackedLineSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesStackedLineSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.StackedLineSeries.aggregation]
      */
@@ -41039,8 +40986,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStackedLineSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesStackedLineSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.StackedLineSeries.aggregation.method]
      */
@@ -41059,8 +41005,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStackedSplineAreaSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesStackedSplineAreaSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.StackedSplineAreaSeries.aggregation]
      */
@@ -41085,8 +41030,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStackedSplineAreaSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesStackedSplineAreaSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.StackedSplineAreaSeries.aggregation.method]
      */
@@ -41115,8 +41059,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStackedSplineSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesStackedSplineSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.StackedSplineSeries.aggregation]
      */
@@ -41137,8 +41080,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStackedSplineSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesStackedSplineSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.StackedSplineSeries.aggregation.method]
      */
@@ -41157,8 +41099,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStepAreaSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesStepAreaSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.StepAreaSeries.aggregation]
      */
@@ -41195,8 +41136,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStepAreaSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesStepAreaSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.StepAreaSeries.aggregation.method]
      */
@@ -41205,8 +41145,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStepAreaSeriesBorder
-    extends dxChartSeriesTypesCommonSeriesBorder {
+  export interface dxChartSeriesTypesStepAreaSeriesBorder extends dxChartSeriesTypesCommonSeriesBorder {
     /**
      * [descr:dxChartSeriesTypes.StepAreaSeries.border.visible]
      */
@@ -41215,8 +41154,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStepAreaSeriesHoverStyle
-    extends dxChartSeriesTypesCommonSeriesHoverStyle {
+  export interface dxChartSeriesTypesStepAreaSeriesHoverStyle extends dxChartSeriesTypesCommonSeriesHoverStyle {
     /**
      * [descr:dxChartSeriesTypes.StepAreaSeries.hoverStyle.border]
      */
@@ -41225,8 +41163,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStepAreaSeriesHoverStyleBorder
-    extends dxChartSeriesTypesCommonSeriesHoverStyleBorder {
+  export interface dxChartSeriesTypesStepAreaSeriesHoverStyleBorder extends dxChartSeriesTypesCommonSeriesHoverStyleBorder {
     /**
      * [descr:dxChartSeriesTypes.StepAreaSeries.hoverStyle.border.visible]
      */
@@ -41255,8 +41192,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStepAreaSeriesSelectionStyle
-    extends dxChartSeriesTypesCommonSeriesSelectionStyle {
+  export interface dxChartSeriesTypesStepAreaSeriesSelectionStyle extends dxChartSeriesTypesCommonSeriesSelectionStyle {
     /**
      * [descr:dxChartSeriesTypes.StepAreaSeries.selectionStyle.border]
      */
@@ -41265,8 +41201,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStepAreaSeriesSelectionStyleBorder
-    extends dxChartSeriesTypesCommonSeriesSelectionStyleBorder {
+  export interface dxChartSeriesTypesStepAreaSeriesSelectionStyleBorder extends dxChartSeriesTypesCommonSeriesSelectionStyleBorder {
     /**
      * [descr:dxChartSeriesTypes.StepAreaSeries.selectionStyle.border.visible]
      */
@@ -41275,8 +41210,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStepLineSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesStepLineSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.StepLineSeries.aggregation]
      */
@@ -41297,8 +41231,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStepLineSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesStepLineSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.StepLineSeries.aggregation.method]
      */
@@ -41317,8 +41250,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStockSeries
-    extends dxChartSeriesTypesCommonSeries {
+  export interface dxChartSeriesTypesStockSeries extends dxChartSeriesTypesCommonSeries {
     /**
      * [descr:dxChartSeriesTypes.StockSeries.aggregation]
      */
@@ -41347,8 +41279,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxChartSeriesTypesStockSeriesAggregation
-    extends dxChartSeriesTypesCommonSeriesAggregation {
+  export interface dxChartSeriesTypesStockSeriesAggregation extends dxChartSeriesTypesCommonSeriesAggregation {
     /**
      * [descr:dxChartSeriesTypes.StockSeries.aggregation.method]
      */
@@ -41475,8 +41406,7 @@ declare module DevExpress.viz {
    * @deprecated [depNote:dxCircularGaugeOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxCircularGaugeOptions
-    extends BaseGaugeOptions<dxCircularGauge> {
+  export interface dxCircularGaugeOptions extends BaseGaugeOptions<dxCircularGauge> {
     /**
      * [descr:dxCircularGaugeOptions.geometry]
      */
@@ -42172,8 +42102,7 @@ declare module DevExpress.viz {
    * @deprecated [depNote:dxLinearGaugeOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxLinearGaugeOptions
-    extends BaseGaugeOptions<dxLinearGauge> {
+  export interface dxLinearGaugeOptions extends BaseGaugeOptions<dxLinearGauge> {
     /**
      * [descr:dxLinearGaugeOptions.geometry]
      */
@@ -42408,8 +42337,7 @@ declare module DevExpress.viz {
    * [descr:dxPieChartAnnotationConfig]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxPieChartAnnotationConfig
-    extends dxPieChartCommonAnnotationConfig {
+  export interface dxPieChartAnnotationConfig extends dxPieChartCommonAnnotationConfig {
     /**
      * [descr:dxPieChartAnnotationConfig.name]
      */
@@ -42419,8 +42347,7 @@ declare module DevExpress.viz {
    * [descr:dxPieChartCommonAnnotationConfig]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxPieChartCommonAnnotationConfig
-    extends BaseWidgetAnnotationConfig {
+  export interface dxPieChartCommonAnnotationConfig extends BaseWidgetAnnotationConfig {
     /**
      * [descr:dxPieChartCommonAnnotationConfig.location]
      */
@@ -42465,8 +42392,10 @@ declare module DevExpress.viz {
    * @deprecated [depNote:dxPieChartOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxPieChartOptions
-    extends BaseChartOptions<dxPieChart, piePointObject> {
+  export interface dxPieChartOptions extends BaseChartOptions<
+    dxPieChart,
+    piePointObject
+  > {
     /**
      * [descr:dxPieChartOptions.adaptiveLayout]
      */
@@ -43791,8 +43720,7 @@ declare module DevExpress.viz {
    * [descr:dxPolarChartAnnotationConfig]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxPolarChartAnnotationConfig
-    extends dxPolarChartCommonAnnotationConfig {
+  export interface dxPolarChartAnnotationConfig extends dxPolarChartCommonAnnotationConfig {
     /**
      * [descr:dxPolarChartAnnotationConfig.name]
      */
@@ -43802,8 +43730,7 @@ declare module DevExpress.viz {
    * [descr:dxPolarChartCommonAnnotationConfig]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxPolarChartCommonAnnotationConfig
-    extends BaseChartAnnotationConfig {
+  export interface dxPolarChartCommonAnnotationConfig extends BaseChartAnnotationConfig {
     /**
      * [descr:dxPolarChartCommonAnnotationConfig.angle]
      */
@@ -43844,8 +43771,10 @@ declare module DevExpress.viz {
    * @deprecated [depNote:dxPolarChartOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxPolarChartOptions
-    extends BaseChartOptions<dxPolarChart, polarPointObject> {
+  export interface dxPolarChartOptions extends BaseChartOptions<
+    dxPolarChart,
+    polarPointObject
+  > {
     /**
      * [descr:dxPolarChartOptions.adaptiveLayout]
      */
@@ -44036,8 +43965,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxPolarChartSeriesTypesAreapolarseries
-    extends dxPolarChartSeriesTypesCommonPolarChartSeries {
+  export interface dxPolarChartSeriesTypesAreapolarseries extends dxPolarChartSeriesTypesCommonPolarChartSeries {
     /**
      * [descr:dxPolarChartSeriesTypes.areapolarseries.hoverMode]
      */
@@ -44054,8 +43982,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxPolarChartSeriesTypesAreapolarseriesPoint
-    extends dxPolarChartSeriesTypesCommonPolarChartSeriesPoint {
+  export interface dxPolarChartSeriesTypesAreapolarseriesPoint extends dxPolarChartSeriesTypesCommonPolarChartSeriesPoint {
     /**
      * [descr:dxPolarChartSeriesTypes.areapolarseries.point.visible]
      */
@@ -44064,8 +43991,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxPolarChartSeriesTypesBarpolarseries
-    extends dxPolarChartSeriesTypesCommonPolarChartSeries {
+  export interface dxPolarChartSeriesTypesBarpolarseries extends dxPolarChartSeriesTypesCommonPolarChartSeries {
     /**
      * [descr:dxPolarChartSeriesTypes.barpolarseries.hoverMode]
      */
@@ -44564,8 +44490,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxPolarChartSeriesTypesLinepolarseries
-    extends dxPolarChartSeriesTypesCommonPolarChartSeries {
+  export interface dxPolarChartSeriesTypesLinepolarseries extends dxPolarChartSeriesTypesCommonPolarChartSeries {
     /**
      * [descr:dxPolarChartSeriesTypes.linepolarseries.hoverMode]
      */
@@ -44578,8 +44503,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxPolarChartSeriesTypesStackedbarpolarseries
-    extends dxPolarChartSeriesTypesCommonPolarChartSeries {
+  export interface dxPolarChartSeriesTypesStackedbarpolarseries extends dxPolarChartSeriesTypesCommonPolarChartSeries {
     /**
      * [descr:dxPolarChartSeriesTypes.stackedbarpolarseries.hoverMode]
      */
@@ -44600,8 +44524,7 @@ declare module DevExpress.viz {
   /**
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxPolarChartSeriesTypesStackedbarpolarseriesLabel
-    extends dxPolarChartSeriesTypesCommonPolarChartSeriesLabel {
+  export interface dxPolarChartSeriesTypesStackedbarpolarseriesLabel extends dxPolarChartSeriesTypesCommonPolarChartSeriesLabel {
     /**
      * [descr:dxPolarChartSeriesTypes.stackedbarpolarseries.label.position]
      */
@@ -44715,8 +44638,7 @@ declare module DevExpress.viz {
    * @deprecated [depNote:dxRangeSelectorOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxRangeSelectorOptions
-    extends BaseWidgetOptions<dxRangeSelector> {
+  export interface dxRangeSelectorOptions extends BaseWidgetOptions<dxRangeSelector> {
     /**
      * [descr:dxRangeSelectorOptions.background]
      */
@@ -45887,8 +45809,7 @@ declare module DevExpress.viz {
    * @deprecated [depNote:dxSparklineOptions]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxSparklineOptions
-    extends BaseSparklineOptions<dxSparkline> {
+  export interface dxSparklineOptions extends BaseSparklineOptions<dxSparkline> {
     /**
      * [descr:dxSparklineOptions.argumentField]
      */
@@ -46818,8 +46739,7 @@ declare module DevExpress.viz {
    * [descr:dxVectorMapAnnotationConfig]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxVectorMapAnnotationConfig
-    extends dxVectorMapCommonAnnotationConfig {
+  export interface dxVectorMapAnnotationConfig extends dxVectorMapCommonAnnotationConfig {
     /**
      * [descr:dxVectorMapAnnotationConfig.name]
      */
@@ -46829,8 +46749,7 @@ declare module DevExpress.viz {
    * [descr:dxVectorMapCommonAnnotationConfig]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface dxVectorMapCommonAnnotationConfig
-    extends BaseWidgetAnnotationConfig {
+  export interface dxVectorMapCommonAnnotationConfig extends BaseWidgetAnnotationConfig {
     /**
      * [descr:dxVectorMapCommonAnnotationConfig.coordinates]
      */
@@ -47382,8 +47301,7 @@ declare module DevExpress.viz {
    * [descr:PieChartSeries]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface PieChartSeries
-    extends dxPieChartSeriesTypesCommonPieChartSeries {
+  export interface PieChartSeries extends dxPieChartSeriesTypesCommonPieChartSeries {
     /**
      * [descr:PieChartSeries.name]
      */
@@ -47437,8 +47355,7 @@ declare module DevExpress.viz {
    * [descr:PolarChartSeries]
    * @deprecated Attention! This type is for internal purposes only. If you used it previously, please submit a ticket to our {@link https://supportcenter.devexpress.com/ticket/create Support Center}. We will check if there is an alternative solution.
    */
-  export interface PolarChartSeries
-    extends dxPolarChartSeriesTypesCommonPolarChartSeries {
+  export interface PolarChartSeries extends dxPolarChartSeriesTypesCommonPolarChartSeries {
     /**
      * [descr:PolarChartSeries.name]
      */


### PR DESCRIPTION
Extend the DashStyle type to support any combination of 'dash' | 'dot' | 'longDash', up to 5 levels deep