### PR TITLE
Grids - DataController: Reuse a shared column value predicate

### DIFF
--- a/packages/devextreme/js/__internal/grids/grid_core/columns_controller/__tests__/column_has_value.test.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/columns_controller/__tests__/column_has_value.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@jest/globals';
+import { AI_COLUMN_NAME } from '@ts/grids/grid_core/ai_column/const';
+import { columnHasValue } from '@ts/grids/grid_core/columns_controller/m_columns_controller_utils';
+import type { Column } from '@ts/grids/grid_core/columns_controller/types';
+
+const column = (partial: Partial<Column>): Column => partial as Column;
+
+describe('columnHasValue', () => {
+  it('should be true for a data column', () => {
+    expect(columnHasValue(column({ dataField: 'name' }))).toBe(true);
+  });
+
+  it('should be false for a command column', () => {
+    expect(columnHasValue(column({ command: 'select' }))).toBe(false);
+  });
+
+  it('should be true for the AI column even though it carries a command', () => {
+    expect(columnHasValue(column({ command: AI_COLUMN_NAME, type: AI_COLUMN_NAME }))).toBe(true);
+  });
+});

--- a/packages/devextreme/js/__internal/grids/grid_core/columns_controller/m_columns_controller_utils.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/columns_controller/m_columns_controller_utils.ts
@@ -1097,4 +1097,8 @@ export const isColumnNameRequired = function ({ type = '' }: Column): boolean {
   return COMMAND_COLUMNS_WITH_REQUIRED_NAMES.includes(type);
 };
 
+export const columnHasValue = (column: Column): boolean => (
+  !column.command || column.type === AI_COLUMN_NAME
+);
+
 export const getColumnHeaderCellSelector = (visibleIndex: number): string => `.dx-header-row td[aria-colindex="${visibleIndex + 1}"]`;

--- a/packages/devextreme/js/__internal/grids/grid_core/data_controller/utils/row_values.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/data_controller/utils/row_values.ts
@@ -1,4 +1,4 @@
-import { AI_COLUMN_NAME } from '@ts/grids/grid_core/ai_column/const';
+import { columnHasValue } from '@ts/grids/grid_core/columns_controller/m_columns_controller_utils';
 import type { Column } from '@ts/grids/grid_core/columns_controller/types';
 
 import type { RawItemData } from '../../data_source_adapter/types';
@@ -13,7 +13,7 @@ export function generateRowValues(
   const emptyValue = isModified ? undefined : null;
 
   return columns.map((column) => {
-    if (column.command && column.type !== AI_COLUMN_NAME) {
+    if (!columnHasValue(column)) {
       return emptyValue;
     }
 

--- a/packages/devextreme/js/__internal/grids/grid_core/views/utils.ts
+++ b/packages/devextreme/js/__internal/grids/grid_core/views/utils.ts
@@ -1,13 +1,13 @@
+import { columnHasValue } from '@ts/grids/grid_core/columns_controller/m_columns_controller_utils';
 import type { Column } from '@ts/grids/grid_core/columns_controller/types';
 
-import { AI_COLUMN_NAME } from '../ai_column/const';
 import gridCoreUtils from '../m_utils';
 
 export const getCellText = (
   column: Column,
   displayValue: unknown,
 ): string => (
-  !column.command || column.type === AI_COLUMN_NAME
+  columnHasValue(column)
     ? gridCoreUtils.formatValue(displayValue, column) as string
     : ''
 );


### PR DESCRIPTION
### What
Removes a duplicated "does this column carry a value" check from the grid data layer, replacing it with a single shared `columnHasValue` helper

### How
The predicate is added to the columns controller utils and reused from row value generation and cell text rendering, which previously each inlined the same command/AI column check