### PR TITLE
GridCore data: Relocate `_editingController` to editing data-extenders (remove from base)

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
@@ -15,7 +15,6 @@ import type {
   ChangedEvent, DataSourceAdapterProvider, LoadOperation, OperationTypes, RawItemData,
 } from '@ts/grids/grid_core/data_source_adapter/types';
 import { isLocalStore } from '@ts/grids/grid_core/data_source_adapter/utils/store';
-import type { EditingController } from '@ts/grids/grid_core/editing/m_editing';
 import type { FilterSyncController } from '@ts/grids/grid_core/filter/m_filter_sync';
 import type { FocusController } from '@ts/grids/grid_core/focus/m_focus';
 import modules from '@ts/grids/grid_core/m_modules';
@@ -128,8 +127,6 @@ export class DataController extends DataHelperMixin(modules.Controller) {
   // TODO public controller
   public _rowsScrollController?: VirtualScrollController | null;
 
-  protected _editingController!: EditingController;
-
   protected _filterSyncController!: FilterSyncController;
 
   private _filterExcludedColumn: Column | null = null;
@@ -146,7 +143,6 @@ export class DataController extends DataHelperMixin(modules.Controller) {
     this._items = [];
     this._cachedProcessedItems = null;
     this._columnsController = this.getController('columns');
-    this._editingController = this.getController('editing');
     this._filterSyncController = this.getController('filterSync');
     this._focusController = this.getController('focus');
 

--- a/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/editing/extenders/editing_data_controller.ts
@@ -16,10 +16,16 @@ import gridCoreUtils from '@ts/grids/grid_core/m_utils';
 import { EDITING_EDITROWKEY_OPTION_NAME } from '../const';
 import type { EditingController } from '../m_editing';
 
+export interface EditingDataControllerExtension {
+  _editingController: EditingController;
+}
+
 export const editingDataControllerExtender = (
   Base: ModuleType<DataController>,
-): ModuleType<DataController> => class EditingDataControllerExtender extends Base {
-  protected _editingController!: EditingController;
+): ModuleType<
+  DataController & EditingDataControllerExtension
+> => class EditingDataControllerExtender extends Base {
+  public _editingController!: EditingController;
 
   public init(): void {
     this._editingController = this.getController('editing');


### PR DESCRIPTION
### What
Removes `_editingController` from the base data controller now that no module reads it from the base

### How
Deletes the field, its initialization, and the unused import from the base data controller, and surfaces `_editingController` from the editing data-controller extender via an `EditingDataControllerExtension` type so the editing extenders keep access