### PR TITLE
Demos Visual Tests: replace job-level always() with !cancelled() so cancel-in-progress can stop jobs

### DIFF
--- a/.github/workflows/visual-tests-demos.yml
+++ b/.github/workflows/visual-tests-demos.yml
@@ -76,7 +76,7 @@ jobs:
     name: Determine scope for framework tests
     needs: [check-should-run, get-changes]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       (needs.get-changes.result == 'success' || needs.get-changes.result == 'skipped')
     outputs:
@@ -102,7 +102,7 @@ jobs:
     name: Determine jQuery test matrix
     needs: [check-should-run, determine-framework-tests-scope]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success'
     outputs:
@@ -147,7 +147,7 @@ jobs:
     name: Build DevExtreme
     needs: [check-should-run, determine-framework-tests-scope]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success'
     env:
@@ -279,7 +279,7 @@ jobs:
     timeout-minutes: 30
     needs: [check-should-run, determine-framework-tests-scope, build-devextreme]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success' &&
       needs.determine-framework-tests-scope.outputs.framework-tests-scope != 'none' &&
@@ -351,7 +351,7 @@ jobs:
     name: Check TS and lint code base
     needs: [check-should-run, determine-framework-tests-scope, build-devextreme]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success' &&
       needs.determine-framework-tests-scope.outputs.framework-tests-scope != 'none' &&
@@ -494,7 +494,7 @@ jobs:
     timeout-minutes: 20
     needs: [check-should-run, get-changes, build-devextreme, determine-framework-tests-scope]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success' &&
       needs.determine-framework-tests-scope.outputs.framework-tests-scope == 'changed' &&
@@ -607,7 +607,7 @@ jobs:
     timeout-minutes: 20
     needs: [check-should-run, build-devextreme, determine-framework-tests-scope]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success' &&
       needs.determine-framework-tests-scope.outputs.framework-tests-scope == 'all' &&
@@ -674,7 +674,7 @@ jobs:
   testcafe-jquery:
     needs: [check-should-run, build-devextreme, determine-framework-tests-scope, determine-jquery-test-matrix]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success' &&
       needs.determine-jquery-test-matrix.result == 'success' &&
@@ -832,7 +832,7 @@ jobs:
   testcafe-frameworks-all:
     needs: [check-should-run, determine-framework-tests-scope, build-demos]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success' &&
       needs.determine-framework-tests-scope.outputs.framework-tests-scope == 'all' &&
@@ -980,7 +980,7 @@ jobs:
   testcafe-frameworks-changed:
     needs: [check-should-run, determine-framework-tests-scope, build-demos]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success' &&
       needs.determine-framework-tests-scope.outputs.framework-tests-scope == 'changed' &&
@@ -1106,7 +1106,7 @@ jobs:
   merge-artifacts:
     runs-on: ubuntu-latest
     needs: [testcafe-jquery, testcafe-frameworks-all, testcafe-frameworks-changed]
-    if: always() && (needs.testcafe-jquery.result == 'failure' || needs.testcafe-frameworks-all.result == 'failure' || needs.testcafe-frameworks-changed.result == 'failure')
+    if: ${{ !cancelled() && (needs.testcafe-jquery.result == 'failure' || needs.testcafe-frameworks-all.result == 'failure' || needs.testcafe-frameworks-changed.result == 'failure') }}
 
     steps:
       - name: Merge jQuery screenshot artifacts
@@ -1158,7 +1158,7 @@ jobs:
     name: CSP check (jQuery)
     needs: [check-should-run, build-devextreme]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.build-devextreme.result == 'success'
     runs-on: devextreme-shr2
@@ -1231,7 +1231,7 @@ jobs:
     name: ${{ matrix.SHARD_TOTAL == 1 && format('CSP check ({0})', matrix.FRAMEWORK) || format('CSP check ({0} {1}/{2})', matrix.FRAMEWORK, matrix.SHARD_INDEX, matrix.SHARD_TOTAL) }}
     needs: [check-should-run, determine-framework-tests-scope, build-devextreme]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success' &&
       needs.determine-framework-tests-scope.outputs.framework-tests-scope != 'none' &&
@@ -1330,7 +1330,7 @@ jobs:
     name: CSP Violations Summary
     runs-on: ubuntu-latest
     needs: [check-should-run, csp-check-jquery, csp-check-frameworks]
-    if: always() && needs.check-should-run.outputs.should-run == 'true'
+    if: ${{ !cancelled() && needs.check-should-run.outputs.should-run == 'true' }}
     timeout-minutes: 5
 
     steps:


### PR DESCRIPTION

When a workflow run is canceled (by concurrency cancel-in-progress or manually), GitHub re-evaluates job-level if conditions and lets jobs whose condition still holds keep running. always() holds even after cancellation, so every heavy job survived the cancel: the superseded run kept occupying devextreme-shr2 runners until it drained naturally, while the new run waited in pending for the whole time.

!cancelled() behaves identically in normal flows (it overrides the implicit success() gate the same way) but turns false once the run is canceled, so jobs actually stop. Step-level always() (result reporting and artifact upload steps) is intentional and left untouched.
