### PR TITLE
GridCore data: Relocate `_editingController` to editing data-extenders (virtual scrolling refactor)

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/extenders/virtual_scrolling_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/extenders/virtual_scrolling_data_controller.ts
@@ -28,23 +28,24 @@ import type { RawItemData } from '@ts/grids/grid_core/data_source_adapter/types'
 import type { ModuleType } from '@ts/grids/grid_core/m_types';
 import type { VirtualItemsCount } from '@ts/grids/grid_core/virtual_data_loader/types';
 
-import type { EditingController } from '../../editing/m_editing';
 import gridCoreUtils from '../../m_utils';
 import {
   LEGACY_SCROLLING_MODE,
   LOAD_TIMEOUT,
   VISIBLE_PAGE_INDEX,
 } from '../const';
-import {
-  correctCount,
-  isAppendMode,
-  isItemCountableByDataSource,
-  isVirtualMode,
-  isVirtualPaging,
-  updateItemIndices,
-} from '../m_virtual_scrolling';
 import { VirtualScrollController } from '../m_virtual_scrolling_core';
 import type { ChangedLoadParams } from '../types';
+import {
+  correctCount,
+  isItemCountableByDataSource,
+  updateItemIndices,
+} from '../utils/items';
+import {
+  isAppendMode,
+  isVirtualMode,
+  isVirtualPaging,
+} from '../utils/scrolling_mode';
 
 export interface VirtualScrollingDataControllerExtension {
   virtualItemsCount: () => VirtualItemsCount | undefined;
@@ -55,8 +56,6 @@ export const virtualScrollingDataControllerExtender = (
 ): ModuleType<
   DataController & VirtualScrollingDataControllerExtension
 > => class VirtualScrollingDataControllerExtender extends Base {
-  protected _editingController!: EditingController;
-
   private _loadViewportParams: any;
 
   private _allItems: any;
@@ -70,11 +69,6 @@ export const virtualScrollingDataControllerExtender = (
   private _needUpdateViewportAfterLoading: any;
 
   private _itemCount: any;
-
-  public init(): void {
-    this._editingController = this.getController('editing');
-    super.init();
-  }
 
   public dispose(): void {
     const rowsScrollController = this._rowsScrollController;
@@ -241,7 +235,7 @@ export const virtualScrollingDataControllerExtender = (
       itemsCount() {
         return this.items(true).length;
       },
-      correctCount(items, count, fromEnd) {
+      correctCount(items: ProcessedItem[], count, fromEnd) {
         return correctCount(items, count, fromEnd, (item, isNextAfterLast, fromEnd) => {
           if (item.isNewRow) {
             return isNextAfterLast && !fromEnd;
@@ -444,7 +438,7 @@ export const virtualScrollingDataControllerExtender = (
 
     if (removeCount) {
       const fromEnd = changeType === 'prepend';
-      removeCount = correctCount(that._items, removeCount, fromEnd, (item, isNextAfterLast) => item.rowType === 'data' && !item.isNewRow || (item.rowType === 'group' && (that._dataSource.isGroupItemCountable(item.data) || isNextAfterLast)));
+      removeCount = correctCount(that._items, removeCount, fromEnd, (item, isNextAfterLast) => isItemCountableByDataSource(item, that._dataSource) || (item.rowType === 'group' && isNextAfterLast));
 
       change.removeCount = removeCount;
     }
@@ -787,7 +781,7 @@ export const virtualScrollingDataControllerExtender = (
                         || checkLoadedParamsOnly);
 
       if (needToUpdateItems) {
-        const noPendingChangesInEditing = !this._editingController?.getChanges()?.length;
+        const noPendingChangesInEditing = !this.option('editing.changes')?.length;
         this.updateItems({
           changeType: 'refresh',
           repaintChangesOnly: true,

--- a/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/extenders/virtual_scrolling_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/extenders/virtual_scrolling_data_controller.ts
@@ -42,7 +42,7 @@ import {
   updateItemIndices,
 } from '../utils/items';
 import {
-  isAppendMode,
+  isInfiniteMode,
   isVirtualMode,
   isVirtualPaging,
 } from '../utils/scrolling_mode';
@@ -661,7 +661,7 @@ export const virtualScrollingDataControllerExtender = (
   private _pageIndexIsValid(pageIndex) {
     let result = true;
 
-    if (isAppendMode(this) && this.hasKnownLastPage() || isVirtualMode(this)) {
+    if (isInfiniteMode(this) && this.hasKnownLastPage() || isVirtualMode(this)) {
       result = pageIndex * this.pageSize() < this.totalItemsCount();
     }
 
@@ -671,7 +671,7 @@ export const virtualScrollingDataControllerExtender = (
   private isAllLoadedInAppendMode(): boolean {
     const loadedItemCount = this.pageSize() * (this._dataSource?.loadPageCount() ?? 0);
 
-    return isAppendMode(this) && this.totalItemsCount() < loadedItemCount;
+    return isInfiniteMode(this) && this.totalItemsCount() < loadedItemCount;
   }
 
   // T1326786: the grid is scrolled to paging.pageIndex on the first resize only,
@@ -861,7 +861,7 @@ export const virtualScrollingDataControllerExtender = (
   public refresh(options?: boolean | RefreshOptions): DeferredObj<unknown> {
     const dataSource = this._dataSource;
 
-    if (dataSource && typeof options !== 'boolean' && options?.load && isAppendMode(this)) {
+    if (dataSource && typeof options !== 'boolean' && options?.load && isInfiniteMode(this)) {
       dataSource.resetCurrentTotalCount();
     }
 

--- a/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/m_virtual_scrolling.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/m_virtual_scrolling.ts
@@ -817,8 +817,8 @@ export const rowsView = (Base: ModuleType<RowsView>) => class VirtualScrollingRo
   private _updateBottomLoading() {
     const that = this;
     const virtualMode = isVirtualMode(this);
-    const appendMode = isInfiniteMode(this);
-    const showBottomLoading = !that._dataController.hasKnownLastPage() && that._dataController.isLoaded() && (virtualMode || appendMode);
+    const infiniteMode = isInfiniteMode(this);
+    const showBottomLoading = !that._dataController.hasKnownLastPage() && that._dataController.isLoaded() && (virtualMode || infiniteMode);
     const $contentElement = that._findContentElement();
     const bottomLoadPanelElement = that._findBottomLoadPanel($contentElement);
 

--- a/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/m_virtual_scrolling.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/m_virtual_scrolling.ts
@@ -30,45 +30,11 @@ import {
   LOAD_TIMEOUT,
   PAGING_METHOD_NAMES,
   ROW_INSERTED,
-  SCROLLING_MODE_INFINITE,
-  SCROLLING_MODE_VIRTUAL,
   VIRTUAL_ROW_CLASS,
 } from './const';
 import { subscribeToExternalScrollers, VirtualScrollController } from './m_virtual_scrolling_core';
-
-export const isVirtualMode = function (that) {
-  return that.option('scrolling.mode') === SCROLLING_MODE_VIRTUAL;
-};
-
-export const isAppendMode = function (that) {
-  return that.option('scrolling.mode') === SCROLLING_MODE_INFINITE;
-};
-
-export const isVirtualPaging = function (that) {
-  return isVirtualMode(that) || isAppendMode(that);
-};
-
-export const correctCount = function (items, count, fromEnd, isItemCountableFunc) {
-  for (let i = 0; i < count + 1; i++) {
-    const item = items[fromEnd ? items.length - 1 - i : i];
-    if (item && !isItemCountableFunc(item, i === count, fromEnd)) {
-      count++;
-    }
-  }
-  return count;
-};
-
-export const isItemCountableByDataSource = function (item, dataSource) {
-  return item.rowType === 'data' && !item.isNewRow || item.rowType === 'group' && dataSource.isGroupItemCountable(item.data);
-};
-
-export const updateItemIndices = function (items) {
-  items.forEach((item, index) => {
-    item.rowIndex = index;
-  });
-
-  return items;
-};
+import { isItemCountableByDataSource } from './utils/items';
+import { isAppendMode, isVirtualMode, isVirtualPaging } from './utils/scrolling_mode';
 
 export const updateLoading = function (that) {
   const beginPageIndex = that._virtualScrollController.beginPageIndex(-1);

--- a/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/m_virtual_scrolling.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/m_virtual_scrolling.ts
@@ -34,7 +34,7 @@ import {
 } from './const';
 import { subscribeToExternalScrollers, VirtualScrollController } from './m_virtual_scrolling_core';
 import { isItemCountableByDataSource } from './utils/items';
-import { isAppendMode, isVirtualMode, isVirtualPaging } from './utils/scrolling_mode';
+import { isInfiniteMode, isVirtualMode, isVirtualPaging } from './utils/scrolling_mode';
 
 export const updateLoading = function (that) {
   const beginPageIndex = that._virtualScrollController.beginPageIndex(-1);
@@ -209,7 +209,7 @@ export const dataSourceAdapterExtender = (Base: ModuleType<DataSourceAdapter>) =
       renderAsync = this._renderTime >= this.option('scrolling.renderingThreshold');
     }
 
-    if ((isVirtualMode(this) || (isAppendMode(this) && newMode)) && !operationTypes.reload && (operationTypes.skip || newMode) && !renderAsync) {
+    if ((isVirtualMode(this) || (isInfiniteMode(this) && newMode)) && !operationTypes.reload && (operationTypes.skip || newMode) && !renderAsync) {
       options.delay = undefined;
     }
 
@@ -299,7 +299,7 @@ export const dataSourceAdapterExtender = (Base: ModuleType<DataSourceAdapter>) =
         updateLoading(this);
         this._isLoaded = true;
 
-        if (isAppendMode(this)) {
+        if (isInfiniteMode(this)) {
           this.pageIndex(0);
           dataSource.pageIndex(0);
           storeLoadOptions.pageIndex = 0;
@@ -312,7 +312,7 @@ export const dataSourceAdapterExtender = (Base: ModuleType<DataSourceAdapter>) =
             storeLoadOptions.skip = this.pageIndex() * this.pageSize();
           }
         }
-      } else if (isAppendMode(this) && storeLoadOptions.skip && this._totalCountCorrection < 0) {
+      } else if (isInfiniteMode(this) && storeLoadOptions.skip && this._totalCountCorrection < 0) {
         storeLoadOptions.skip += this._totalCountCorrection;
       }
     }
@@ -537,7 +537,7 @@ export const rowsView = (Base: ModuleType<RowsView>) => class VirtualScrollingRo
     const pageSize = this._dataController ? this._dataController.pageSize() : 0;
     let scrollPosition;
 
-    if (isVirtualMode(this) || isAppendMode(this)) {
+    if (isVirtualMode(this) || isInfiniteMode(this)) {
       const itemSize = this._dataController
         // @ts-expect-error
         .getItemSize();
@@ -817,7 +817,7 @@ export const rowsView = (Base: ModuleType<RowsView>) => class VirtualScrollingRo
   private _updateBottomLoading() {
     const that = this;
     const virtualMode = isVirtualMode(this);
-    const appendMode = isAppendMode(this);
+    const appendMode = isInfiniteMode(this);
     const showBottomLoading = !that._dataController.hasKnownLastPage() && that._dataController.isLoaded() && (virtualMode || appendMode);
     const $contentElement = that._findContentElement();
     const bottomLoadPanelElement = that._findBottomLoadPanel($contentElement);
@@ -866,7 +866,7 @@ export const rowsView = (Base: ModuleType<RowsView>) => class VirtualScrollingRo
   protected _needUpdateRowHeight(itemsCount) {
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     return super._needUpdateRowHeight.apply(this, arguments as any) || (itemsCount > 0
-              && (isAppendMode(this) && !gridCoreUtils.isVirtualRowRendering(this))
+              && (isInfiniteMode(this) && !gridCoreUtils.isVirtualRowRendering(this))
     );
   }
 

--- a/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/utils/__tests__/items.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/utils/__tests__/items.test.ts
@@ -1,0 +1,107 @@
+import {
+  describe, expect, it,
+} from '@jest/globals';
+
+import {
+  correctCount, isItemCountableByDataSource, updateItemIndices,
+} from '../items';
+
+describe('correctCount', () => {
+  it('should not increase count when all items are countable', () => {
+    const items = [{ v: 1 }, { v: 2 }, { v: 3 }];
+
+    expect(correctCount(items, 2, false, () => true)).toBe(2);
+  });
+
+  it('should increase count for each not countable item from the start', () => {
+    const items = [
+      { countable: false },
+      { countable: true },
+      { countable: false },
+      { countable: true },
+      { countable: true },
+    ];
+
+    const result = correctCount(items, 2, false, (item) => item.countable);
+
+    expect(result).toBe(4);
+  });
+
+  it('should walk from the end when fromEnd is true', () => {
+    const items = [
+      { countable: true },
+      { countable: false },
+      { countable: true },
+    ];
+
+    const seen: boolean[] = [];
+    const result = correctCount(items, 1, true, (item) => {
+      seen.push(item.countable);
+      return item.countable;
+    });
+
+    expect(result).toBe(2);
+    expect(seen[0]).toBe(true);
+    expect(seen[1]).toBe(false);
+  });
+
+  it('should pass isNextAfterLast as true only when i equals the current count', () => {
+    const items = [{ id: 0 }, { id: 1 }, { id: 2 }];
+    const flags: boolean[] = [];
+
+    correctCount(items, 1, false, (_item, isNextAfterLast) => {
+      flags.push(isNextAfterLast);
+      return true;
+    });
+
+    expect(flags).toEqual([false, true]);
+  });
+
+  it('should stop against missing items (undefined) without incrementing', () => {
+    const items = [{ countable: true }];
+
+    expect(correctCount(items, 3, false, (item) => item.countable)).toBe(3);
+  });
+});
+
+describe('isItemCountableByDataSource', () => {
+  const dataSource = {
+    isGroupItemCountable: (data: unknown): boolean => data === 'countable',
+  };
+
+  it('should count a data row that is not a new row', () => {
+    expect(isItemCountableByDataSource({ rowType: 'data', isNewRow: false }, dataSource)).toBe(true);
+  });
+
+  it('should not count a new data row', () => {
+    expect(isItemCountableByDataSource({ rowType: 'data', isNewRow: true }, dataSource)).toBe(false);
+  });
+
+  it('should count a group row when the data source says it is countable', () => {
+    expect(isItemCountableByDataSource({ rowType: 'group', data: 'countable' }, dataSource)).toBe(true);
+  });
+
+  it('should not count a group row when the data source says it is not countable', () => {
+    expect(isItemCountableByDataSource({ rowType: 'group', data: 'other' }, dataSource)).toBe(false);
+  });
+
+  it('should not count other row types', () => {
+    expect(isItemCountableByDataSource({ rowType: 'groupFooter' }, dataSource)).toBe(false);
+  });
+});
+
+describe('updateItemIndices', () => {
+  it('should assign rowIndex to each item by position', () => {
+    const items = [{ rowIndex: -1 }, { rowIndex: -1 }, { rowIndex: -1 }];
+
+    updateItemIndices(items);
+
+    expect(items.map((item) => item.rowIndex)).toEqual([0, 1, 2]);
+  });
+
+  it('should return the same array reference', () => {
+    const items = [{ rowIndex: 0 }];
+
+    expect(updateItemIndices(items)).toBe(items);
+  });
+});

--- a/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/utils/__tests__/items.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/utils/__tests__/items.test.ts
@@ -1,43 +1,51 @@
 import {
   describe, expect, it,
 } from '@jest/globals';
+import type { ProcessedItem } from '@ts/grids/grid_core/data_controller/types';
 
 import {
   correctCount, isItemCountableByDataSource, updateItemIndices,
 } from '../items';
 
+type TestItem = ProcessedItem & { countable?: boolean };
+
+const asItems = (items: unknown[]): ProcessedItem[] => items as ProcessedItem[];
+const asItem = (item: unknown): ProcessedItem => item as ProcessedItem;
+const isCountable = (item: ProcessedItem): boolean => (item as TestItem).countable ?? false;
+
 describe('correctCount', () => {
   it('should not increase count when all items are countable', () => {
-    const items = [{ v: 1 }, { v: 2 }, { v: 3 }];
+    const items = asItems([{ v: 1 }, { v: 2 }, { v: 3 }]);
 
     expect(correctCount(items, 2, false, () => true)).toBe(2);
   });
 
   it('should increase count for each not countable item from the start', () => {
-    const items = [
+    const items = asItems([
       { countable: false },
       { countable: true },
       { countable: false },
       { countable: true },
       { countable: true },
-    ];
+    ]);
 
-    const result = correctCount(items, 2, false, (item) => item.countable);
+    const result = correctCount(items, 2, false, isCountable);
 
     expect(result).toBe(4);
   });
 
   it('should walk from the end when fromEnd is true', () => {
-    const items = [
+    const items = asItems([
       { countable: true },
       { countable: false },
       { countable: true },
-    ];
+    ]);
 
     const seen: boolean[] = [];
     const result = correctCount(items, 1, true, (item) => {
-      seen.push(item.countable);
-      return item.countable;
+      const countable = isCountable(item);
+      seen.push(countable);
+      return countable;
     });
 
     expect(result).toBe(2);
@@ -46,7 +54,7 @@ describe('correctCount', () => {
   });
 
   it('should pass isNextAfterLast as true only when i equals the current count', () => {
-    const items = [{ id: 0 }, { id: 1 }, { id: 2 }];
+    const items = asItems([{ id: 0 }, { id: 1 }, { id: 2 }]);
     const flags: boolean[] = [];
 
     correctCount(items, 1, false, (_item, isNextAfterLast) => {
@@ -58,9 +66,9 @@ describe('correctCount', () => {
   });
 
   it('should stop against missing items (undefined) without incrementing', () => {
-    const items = [{ countable: true }];
+    const items = asItems([{ countable: true }]);
 
-    expect(correctCount(items, 3, false, (item) => item.countable)).toBe(3);
+    expect(correctCount(items, 3, false, isCountable)).toBe(3);
   });
 });
 
@@ -70,29 +78,29 @@ describe('isItemCountableByDataSource', () => {
   };
 
   it('should count a data row that is not a new row', () => {
-    expect(isItemCountableByDataSource({ rowType: 'data', isNewRow: false }, dataSource)).toBe(true);
+    expect(isItemCountableByDataSource(asItem({ rowType: 'data', isNewRow: false }), dataSource)).toBe(true);
   });
 
   it('should not count a new data row', () => {
-    expect(isItemCountableByDataSource({ rowType: 'data', isNewRow: true }, dataSource)).toBe(false);
+    expect(isItemCountableByDataSource(asItem({ rowType: 'data', isNewRow: true }), dataSource)).toBe(false);
   });
 
   it('should count a group row when the data source says it is countable', () => {
-    expect(isItemCountableByDataSource({ rowType: 'group', data: 'countable' }, dataSource)).toBe(true);
+    expect(isItemCountableByDataSource(asItem({ rowType: 'group', data: 'countable' }), dataSource)).toBe(true);
   });
 
   it('should not count a group row when the data source says it is not countable', () => {
-    expect(isItemCountableByDataSource({ rowType: 'group', data: 'other' }, dataSource)).toBe(false);
+    expect(isItemCountableByDataSource(asItem({ rowType: 'group', data: 'other' }), dataSource)).toBe(false);
   });
 
   it('should not count other row types', () => {
-    expect(isItemCountableByDataSource({ rowType: 'groupFooter' }, dataSource)).toBe(false);
+    expect(isItemCountableByDataSource(asItem({ rowType: 'groupFooter' }), dataSource)).toBe(false);
   });
 });
 
 describe('updateItemIndices', () => {
   it('should assign rowIndex to each item by position', () => {
-    const items = [{ rowIndex: -1 }, { rowIndex: -1 }, { rowIndex: -1 }];
+    const items = asItems([{ rowIndex: -1 }, { rowIndex: -1 }, { rowIndex: -1 }]);
 
     updateItemIndices(items);
 
@@ -100,7 +108,7 @@ describe('updateItemIndices', () => {
   });
 
   it('should return the same array reference', () => {
-    const items = [{ rowIndex: 0 }];
+    const items = asItems([{ rowIndex: 0 }]);
 
     expect(updateItemIndices(items)).toBe(items);
   });

--- a/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/utils/__tests__/scrolling_mode.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/utils/__tests__/scrolling_mode.test.ts
@@ -1,0 +1,53 @@
+import {
+  describe, expect, it,
+} from '@jest/globals';
+
+import {
+  isAppendMode, isVirtualMode, isVirtualPaging,
+} from '../scrolling_mode';
+
+const createController = (mode: string): { option: (name: string) => unknown } => ({
+  option: (name: string): unknown => (name === 'scrolling.mode' ? mode : undefined),
+});
+
+describe('isVirtualMode', () => {
+  it('should be true for the virtual scrolling mode', () => {
+    expect(isVirtualMode(createController('virtual'))).toBe(true);
+  });
+
+  it('should be false for the infinite scrolling mode', () => {
+    expect(isVirtualMode(createController('infinite'))).toBe(false);
+  });
+
+  it('should be false for the standard scrolling mode', () => {
+    expect(isVirtualMode(createController('standard'))).toBe(false);
+  });
+});
+
+describe('isAppendMode', () => {
+  it('should be true for the infinite scrolling mode', () => {
+    expect(isAppendMode(createController('infinite'))).toBe(true);
+  });
+
+  it('should be false for the virtual scrolling mode', () => {
+    expect(isAppendMode(createController('virtual'))).toBe(false);
+  });
+
+  it('should be false for the standard scrolling mode', () => {
+    expect(isAppendMode(createController('standard'))).toBe(false);
+  });
+});
+
+describe('isVirtualPaging', () => {
+  it('should be true for the virtual scrolling mode', () => {
+    expect(isVirtualPaging(createController('virtual'))).toBe(true);
+  });
+
+  it('should be true for the infinite scrolling mode', () => {
+    expect(isVirtualPaging(createController('infinite'))).toBe(true);
+  });
+
+  it('should be false for the standard scrolling mode', () => {
+    expect(isVirtualPaging(createController('standard'))).toBe(false);
+  });
+});

--- a/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/utils/__tests__/scrolling_mode.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/utils/__tests__/scrolling_mode.test.ts
@@ -3,7 +3,7 @@ import {
 } from '@jest/globals';
 
 import {
-  isAppendMode, isVirtualMode, isVirtualPaging,
+  isInfiniteMode, isVirtualMode, isVirtualPaging,
 } from '../scrolling_mode';
 
 const createController = (mode: string): { option: (name: string) => unknown } => ({
@@ -24,17 +24,17 @@ describe('isVirtualMode', () => {
   });
 });
 
-describe('isAppendMode', () => {
+describe('isInfiniteMode', () => {
   it('should be true for the infinite scrolling mode', () => {
-    expect(isAppendMode(createController('infinite'))).toBe(true);
+    expect(isInfiniteMode(createController('infinite'))).toBe(true);
   });
 
   it('should be false for the virtual scrolling mode', () => {
-    expect(isAppendMode(createController('virtual'))).toBe(false);
+    expect(isInfiniteMode(createController('virtual'))).toBe(false);
   });
 
   it('should be false for the standard scrolling mode', () => {
-    expect(isAppendMode(createController('standard'))).toBe(false);
+    expect(isInfiniteMode(createController('standard'))).toBe(false);
   });
 });
 

--- a/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/utils/items.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/utils/items.ts
@@ -1,28 +1,20 @@
-interface CountableItem {
-  rowType?: string;
-  isNewRow?: boolean;
-  data?: unknown;
-}
-
-interface RowIndexedItem {
-  rowIndex?: number;
-}
+import type { ProcessedItem } from '@ts/grids/grid_core/data_controller/types';
 
 interface GroupCountableDataSource {
   isGroupItemCountable: (data: unknown) => boolean;
 }
 
-type IsItemCountableFunc<TItem> = (
-  item: TItem,
+type IsItemCountableFunc = (
+  item: ProcessedItem,
   isNextAfterLast: boolean,
   fromEnd: boolean,
 ) => boolean;
 
-export const correctCount = <TItem>(
-  items: TItem[],
+export const correctCount = (
+  items: ProcessedItem[],
   count: number,
   fromEnd: boolean,
-  isItemCountableFunc: IsItemCountableFunc<TItem>,
+  isItemCountableFunc: IsItemCountableFunc,
 ): number => {
   let result = count;
 
@@ -37,12 +29,12 @@ export const correctCount = <TItem>(
 };
 
 export const isItemCountableByDataSource = (
-  item: CountableItem,
+  item: ProcessedItem,
   dataSource: GroupCountableDataSource,
 ): boolean => (item.rowType === 'data' && !item.isNewRow)
   || (item.rowType === 'group' && dataSource.isGroupItemCountable(item.data));
 
-export const updateItemIndices = <TItem extends RowIndexedItem>(items: TItem[]): TItem[] => {
+export const updateItemIndices = (items: ProcessedItem[]): ProcessedItem[] => {
   items.forEach((item, index) => {
     item.rowIndex = index;
   });

--- a/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/utils/items.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/utils/items.ts
@@ -1,0 +1,51 @@
+interface CountableItem {
+  rowType?: string;
+  isNewRow?: boolean;
+  data?: unknown;
+}
+
+interface RowIndexedItem {
+  rowIndex?: number;
+}
+
+interface GroupCountableDataSource {
+  isGroupItemCountable: (data: unknown) => boolean;
+}
+
+type IsItemCountableFunc<TItem> = (
+  item: TItem,
+  isNextAfterLast: boolean,
+  fromEnd: boolean,
+) => boolean;
+
+export const correctCount = <TItem>(
+  items: TItem[],
+  count: number,
+  fromEnd: boolean,
+  isItemCountableFunc: IsItemCountableFunc<TItem>,
+): number => {
+  let result = count;
+
+  for (let i = 0; i < result + 1; i += 1) {
+    const item = items[fromEnd ? items.length - 1 - i : i];
+    if (item && !isItemCountableFunc(item, i === result, fromEnd)) {
+      result += 1;
+    }
+  }
+
+  return result;
+};
+
+export const isItemCountableByDataSource = (
+  item: CountableItem,
+  dataSource: GroupCountableDataSource,
+): boolean => (item.rowType === 'data' && !item.isNewRow)
+  || (item.rowType === 'group' && dataSource.isGroupItemCountable(item.data));
+
+export const updateItemIndices = <TItem extends RowIndexedItem>(items: TItem[]): TItem[] => {
+  items.forEach((item, index) => {
+    item.rowIndex = index;
+  });
+
+  return items;
+};

--- a/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/utils/scrolling_mode.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/utils/scrolling_mode.ts
@@ -1,0 +1,12 @@
+import { SCROLLING_MODE_INFINITE, SCROLLING_MODE_VIRTUAL } from '../const';
+
+interface ScrollingModeController {
+  option: (name: string) => unknown;
+}
+
+export const isVirtualMode = (that: ScrollingModeController): boolean => that.option('scrolling.mode') === SCROLLING_MODE_VIRTUAL;
+
+export const isAppendMode = (that: ScrollingModeController): boolean => that.option('scrolling.mode') === SCROLLING_MODE_INFINITE;
+
+export const isVirtualPaging = (that: ScrollingModeController): boolean => isVirtualMode(that)
+  || isAppendMode(that);

--- a/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/utils/scrolling_mode.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/virtual_scrolling/utils/scrolling_mode.ts
@@ -6,7 +6,7 @@ interface ScrollingModeController {
 
 export const isVirtualMode = (that: ScrollingModeController): boolean => that.option('scrolling.mode') === SCROLLING_MODE_VIRTUAL;
 
-export const isAppendMode = (that: ScrollingModeController): boolean => that.option('scrolling.mode') === SCROLLING_MODE_INFINITE;
+export const isInfiniteMode = (that: ScrollingModeController): boolean => that.option('scrolling.mode') === SCROLLING_MODE_INFINITE;
 
 export const isVirtualPaging = (that: ScrollingModeController): boolean => isVirtualMode(that)
-  || isAppendMode(that);
+  || isInfiniteMode(that);


### PR DESCRIPTION
### What
Removes `_editingController` usage from the virtual scrolling data-controller extender and moves its shared helpers into a tested *utils* folder

### How
Reads `editing.changes` from the option directly instead of the editing controller, and extracts the scrolling-mode and item helpers into *utils* with Jest coverage