### PR TITLE
Demos Visual Tests: replace job-level always() with !cancelled() so cancel-in-progress can stop jobs

### DIFF
--- a/.github/workflows/demos_visual_tests.yml
+++ b/.github/workflows/demos_visual_tests.yml
@@ -78,7 +78,7 @@ jobs:
     name: Determine scope for framework tests
     needs: [check-should-run, get-changes]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       (needs.get-changes.result == 'success' || needs.get-changes.result == 'skipped')
     outputs:
@@ -104,7 +104,7 @@ jobs:
     name: Build DevExtreme
     needs: [check-should-run, determine-framework-tests-scope]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success'
     env:
@@ -192,7 +192,7 @@ jobs:
     timeout-minutes: 30
     needs: [check-should-run, determine-framework-tests-scope, build-devextreme]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success' &&
       needs.determine-framework-tests-scope.outputs.framework-tests-scope != 'none' &&
@@ -264,7 +264,7 @@ jobs:
     name: Check TS
     needs: [check-should-run, determine-framework-tests-scope, build-devextreme]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success' &&
       needs.determine-framework-tests-scope.outputs.framework-tests-scope != 'none' &&
@@ -326,7 +326,7 @@ jobs:
     name: Lint code base
     needs: [check-should-run, determine-framework-tests-scope, build-devextreme]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success' &&
       needs.determine-framework-tests-scope.outputs.framework-tests-scope != 'none' &&
@@ -423,7 +423,7 @@ jobs:
     timeout-minutes: 10
     needs: [check-should-run, get-changes, build-devextreme, determine-framework-tests-scope]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success' &&
       needs.determine-framework-tests-scope.outputs.framework-tests-scope == 'changed' &&
@@ -536,7 +536,7 @@ jobs:
     timeout-minutes: 15
     needs: [check-should-run, build-devextreme, determine-framework-tests-scope]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success' &&
       needs.determine-framework-tests-scope.outputs.framework-tests-scope == 'all' &&
@@ -609,7 +609,7 @@ jobs:
   testcafe-jquery:
     needs: [check-should-run, build-devextreme]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.build-devextreme.result == 'success'
     strategy:
@@ -775,7 +775,7 @@ jobs:
   testcafe-frameworks-all:
     needs: [check-should-run, determine-framework-tests-scope, build-demos]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success' &&
       needs.determine-framework-tests-scope.outputs.framework-tests-scope == 'all' &&
@@ -925,7 +925,7 @@ jobs:
   testcafe-frameworks-changed:
     needs: [check-should-run, determine-framework-tests-scope, build-demos]
     if: |
-      always() &&
+      !cancelled() &&
       needs.check-should-run.outputs.should-run == 'true' &&
       needs.determine-framework-tests-scope.result == 'success' &&
       needs.determine-framework-tests-scope.outputs.framework-tests-scope == 'changed' &&
@@ -1053,7 +1053,7 @@ jobs:
   merge-artifacts:
     runs-on: ubuntu-latest
     needs: [testcafe-jquery, testcafe-frameworks-all, testcafe-frameworks-changed]
-    if: always() && (needs.testcafe-jquery.result == 'failure' || needs.testcafe-frameworks-all.result == 'failure' || needs.testcafe-frameworks-changed.result == 'failure')
+    if: ${{ !cancelled() && (needs.testcafe-jquery.result == 'failure' || needs.testcafe-frameworks-all.result == 'failure' || needs.testcafe-frameworks-changed.result == 'failure') }}
 
     steps:
       - name: Merge jQuery screenshot artifacts


### PR DESCRIPTION

When a workflow run is canceled (by concurrency cancel-in-progress or manually), GitHub re-evaluates job-level if conditions and lets jobs whose condition still holds keep running. always() holds even after cancellation, so every heavy job survived the cancel: the superseded run kept occupying devextreme-shr2 runners until it drained naturally, while the new run waited in pending for the whole time.

!cancelled() behaves identically in normal flows (it overrides the implicit success() gate the same way) but turns false once the run is canceled, so jobs actually stop. Step-level always() (result reporting and artifact upload steps) is intentional and left untouched.


