### PR TITLE
DataGrid: separate the kept-row refresh from the row changes lookup

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/__tests__/data_controller.row_changes.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/__tests__/data_controller.row_changes.test.ts
@@ -1,0 +1,300 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { logger } from '@js/core/utils/console';
+import {
+  afterTest,
+  beforeTest,
+  createDataGrid,
+} from '@ts/grids/grid_core/__tests__/__mock__/helpers/utils';
+
+import { DataController } from '../data_controller';
+import type {
+  Cell, DataChange, ProcessedItem, UpdateChange,
+} from '../types';
+
+type CallLog = string[];
+
+declare class ExposedDataController extends DataController {
+  public _items: ProcessedItem[];
+
+  public applyChangesOnly: (change: DataChange) => void;
+}
+
+interface TestContext {
+  dataController: ExposedDataController;
+  log: CallLog;
+}
+
+const createGridWithCallLog = async (): Promise<TestContext> => {
+  const { instance } = await createDataGrid({
+    dataSource: [],
+    columns: ['name', 'age'],
+    repaintChangesOnly: true,
+  });
+
+  return {
+    dataController: instance.getController('data') as unknown as ExposedDataController,
+    log: [],
+  };
+};
+
+const createOldRow = (key: number, values: unknown[], log: CallLog): ProcessedItem => ({
+  rowType: 'data',
+  key,
+  data: { id: key },
+  values,
+  cells: values.map((_value, columnIndex): Cell => ({
+    column: { index: columnIndex },
+    isEditing: false,
+    update: (_row?: ProcessedItem, keepRow?: boolean): void => {
+      log.push(`cell ${key}.${columnIndex} ${keepRow ? 'keepRow' : 'replaceRow'}`);
+    },
+  })),
+  update: (): void => {
+    log.push(`row ${key}`);
+  },
+});
+
+const createNewRow = (key: number, values: unknown[]): ProcessedItem => ({
+  rowType: 'data',
+  key,
+  data: { id: key },
+  values,
+});
+
+const createRefreshChange = (items: ProcessedItem[]): DataChange => ({
+  changeType: 'refresh',
+  repaintChangesOnly: true,
+  items,
+});
+
+describe('DataController row changes', () => {
+  beforeEach(beforeTest);
+  afterEach(afterTest);
+
+  describe('applyChangesOnly', () => {
+    it('should hand the new row to the updaters of every unchanged row', async () => {
+      const { dataController, log } = await createGridWithCallLog();
+
+      dataController._items = [
+        createOldRow(1, ['Alex', 15], log),
+        createOldRow(2, ['Dan', 20], log),
+      ];
+
+      dataController.applyChangesOnly(createRefreshChange([
+        createNewRow(1, ['Alex', 15]),
+        createNewRow(2, ['Dan', 20]),
+      ]));
+
+      expect(log).toEqual([
+        'row 1',
+        'cell 1.0 keepRow',
+        'cell 1.1 keepRow',
+        'row 2',
+        'cell 2.0 keepRow',
+        'cell 2.1 keepRow',
+      ]);
+    });
+
+    it('should report no changed rows when every row is unchanged', async () => {
+      const { dataController, log } = await createGridWithCallLog();
+
+      dataController._items = [createOldRow(1, ['Alex', 15], log)];
+
+      const change = createRefreshChange([createNewRow(1, ['Alex', 15])]);
+      dataController.applyChangesOnly(change);
+
+      const updateChange = change as UpdateChange;
+
+      expect(updateChange.changeType).toBe('update');
+      expect(updateChange.rowIndices).toEqual([]);
+      expect(updateChange.changeTypes).toEqual([]);
+      expect(updateChange.items).toEqual([]);
+      expect(updateChange.isLiveUpdate).toBe(true);
+    });
+
+    it('should skip the unchanged-row hand-over for a row whose values changed', async () => {
+      const { dataController, log } = await createGridWithCallLog();
+
+      dataController._items = [
+        createOldRow(1, ['Alex', 15], log),
+        createOldRow(2, ['Dan', 20], log),
+      ];
+
+      const change = createRefreshChange([
+        createNewRow(1, ['Alex', 15]),
+        createNewRow(2, ['Dan', 21]),
+      ]);
+      dataController.applyChangesOnly(change);
+
+      expect(log).toEqual([
+        'row 1',
+        'cell 1.0 keepRow',
+        'cell 1.1 keepRow',
+        // only untouched cell is called, without `keepRow` - `_partialUpdateRow`, not the refresh.
+        'cell 2.0 replaceRow',
+        'row 2',
+      ]);
+
+      const updateChange = change as UpdateChange;
+
+      expect(updateChange.rowIndices).toEqual([1]);
+      expect(updateChange.changeTypes).toEqual(['update']);
+      expect(updateChange.columnIndices).toEqual([[1]]);
+    });
+
+    it('should hand over every unchanged row before applying any change', async () => {
+      const { dataController, log } = await createGridWithCallLog();
+
+      dataController._items = [
+        createOldRow(1, ['Alex', 15], log),
+        createOldRow(2, ['Dan', 20], log),
+      ];
+
+      dataController.applyChangesOnly(createRefreshChange([
+        createNewRow(1, ['Alexander', 15]),
+        createNewRow(2, ['Dan', 20]),
+      ]));
+
+      expect(log).toEqual([
+        'row 2',
+        'cell 2.0 keepRow',
+        'cell 2.1 keepRow',
+        'cell 1.1 replaceRow',
+        'row 1',
+      ]);
+    });
+
+    it('should hand over the rows surrounding an insert', async () => {
+      const { dataController, log } = await createGridWithCallLog();
+
+      dataController._items = [
+        createOldRow(1, ['Alex', 15], log),
+        createOldRow(2, ['Dan', 20], log),
+      ];
+
+      const change = createRefreshChange([
+        createNewRow(1, ['Alex', 15]),
+        createNewRow(3, ['Sam', 30]),
+        createNewRow(2, ['Dan', 20]),
+      ]);
+      dataController.applyChangesOnly(change);
+
+      expect(log).toEqual([
+        'row 1',
+        'cell 1.0 keepRow',
+        'cell 1.1 keepRow',
+        'row 2',
+        'cell 2.0 keepRow',
+        'cell 2.1 keepRow',
+      ]);
+
+      const updateChange = change as UpdateChange;
+
+      expect(updateChange.changeTypes).toEqual(['insert']);
+      expect(updateChange.rowIndices).toEqual([1]);
+    });
+
+    it('should hand over the rows surrounding a remove', async () => {
+      const { dataController, log } = await createGridWithCallLog();
+
+      dataController._items = [
+        createOldRow(1, ['Alex', 15], log),
+        createOldRow(2, ['Dan', 20], log),
+        createOldRow(3, ['Sam', 30], log),
+      ];
+
+      const change = createRefreshChange([
+        createNewRow(1, ['Alex', 15]),
+        createNewRow(3, ['Sam', 30]),
+      ]);
+      dataController.applyChangesOnly(change);
+
+      expect(log).toEqual([
+        'row 1',
+        'cell 1.0 keepRow',
+        'cell 1.1 keepRow',
+        'row 3',
+        'cell 3.0 keepRow',
+        'cell 3.1 keepRow',
+      ]);
+
+      const updateChange = change as UpdateChange;
+
+      expect(updateChange.changeTypes).toEqual(['remove']);
+      expect(updateChange.rowIndices).toEqual([1]);
+    });
+
+    describe('when the rows are reordered', () => {
+      const reorder = async (): Promise<TestContext & {
+        change: DataChange;
+        newRows: ProcessedItem[];
+      }> => {
+        const { dataController, log } = await createGridWithCallLog();
+
+        dataController._items = [
+          createOldRow(1, ['Alex', 15], log),
+          createOldRow(2, ['Dan', 20], log),
+          createOldRow(3, ['Sam', 30], log),
+        ];
+
+        const newRows = [
+          createNewRow(1, ['Alex', 15]),
+          createNewRow(3, ['Sam', 30]),
+          createNewRow(2, ['Dan', 20]),
+        ];
+        const change = createRefreshChange(newRows);
+        dataController.applyChangesOnly(change);
+
+        return {
+          dataController, log, change, newRows,
+        };
+      };
+
+      it('should fall back to a full change', async () => {
+        const { dataController, change, newRows } = await reorder();
+
+        expect(change.changeType).toBe('refresh');
+        expect((change as UpdateChange).rowIndices).toBeUndefined();
+        expect(dataController._items).toEqual(newRows);
+      });
+
+      it('should not refresh the rows compared before reorder detected', async () => {
+        const { log } = await reorder();
+
+        expect(log).toEqual([]);
+      });
+    });
+
+    describe('when a row updater throws', () => {
+      it('should catch the throw and fall back to a full change', async () => {
+        const { dataController, log } = await createGridWithCallLog();
+        const loggedError = jest.spyOn(logger, 'error').mockImplementation(() => {});
+        const throwingRow = createOldRow(2, ['Dan', 20], log);
+
+        throwingRow.update = (): void => {
+          throw new Error('row template failed');
+        };
+
+        dataController._items = [createOldRow(1, ['Alex', 15], log), throwingRow];
+
+        const newRows = [createNewRow(1, ['Alex', 15]), createNewRow(2, ['Dan', 20])];
+        const change = createRefreshChange(newRows);
+
+        expect(() => dataController.applyChangesOnly(change)).not.toThrow();
+        expect(change.changeType).toBe('refresh');
+        expect(dataController._items).toEqual(newRows);
+        expect(log).toEqual(['row 1', 'cell 1.0 keepRow', 'cell 1.1 keepRow']);
+        expect(loggedError).toHaveBeenCalledTimes(1);
+
+        loggedError.mockRestore();
+      });
+    });
+  });
+});

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
@@ -1,6 +1,7 @@
 import type { Store } from '@js/common/data';
 import type { Callback } from '@js/core/utils/callbacks';
 import { deferRender } from '@js/core/utils/common';
