### PR TITLE
Grids - DataController: Extract summary loadAll knowledge to extenders

### DIFF
--- a/packages/devextreme/js/__internal/grids/data_grid/summary/extenders/__tests__/summary_data_controller.load_all_items.test.ts
+++ b/packages/devextreme/js/__internal/grids/data_grid/summary/extenders/__tests__/summary_data_controller.load_all_items.test.ts
@@ -1,0 +1,46 @@
+import {
+  afterEach, beforeEach, describe, expect, it,
+} from '@jest/globals';
+import type { Properties as DataGridProperties } from '@js/ui/data_grid';
+import {
+  afterTest,
+  beforeTest,
+  createDataGrid,
+  flushAsync,
+} from '@ts/grids/grid_core/__tests__/__mock__/helpers/utils';
+
+const DATA = [{ id: 1, value: 10 }, { id: 2, value: 20 }];
+
+const loadAllSummary = async (
+  options: DataGridProperties = {},
+): Promise<unknown> => {
+  const { instance } = await createDataGrid({ dataSource: DATA, ...options });
+  const dataController = instance.getController('data');
+
+  let resolvedSummary: unknown = null;
+  dataController.loadAllItems().done((_items, summary) => {
+    resolvedSummary = summary;
+  });
+  await flushAsync();
+
+  return resolvedSummary;
+};
+
+describe('Summary data controller loadAllItems', () => {
+  beforeEach(beforeTest);
+  afterEach(afterTest);
+
+  it('should resolve the total summary as the second argument', async () => {
+    const summary = await loadAllSummary({
+      summary: { totalItems: [{ column: 'value', summaryType: 'sum' }] },
+    });
+
+    expect(summary).toEqual([30]);
+  });
+
+  it('should resolve no second argument when no summary is configured', async () => {
+    const summary = await loadAllSummary();
+
+    expect(summary).toBeUndefined();
+  });
+});

