### PR TITLE
Grids - DataController: Extract getRowIndicesForExpand into master detail

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/adaptivity/extenders/adaptivity_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/adaptivity/extenders/adaptivity_data_controller.ts
@@ -4,6 +4,7 @@ import type { DataChange, ProcessedItem } from '@ts/grids/grid_core/data_control
 import type { RawItemData } from '@ts/grids/grid_core/data_source_adapter/types';
 import type { ModuleType, RowKey } from '@ts/grids/grid_core/m_types';
 import gridCoreUtils from '@ts/grids/grid_core/m_utils';
+import type { MasterDetailDataControllerExtension } from '@ts/grids/grid_core/master_detail/m_master_detail';
 
 import {
   ADAPTIVE_ROW_TYPE,
@@ -15,8 +16,10 @@ import type { AdaptiveColumnsController } from '../m_adaptivity';
 import type { AdaptivityDataController } from '../types';
 import { getAdaptiveDetailRowIndex, resolveAdaptiveDetailRowTarget } from '../utils';
 
+type AdaptivityDataControllerBase = DataController & MasterDetailDataControllerExtension;
+
 export const adaptivityDataControllerExtender = (
-  Base: ModuleType<DataController>,
+  Base: ModuleType<AdaptivityDataControllerBase>,
 ): ModuleType<AdaptivityDataController> => class AdaptivityDataControllerExtender extends Base {
   private adaptiveExpandedKey?: RowKey;
 
@@ -59,7 +62,7 @@ export const adaptivityDataControllerExtender = (
     return processedItems;
   }
 
-  protected getRowIndicesForExpand(key: RowKey): number[] {
+  public getRowIndicesForExpand = (key: RowKey): number[] => {
     const rowIndices = super.getRowIndicesForExpand(key);
 
     if (this.adaptiveColumnsController.isAdaptiveDetailRowExpanded(key)) {
@@ -69,7 +72,7 @@ export const adaptivityDataControllerExtender = (
     }
 
     return rowIndices;
-  }
+  };
 
   public toggleExpandAdaptiveDetailRow(key?: RowKey, alwaysExpanded = false): void {
     const oldKey = this.adaptiveExpandedKey;

--- a/packages/devextreme/js/__internal/grids/grid_core/adaptivity/extenders/adaptivity_data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/adaptivity/extenders/adaptivity_data_controller.ts
@@ -62,7 +62,7 @@ export const adaptivityDataControllerExtender = (
     return processedItems;
   }
 
-  public getRowIndicesForExpand = (key: RowKey): number[] => {
+  public override getRowIndicesForExpand(key: RowKey): number[] {
     const rowIndices = super.getRowIndicesForExpand(key);
 
     if (this.adaptiveColumnsController.isAdaptiveDetailRowExpanded(key)) {
@@ -72,7 +72,7 @@ export const adaptivityDataControllerExtender = (
     }
 
     return rowIndices;
-  };
+  }
 
   public toggleExpandAdaptiveDetailRow(key?: RowKey, alwaysExpanded = false): void {
     const oldKey = this.adaptiveExpandedKey;

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/data_controller.ts
@@ -161,18 +161,6 @@ export class DataController extends modules.Controller {
   }
 
   /**
-   * TODO: Define this method only in masterDetail.
-   * Remove the override from adaptive behavior
-   * and move the implementation to masterDetail.
-   *
-   * @extended: adaptivity, master_detail
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getRowIndicesForExpand(key: RowKey): number[] {
-    return [];
-  }
-
-  /**
    * @extended: virtual_scrolling
    */
   protected _getPagingOptionValue(optionName: PagingOptionName): number {

--- a/packages/devextreme/js/__internal/grids/grid_core/master_detail/__tests__/get_row_indices_for_expand.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/master_detail/__tests__/get_row_indices_for_expand.test.ts
@@ -1,0 +1,47 @@
+import {
+  afterEach, beforeEach, describe, expect, it,
+} from '@jest/globals';
+import {
+  afterTest, beforeTest, createDataGrid, flushAsync,
+} from '@ts/grids/grid_core/__tests__/__mock__/helpers/utils';
+import type { DataController } from '@ts/grids/grid_core/data_controller/data_controller';
+import type { MasterDetailDataControllerExtension } from '@ts/grids/grid_core/master_detail/m_master_detail';
+import {
+  afterTest as afterTreeListTest,
+  beforeTest as beforeTreeListTest,
+  createTreeList,
+} from '@ts/grids/tree_list/__tests__/__mock__/helpers/utils';
+
+type ExposedDataController = DataController & MasterDetailDataControllerExtension;
+
+const DATA = [{ id: 1 }, { id: 2 }, { id: 3 }];
+
+describe('DataController getRowIndicesForExpand', () => {
+  describe('DataGrid', () => {
+    beforeEach(beforeTest);
+    afterEach(afterTest);
+
+    it('should reach master_detail through the adaptivity chain', async () => {
+      const { instance } = await createDataGrid({ dataSource: DATA });
+      await flushAsync();
+      const dataController = instance.getController('data') as unknown as ExposedDataController;
+
+      expect(dataController.getRowIndicesForExpand(1)).toEqual([0, 1]);
+      expect(dataController.getRowIndicesForExpand(3)).toEqual([2, 3]);
+    });
+  });
+
+  describe('TreeList', () => {
+    beforeEach(beforeTreeListTest);
+    afterEach(afterTreeListTest);
+
+    it('should reach master_detail through the adaptivity chain', async () => {
+      const { instance } = await createTreeList({ dataSource: DATA });
+      await flushAsync();
+      const dataController = instance.getController('data') as unknown as ExposedDataController;
+
+      expect(dataController.getRowIndicesForExpand(1)).toEqual([0, 1]);
+      expect(dataController.getRowIndicesForExpand(3)).toEqual([2, 3]);
+    });
+  });
+});

--- a/packages/devextreme/js/__internal/grids/grid_core/master_detail/__tests__/get_row_indices_for_expand.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/master_detail/__tests__/get_row_indices_for_expand.test.ts
@@ -12,7 +12,7 @@ import {
   createTreeList,
 } from '@ts/grids/tree_list/__tests__/__mock__/helpers/utils';
 
-type ExposedDataController = DataController & MasterDetailDataControllerExtension;
+type MasterDetailDataController = DataController & MasterDetailDataControllerExtension;
 
 const DATA = [{ id: 1 }, { id: 2 }, { id: 3 }];
 
@@ -24,7 +24,7 @@ describe('DataController getRowIndicesForExpand', () => {
     it('should reach master_detail through the adaptivity chain', async () => {
       const { instance } = await createDataGrid({ dataSource: DATA });
       await flushAsync();
-      const dataController = instance.getController('data') as unknown as ExposedDataController;
+      const dataController = instance.getController('data') as MasterDetailDataController;
 
       expect(dataController.getRowIndicesForExpand(1)).toEqual([0, 1]);
       expect(dataController.getRowIndicesForExpand(3)).toEqual([2, 3]);
@@ -38,7 +38,7 @@ describe('DataController getRowIndicesForExpand', () => {
     it('should reach master_detail through the adaptivity chain', async () => {
       const { instance } = await createTreeList({ dataSource: DATA });
       await flushAsync();
-      const dataController = instance.getController('data') as unknown as ExposedDataController;
+      const dataController = instance.getController('data') as MasterDetailDataController;
 
       expect(dataController.getRowIndicesForExpand(1)).toEqual([0, 1]);
       expect(dataController.getRowIndicesForExpand(3)).toEqual([2, 3]);

--- a/packages/devextreme/js/__internal/grids/grid_core/master_detail/m_master_detail.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/master_detail/m_master_detail.ts
@@ -44,7 +44,13 @@ const initMasterDetail = function (that) {
   that._isExpandAll = that.option('masterDetail.autoExpandAll');
 };
 
-export const dataMasterDetailExtenderMixin = (Base: ModuleType<DataController>) => class DataMasterDetailExtender extends Base {
+export interface MasterDetailDataControllerExtension {
+  getRowIndicesForExpand: (key: RowKey) => number[];
+}
+
+export const dataMasterDetailExtenderMixin = (
+  Base: ModuleType<DataController>,
+): ModuleType<DataController & MasterDetailDataControllerExtension> => class DataMasterDetailExtender extends Base {
   private _isExpandAll: any;
 
   private _expandedItems: any;
@@ -98,7 +104,7 @@ export const dataMasterDetailExtenderMixin = (Base: ModuleType<DataController>) 
     return !!(that._isExpandAll ^ (expandIndex >= 0 && that._expandedItems[expandIndex].visible));
   }
 
-  protected getRowIndicesForExpand(key: RowKey): number[] {
+  public getRowIndicesForExpand(key: RowKey): number[] {
     const rowIndex = this.getRowIndexByKey(key);
 
     return [rowIndex, rowIndex + 1];

--- a/packages/devextreme/js/__internal/grids/grid_core/master_detail/m_master_detail.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/master_detail/m_master_detail.ts
@@ -45,7 +45,8 @@ const initMasterDetail = function (that) {
 };
 
 export interface MasterDetailDataControllerExtension {
-  getRowIndicesForExpand: (key: RowKey) => number[];
+  // eslint-disable-next-line @typescript-eslint/method-signature-style
+  getRowIndicesForExpand(key: RowKey): number[];
 }
 
 export const dataMasterDetailExtenderMixin = (


### PR DESCRIPTION
### What
Removes the master-detail row-expand helper from the shared grid `DataController`, so the base data layer no longer carries logic that only the master detail module uses

### How
The base `getRowIndicesForExpand` placeholder is removed; the master detail module surfaces the method through a new extension interface, and the adaptive columns extender reads it from there