### PR TITLE
CardView - flaky tests in 26.1

### DIFF
--- a/e2e/testcafe-devextreme/tests/cardView/columnChooser/functional.ts
+++ b/e2e/testcafe-devextreme/tests/cardView/columnChooser/functional.ts
@@ -60,6 +60,7 @@ function testsFactory(testModel: {
     const cardView = new CardView('#container');
 
     await cardView.apiShowColumnChooser();
+    await testModel.assertFirstColumnVisible(t, cardView);
 
     await testModel.hideFirstColumn(t, cardView);
     await testModel.assertFirstColumnHidden(t, cardView);
@@ -230,11 +231,13 @@ test('cards should update when column is hidden via column chooser (select mode)
   await t.expect(initialCaptions).eql(['A', 'B', 'C']);
 
   await cardView.apiShowColumnChooser();
+  await t.expect(cardView.getColumnChooser().isCheckboxChecked(0)).ok();
 
   await t.click(cardView.getColumnChooser().getCheckbox(0));
 
   const captionsAfterHide = await getCardFieldCaptions(t, cardView, 2);
   await t.expect(captionsAfterHide).eql(['B', 'C']);
+  await t.expect(cardView.getColumnChooser().isCheckboxChecked(0)).notOk();
 
   await t.click(cardView.getColumnChooser().getCheckbox(0));
 


### PR DESCRIPTION
### What
Makes the flaky **CardView** column chooser select-mode functional tests stable

### How
Waits for the column chooser to settle (auto-retrying checkbox-state assertions) before each interaction, so a click no longer races the asynchronous re-render