--- a/packages/devextreme/js/__internal/grids/data_grid/summary/extenders/summary_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/data_grid/summary/extenders/summary_data_controller.ts
@@ -1,4 +1,3 @@
-import type { DeferredObj } from '@js/core/utils/deferred';
 import { extend } from '@js/core/utils/extend';
 import {
   isDefined, isEmptyObject, isString,
@@ -7,7 +6,9 @@ import type { Format } from '@js/localization';
 import type { SummaryGroupItem as SummaryGroupItemOption } from '@js/ui/data_grid';
 import type { Column } from '@ts/grids/data_grid/types';
 import type { DataController } from '@ts/grids/grid_core/data_controller/data_controller';
-import type { DataChange, ItemProcessingOptions, ProcessedItem } from '@ts/grids/grid_core/data_controller/types';
+import type {
+  DataChange, ItemProcessingOptions, LoadAllItemsDeferred, ProcessedItem,
+} from '@ts/grids/grid_core/data_controller/types';
 import type { CustomLoadResult } from '@ts/grids/grid_core/data_source_adapter/custom_loader';
 import type { RawItemData } from '@ts/grids/grid_core/data_source_adapter/types';
 import type { ModuleType, OptionChanged } from '@ts/grids/grid_core/m_types';
@@ -304,12 +305,10 @@ export const summaryDataControllerExtender = (
   }
 
   protected resolveLoadAllItems(
-    d: DeferredObj<ProcessedItem[]>,
+    d: LoadAllItemsDeferred,
     loadResult: CustomLoadResult,
   ): void {
-    const resolveWithSummary = d.resolve as (...args: unknown[]) => void;
-
-    resolveWithSummary(this.processLoadAllItems(loadResult), loadResult.extra?.summary);
+    d.resolve(this.processLoadAllItems(loadResult), loadResult.extra?.summary);
   }
 
   protected _updateItemsCore(change: DataChange): void {

--- a/packages/devextreme/js/__internal/grids/data_grid/summary/extenders/summary_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/data_grid/summary/extenders/summary_data_controller.ts
@@ -1,3 +1,4 @@
+import type { DeferredObj } from '@js/core/utils/deferred';
 import { extend } from '@js/core/utils/extend';
 import {
   isDefined, isEmptyObject, isString,
@@ -7,6 +8,7 @@ import type { SummaryGroupItem as SummaryGroupItemOption } from '@js/ui/data_gri
 import type { Column } from '@ts/grids/data_grid/types';
 import type { DataController } from '@ts/grids/grid_core/data_controller/data_controller';
 import type { DataChange, ItemProcessingOptions, ProcessedItem } from '@ts/grids/grid_core/data_controller/types';
+import type { CustomLoadResult } from '@ts/grids/grid_core/data_source_adapter/custom_loader';
 import type { RawItemData } from '@ts/grids/grid_core/data_source_adapter/types';
 import type { ModuleType, OptionChanged } from '@ts/grids/grid_core/m_types';
 
@@ -299,6 +301,15 @@ export const summaryDataControllerExtender = (
     }
 
     return super.getChangedColumnIndices(oldItem, newItem, visibleRowIndex, isLiveUpdate);
+  }
+
+  protected resolveLoadAllItems(
+    d: DeferredObj<ProcessedItem[]>,
+    loadResult: CustomLoadResult,
+  ): void {
+    const resolveWithSummary = d.resolve as (...args: unknown[]) => void;
+
+    resolveWithSummary(this.processLoadAllItems(loadResult), loadResult.extra?.summary);
   }
 
   protected _updateItemsCore(change: DataChange): void {

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
@@ -36,6 +36,7 @@ import type {
   ItemChangeOptions,
   ItemOperationOptions,
   ItemProcessingOptions,
+  LoadAllItemsDeferred,
   PagingChanges,
   PagingDataSource,
   PagingOptionName,
@@ -1377,8 +1378,8 @@ export class DataController extends modules.Controller {
   public loadAllItems(
     data?: RawItemData[],
     skipFilter = false,
-  ): DeferredObj<ProcessedItem[]> {
-    const d = Deferred<ProcessedItem[]>();
+  ): LoadAllItemsDeferred {
+    const d = Deferred<ProcessedItem[]>() as LoadAllItemsDeferred;
     const dataSource = this._dataSource;
 
     if (!dataSource) {
@@ -1420,7 +1421,7 @@ export class DataController extends modules.Controller {
    * @extended: summary (DataGrid)
    */
   protected resolveLoadAllItems(
-    d: DeferredObj<ProcessedItem[]>,
+    d: LoadAllItemsDeferred,
     loadResult: CustomLoadResult,
   ): void {
     d.resolve(this.processLoadAllItems(loadResult));

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
@@ -1386,14 +1386,8 @@ export class DataController extends modules.Controller {
       return d;
     }
 
-    const resolveWithProcessedItems = (loadResult: CustomLoadResult): void => {
-      const items = this._processItems(
-        this._beforeProcessItems(loadResult.data),
-        { changeType: 'loadingAll' },
-      );
-
-      // @ts-expect-error DataGrid-only summary leaks into grid_core
-      d.resolve(items, loadResult.extra?.summary);
+    const resolveLoaded = (loadResult: CustomLoadResult): void => {
+      this.resolveLoadAllItems(d, loadResult);
     };
 
     if (data) {
@@ -1402,17 +1396,34 @@ export class DataController extends modules.Controller {
         group: dataSource.group(),
         sort: dataSource.sort(),
       })
-        .done(resolveWithProcessedItems)
+        .done(resolveLoaded)
         .fail(d.reject as (...args: unknown[]) => void);
     } else if (!dataSource.isLoading()) {
       dataSource.customLoader.loadAll()
-        .done(resolveWithProcessedItems)
+        .done(resolveLoaded)
         .fail(d.reject as (...args: unknown[]) => void);
     } else {
       d.reject();
     }
 
     return d;
+  }
+
+  protected processLoadAllItems(loadResult: CustomLoadResult): ProcessedItem[] {
+    return this._processItems(
+      this._beforeProcessItems(loadResult.data),
+      { changeType: 'loadingAll' },
+    );
+  }
+
+  /**
+   * @extended: summary (DataGrid)
+   */
+  protected resolveLoadAllItems(
+    d: DeferredObj<ProcessedItem[]>,
+    loadResult: CustomLoadResult,
+  ): void {
+    d.resolve(this.processLoadAllItems(loadResult));
   }
 
   public async getAllDataRowKeys(): Promise<RowKey[]> {

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/types.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/types.ts
@@ -73,6 +73,13 @@ export interface ProcessedItem extends GeneratedItem {
   watch?: RowWatch;
 }
 
+type LoadAllItemsCallback = (items: ProcessedItem[], totalAggregates?: unknown[]) => void;
+
+export type LoadAllItemsDeferred = Omit<DeferredObj<ProcessedItem[]>, 'done' | 'resolve'> & {
+  done: (callback: LoadAllItemsCallback) => LoadAllItemsDeferred;
+  resolve: LoadAllItemsCallback;
+};
+
 /** changes */
 
 export type RowChangeType = 'update' | 'insert' | 'remove';


### PR DESCRIPTION
### What
Moves the DataGrid-only total summary knowledge out of the shared grid `DataController` into the **DataGrid** summary module, so the base data layer no longer knows about summary aggregates

### How
`loadAllItems` now resolves through an overridable `resolveLoadAllItems` hook, which the summary module overrides to attach the total summary as the second result