+import { logger } from '@js/core/utils/console';
 import type { DeferredObj } from '@js/core/utils/deferred';
 import { Deferred, when } from '@js/core/utils/deferred';
 import { isDefined } from '@js/core/utils/type';
@@ -61,7 +62,7 @@ import {
   markUpdateChange,
   pushChangedRow,
   resetChangedRows,
-  updateRowCells,
+  updateKeptRows,
 } from './utils/row_changes';
 import { generateRowValues } from './utils/row_values';
 
@@ -1025,7 +1026,7 @@ export class DataController extends DataHelperMixin(modules.Controller) {
     return columnIndices;
   }
 
-  protected _isItemEquals(item1: ProcessedItem, item2: ProcessedItem): boolean {
+  protected isSameRowState(item1: ProcessedItem, item2: ProcessedItem): boolean {
     if (JSON.stringify(item1.values) !== JSON.stringify(item2.values)) {
       return false;
     }
@@ -1080,28 +1081,6 @@ export class DataController extends DataHelperMixin(modules.Controller) {
     }
   }
 
-  private findItemChanges(
-    oldItems: ProcessedItem[],
-    newItems: ProcessedItem[],
-  ): ItemChange[] | undefined {
-    const isItemEquals = (item1: ProcessedItem, item2: ProcessedItem): boolean => {
-      if (!this._isItemEquals(item1, item2)) {
-        return false;
-      }
-
-      updateRowCells(item1, item2);
-
-      return true;
-    };
-
-    return findChanges({
-      oldItems,
-      newItems,
-      getKey: getRowKey,
-      isItemEquals,
-    });
-  }
-
   private applyItemChanges(itemChanges: ItemChange[], isLiveUpdate: boolean): ChangedRows {
     const changedRows = initChangedRows();
 
@@ -1136,9 +1115,23 @@ export class DataController extends DataHelperMixin(modules.Controller) {
     const newItems = change.items ?? [];
     const oldItems = this._items.slice();
     const newIndexByKey = indexRowsByKey(newItems);
-    const itemChanges = this.findItemChanges(oldItems, newItems);
+    const itemChanges = findChanges({
+      oldItems,
+      newItems,
+      getKey: getRowKey,
+      isItemEquals: this.isSameRowState.bind(this),
+    });
 
+    // Changes cannot be found for a moved row, duplicate keys, or any throw.
     if (!itemChanges) {
+      this._applyChangeFull(change);
+      return;
+    }
+
+    try {
+      updateKeptRows(oldItems, newItems, newIndexByKey, itemChanges);
+    } catch (error) {
+      logger.error(error);
       this._applyChangeFull(change);
       return;
     }

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/utils/__tests__/row_changes.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/utils/__tests__/row_changes.test.ts
@@ -3,12 +3,21 @@ import {
 } from '@jest/globals';
 
 import type {
-  ChangedRows, DataChange, ProcessedItem, UpdateChange,
+  ChangedRows, DataChange, ItemChange, ProcessedItem, UpdateChange,
 } from '../../types';
 import {
-  getChangedRowIndices, getDataRowIndex, getRowKey,
-  getRowOperation, indexRowsByKey, isSameGroupRowState, isSameItem,
-  markUpdateChange, pushChangedRow, resetChangedRows, updateRowCells,
+  getChangedRowIndices,
+  getDataRowIndex,
+  getRowKey,
+  getRowOperation,
+  indexRowsByKey,
+  isSameGroupRowState,
+  isSameItem,
+  markUpdateChange,
+  pushChangedRow,
+  resetChangedRows,
+  updateKeptRows,
+  updateRowCells,
 } from '../row_changes';
 
 const row = (partial: Partial<ProcessedItem>): ProcessedItem => ({
@@ -165,6 +174,95 @@ describe('updateRowCells', () => {
     updateRowCells(row({ key: 1, update }), row({ key: 1 }));
 
     expect(update).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateKeptRows', () => {
+  const trackedRow = (key: number): ProcessedItem => row({
+    key,
+    update: jest.fn(),
+    cells: [{ update: jest.fn() }],
+  });
+
+  const updateOf = (item: ProcessedItem): jest.Mock => item.update as jest.Mock;
+
+  const refreshRows = (
+    oldItems: ProcessedItem[],
+    newItems: ProcessedItem[],
+    itemChanges: ItemChange[],
+  ): void => {
+    updateKeptRows(oldItems, newItems, indexRowsByKey(newItems), itemChanges);
+  };
+
+  it('should pass the new row to a row that has no changes', () => {
+    const oldItem = trackedRow(1);
+    const newItem = row({ key: 1 });
+
+    refreshRows([oldItem], [newItem], []);
+
+    expect(updateOf(oldItem)).toHaveBeenCalledWith(newItem);
+  });
+
+  it('should skip a row reported as updated', () => {
+    const oldItem = trackedRow(1);
+    const newItem = row({ key: 1 });
+
+    refreshRows([oldItem], [newItem], [{
+      type: 'update', index: 0, data: newItem, oldItem,
+    }]);
+
+    expect(updateOf(oldItem)).not.toHaveBeenCalled();
+  });
+
+  it('should skip a row that is gone from the new list', () => {
+    const oldItem = trackedRow(1);
+
+    refreshRows([oldItem], [], [{ type: 'remove', index: 0, oldItem }]);
+
+    expect(updateOf(oldItem)).not.toHaveBeenCalled();
+  });
+
+  it('should skip a reordered row', () => {
+    const [stayed, ...moved] = [trackedRow(1), trackedRow(2), trackedRow(3)];
+    const newRows = [row({ key: 1 }), row({ key: 3 }), row({ key: 2 })];
+
+    // [1, 2, 3] -> [1, 3, 2]: rows 2 and 3 each is reported as a remove plus an insert
+    refreshRows([stayed, ...moved], newRows, [
+      { type: 'remove', index: 2, oldItem: moved[1] },
+      { type: 'remove', index: 1, oldItem: moved[0] },
+      { type: 'insert', index: 1, data: newRows[1] },
+      { type: 'insert', index: 2, data: newRows[2] },
+    ]);
+
+    expect(updateOf(stayed)).toHaveBeenCalledWith(newRows[0]);
+    expect(updateOf(moved[0])).not.toHaveBeenCalled();
+    expect(updateOf(moved[1])).not.toHaveBeenCalled();
+  });
+
+  it('should ignore an inserted row, which has no old counterpart', () => {
+    const oldItem = trackedRow(1);
+    const inserted = row({ key: 2 });
+    const newItem = row({ key: 1 });
+
+    refreshRows([oldItem], [inserted, newItem], [{
+      type: 'insert', index: 0, data: inserted,
+    }]);
+
+    expect(updateOf(oldItem)).toHaveBeenCalledWith(newItem);
+  });
+
+  it('should refresh the rows in old-list order', () => {
+    const order: number[] = [];
+    const track = (key: number): ProcessedItem => row({
+      key,
+      update: jest.fn(() => { order.push(key); }),
+      cells: [{ update: jest.fn() }],
+    });
+    const oldItems = [track(1), track(2), track(3)];
+
+    refreshRows(oldItems, [row({ key: 1 }), row({ key: 2 }), row({ key: 3 })], []);
+
+    expect(order).toEqual([1, 2, 3]);
   });
 });
 

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/utils/row_changes.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/utils/row_changes.ts
@@ -1,7 +1,7 @@
 import { equalByValue } from '@js/core/utils/common';
 
 import type {
-  ChangedRows, DataChange, ProcessedItem, RowIndexByKey,
+  ChangedRows, DataChange, ItemChange, ProcessedItem, RowIndexByKey,
   RowOperation, UpdateChange, UpdateRowChange,
 } from '../types';
 
@@ -55,8 +55,8 @@ export function indexRowsByKey(items: ProcessedItem[]): RowIndexByKey {
 }
 
 /**
- * A row that only got new data keeps its cells: the updaters the rows view has
- * installed on the row and on every cell take the new row in place.
+ * Refreshes a rendered row in place: the rows view's updaters take the new row
+ * instead of the old one. A row that was never rendered has no cells to update.
  */
 export function updateRowCells(oldItem: ProcessedItem, newItem: ProcessedItem): void {
   if (!oldItem.cells) {
@@ -66,6 +66,32 @@ export function updateRowCells(oldItem: ProcessedItem, newItem: ProcessedItem): 
   oldItem.update?.(newItem);
   oldItem.cells.forEach((cell) => {
     cell?.update?.(newItem, true);
+  });
+}
+
+export function updateKeptRows(
+  oldItems: ProcessedItem[],
+  newItems: ProcessedItem[],
+  newIndexByKey: RowIndexByKey,
+  itemChanges: ItemChange[],
+): void {
+  const changedItemKeys = new Set<string>();
+
+  itemChanges.forEach((itemChange) => {
+    changedItemKeys.add(getRowKey(
+      itemChange.type === 'insert' ? itemChange.data : itemChange.oldItem,
+    ));
+  });
+
+  oldItems.forEach((oldItem) => {
+    const key = getRowKey(oldItem);
+    const newIndex = newIndexByKey[key];
+
+    if (newIndex === undefined || changedItemKeys.has(key)) {
+      return;
+    }
+
+    updateRowCells(oldItem, newItems[newIndex]);
   });
 }
 

--- a/packages/devextreme/js/__internal/grids/tree_list/data_controller/m_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/tree_list/data_controller/m_data_controller.ts
@@ -39,7 +39,7 @@ export class TreeListDataController extends DataController {
     this._dataSource.load();
   }
 
-  protected _isItemEquals(item1, item2) {
+  protected isSameRowState(item1, item2): boolean {
     if (item1.isSelected !== item2.isSelected) {
       return false;
     }
@@ -52,7 +52,7 @@ export class TreeListDataController extends DataController {
       return false;
     }
 
-    return super._isItemEquals.apply(this, arguments as any);
+    return super.isSameRowState(item1, item2);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
### Summary

`findItemChanges` hided a side effect off the changes lookup: its `isItemEquals` predicate called `updateRowCells` whenever two rows compared equal.

Now `applyChangesOnly` calls `findChanges` with a plain predicate, and a new `updateUnchangedRows` helper refreshes the rows the lookup **reported nothing about** afterwards. 

### Changed behaviour

Previously when `findChanges` return `undefined` (on a moved row, duplicate keys, or a throw), the rows it had already compared were refreshed. And then in `applyChangesOnly` we called `_applyChangeFull`, which replaces `_items` and leaves `changeType: 'refresh'`, so the rows view rerenders the whole table.
Now we do not refresh same state rows in such cases as it will be discarded anyway

Everything else is identical.
